### PR TITLE
Add v0/Stitch prompt and refine events, home, and how-it-works specs

### DIFF
--- a/prd/PRD.md
+++ b/prd/PRD.md
@@ -172,8 +172,12 @@ relative to this file, `prd/PRD.md`):
 
 ### 5.1 Visual tone
 
-- **Professional and elegant**, not corporate. Confident use of whitespace,
-  a refined type scale, and editorial-style layouts.
+- **Professional and welcoming**, not corporate and not casual. The
+  visual tone should be credible enough that a sponsor's marketing team
+  feels comfortable associating their brand, while remaining open and
+  approachable to a first-time attendee from any background. Confident
+  use of whitespace and a clean type scale; avoid anything that reads
+  as playful, youthful, or consumer-app-like.
 - Keep the aquatic motif (fish logo, "Tank" vocabulary) but treat it as a
   subtle mark rather than the dominant motif.
 - Prefer **real event photography** over stock illustration.
@@ -312,8 +316,11 @@ and is explicitly out of scope for the initial launch.
 ## 8. Content & Brand
 
 - **Voice:** warm, welcoming, beginner-safe, Toronto-local, confident.
-- **Typography:** one editorial serif for display, one humanist sans for
-  body (final pairing per visual design).
+- **Typography:** a strong, neutral display typeface (geometric or
+  grotesque sans preferred — avoid decorative serifs or script faces);
+  a legible humanist sans for body. The pairing should read as
+  industry-conference-grade, not startup-blog or community-newsletter.
+  Final pairing per visual design.
 - **Color palette (extracted from current site):**
   - **Gradient:** warm peach/coral → soft lavender → aqua teal. This
     three-stop gradient is the site's primary background motif (hero,

--- a/prd/PRD.md
+++ b/prd/PRD.md
@@ -204,6 +204,54 @@ CTAs are fine; tertiary links belong in the footer.
   `/how-it-works` must collapse into a single-line segmented control on
   mobile.
 
+### 5.6 Event archive & recap pattern
+
+`/events` and the home page treat each event as a recurring entry in
+an ongoing series, not just a flat Luma embed. Every event record
+carries:
+
+- Event number and/or date badge (e.g. "Event 14 · April 2026")
+- Title and one-line pitch
+- Venue + time chips
+- Tag chips (topic, track, "beginner-friendly", capacity note)
+- Host / sponsor attribution (**Supported by** + logo)
+- Status:
+  - **Upcoming** — shows "Next Up" treatment and an **RSVP on Luma**
+    CTA
+  - **Past** — shows a **View Recap** CTA linking to the event's
+    Google Photos album and YouTube recording
+- A past-events timeline lives directly below the upcoming event,
+  so visitors can scroll the full history as additional social proof.
+
+For v1, a "recap" is a linked bundle (Google Photos URL + YouTube URL
++ host/sponsor thanks surfaced inline). A dedicated `/events/<slug>`
+detail route is a v2 option only if organizers want editorial recaps
+and is explicitly out of scope for the initial launch.
+
+### 5.7 Recurring UI patterns
+
+- **Overline kicker.** Every major section opens with a short,
+  all-caps kicker (e.g. `WAYS TO GET INVOLVED`, `NEXT UP`, `RECENT
+  EVENTS`, `LATEST HIGHLIGHTS`, `GET IN TOUCH`) above the headline.
+  Establishes a clear scanning rhythm.
+- **Role cards with checkmarks.** The four `/how-it-works` role
+  teasers share one shape on `/` and `/how-it-works`: icon → overline
+  → headline → one-paragraph pitch → three bulleted checkmarks of
+  what the contributor gets. Reused verbatim so the four paths feel
+  like siblings.
+- **Supported-by strip.** A single-line host/sponsor acknowledgment
+  ("Supported by <logos>") appears above the footer on `/` and
+  `/events`, and on each past-event card. Distinct from, and
+  complementary to, the logo cloud higher up the page.
+- **Dual end-of-page CTA cards.** Long pages close with a two-up
+  card block: one "stay in the loop" card (Luma / Slack) and one
+  "collaborate with us" card (email / `/how-it-works`). Used on `/`
+  and `/events`.
+- **Direct-email contact card.** `techtankto@gmail.com` appears as a
+  prominent, copy-friendly contact card (not just a hyperlink) at the
+  end of `/how-it-works`, `/how-it-works/*`, and `/press-kit`. One
+  line of context explains what we respond to.
+
 ---
 
 ## 6. Functional Requirements
@@ -212,7 +260,13 @@ CTAs are fine; tertiary links belong in the footer.
 
 - Next.js App Router with shared layouts for `/how-it-works` and `/legal`.
 - Global header + footer on every route.
-- `/events` renders an embedded Luma calendar (or API-backed list).
+- `/events` renders an embedded Luma calendar (or API-backed list),
+  **and** a hand-curated "Next Up" + "Past Events" timeline driven by
+  structured event content (see below).
+- Events are modeled as structured content (MDX or JSON). Each record
+  carries: date, venue, title, tags, host/sponsor attribution, status
+  (`upcoming` | `past`), RSVP URL, Google Photos album URL, YouTube
+  recording URL. Powers both `/events` and the home-page preview.
 - Google Form embedded (or linked) on each `/how-it-works/*` page.
 - Press Kit exposes a downloadable ZIP of logos + a brand-guidelines PDF.
 - Social share / Open Graph metadata on every page.
@@ -227,6 +281,9 @@ CTAs are fine; tertiary links belong in the footer.
 - Branded slide deck template (Google Slides / PPTX) linked from
   `/how-it-works/speaker` and `/press-kit`.
 - Speaker run-of-show and host checklist (linked PDFs).
+- Per-event recap surface: Google Photos album + YouTube recording +
+  host/sponsor acknowledgment, reached via "View Recap" from the
+  past-events timeline.
 
 ### 6.3 Nice-to-have
 

--- a/prd/PRD.md
+++ b/prd/PRD.md
@@ -177,7 +177,7 @@ relative to this file, `prd/PRD.md`):
   feels comfortable associating their brand, while remaining open and
   approachable to a first-time attendee from any background. Confident
   use of whitespace and a clean type scale; avoid anything that reads
-  as playful, youthful, or consumer-app-like.
+  as playful or youthful.
 - Keep the aquatic motif (fish logo, "Tank" vocabulary) but treat it as a
   subtle mark rather than the dominant motif.
 - Prefer **real event photography** over stock illustration.

--- a/prd/PRD.md
+++ b/prd/PRD.md
@@ -314,8 +314,22 @@ and is explicitly out of scope for the initial launch.
 - **Voice:** warm, welcoming, beginner-safe, Toronto-local, confident.
 - **Typography:** one editorial serif for display, one humanist sans for
   body (final pairing per visual design).
-- **Color:** current gradient (pink → blue → teal) retained as a signature
-  accent; grounded by a neutral base (off-white / ink) for professionalism.
+- **Color palette (extracted from current site):**
+  - **Gradient:** warm peach/coral → soft lavender → aqua teal. This
+    three-stop gradient is the site's primary background motif (hero,
+    section banding). It is *not* pink — the warm stop is a
+    desaturated salmon/peach (`≈ #F5C4A8`), the mid is a muted
+    lavender (`≈ #D8CEED`), and the cool stop is a pale aqua
+    (`≈ #B5E0D9`).
+  - **Logo teal:** saturated cyan-teal (`≈ #3DC4C0`) — the fish mark
+    and primary brand colour.
+  - **Logo amber:** warm golden yellow (`≈ #F0AA00`) — the lightning
+    bolt in the logomark; used sparingly as a highlight.
+  - **CTA / surface dark:** near-black for pill buttons and the footer
+    (`≈ #141926`).
+  - **Body text:** near-black on light backgrounds.
+  - Do *not* introduce hot pink, true blue, or colours outside this
+    family without explicit organizer sign-off.
 - **Imagery:** real event photography first; diverse, candid, well-lit.
 
 ---

--- a/prd/pages/events.md
+++ b/prd/pages/events.md
@@ -2,72 +2,134 @@
 
 **URL:** https://www.techtankto.com/events
 **Page title:** Events — TechTank TO
-**Role:** Single source of truth for upcoming TechTank events, powered
-by the TechTank Luma calendar.
+**Role:** Single source of truth for upcoming TechTank events and a
+scrollable archive of everything we've run before. Powered by the
+TechTank Luma calendar plus hand-curated event records.
 
 ---
 
 ## 1. Purpose
 
-Make it effortless for a visitor to see what's coming up and RSVP. The
-page is primarily a **calendar embed**, not a bespoke events system.
+Make it effortless for a visitor to see what's coming up and RSVP —
+and, just as importantly, prove the community's cadence is real by
+giving them a full past-events timeline with recaps.
 
 ## 2. Primary audience
 
 - Returning members checking what's next
 - Newcomers deciding whether to attend
-- Sponsors / speakers verifying the cadence is real
+- Sponsors / speakers verifying the cadence is real and scoping past
+  events before reaching out
 
 ## 3. Key messages
 
 - "Stay up to date with everything happening at TechTank."
-- Browse and RSVP directly from the Luma calendar.
 - Monthly in-person events; occasional socials and virtual talks.
+- Every past event has photos, speakers, and often a recording — this
+  is an active, ongoing community, not a dormant page.
 
 ## 4. Content sections
 
 1. **Hero**
-   - Headline: "Our Upcoming Events".
-   - Sub-headline: "Stay up to date with everything happening at
-     TechTank."
-   - One line: "Don't miss our next event. Browse and RSVP directly
-     through our Luma calendar below."
+   - Overline kicker: `TECHTANK TO`.
+   - Headline: "All Events".
+   - Sub-headline: "Every TechTank meetup — most recent first."
+   - Right-aligned counter strip: "<N> EVENTS · SINCE 2022" (counts
+     pulled from the structured event content; no hardcoded numbers).
 
-2. **Luma calendar embed**
-   - Full-width Luma calendar for `techtankto` (or equivalent handle).
-   - Fallback: if the embed fails, render a server-fetched list of the
-     next 5 events with date, title, venue, and RSVP button.
+2. **Next Up (featured upcoming event)**
+   - Overline kicker: `NEXT UP`.
+   - Full-width card for the next scheduled event:
+     - Status badge: `UPCOMING`
+     - Event number or month badge (e.g. `EVENT 14` or `APR 2026`)
+     - Title and one-line pitch
+     - Date + time chip, venue chip
+     - Tag chips (e.g. "Beginner-friendly", "Recording planned",
+       "100 seats")
+     - Primary CTA: **"RSVP on Luma"** → Luma event URL
+     - Secondary CTA: "View details" → Luma event URL (anchor)
+     - Right-rail "Supported by" block with host/sponsor logo; if
+       none confirmed, shows "Looking for a host" with a link to
+       `/how-it-works/host`.
+   - If no event is scheduled yet, the card degrades to a "Next event
+     announcing soon — join Slack to be first to hear" state.
 
-3. **Subscribe**
-   - Buttons: "Subscribe on Luma", "Add to Google Calendar (.ics)",
-     "Follow on Meetup".
+3. **Luma calendar embed**
+   - Full-width Luma calendar for the TechTank handle, under the
+     featured card.
+   - Fallback: if the embed fails, render the next 5 events from the
+     structured event content with date, title, venue, and RSVP
+     button.
 
-4. **Past events (optional)**
-   - Small grid linking to past event albums (Google Photos) and
-     recorded talks (YouTube).
-   - Serves as additional social proof.
+4. **Past Events timeline**
+   - Overline kicker: `PAST EVENTS`.
+   - Vertical timeline, most recent first. Each past-event card
+     carries:
+     - Event number + date badge
+     - `RECAP AVAILABLE` status chip when a recap bundle exists
+     - Title and host/sponsor attribution line (e.g. "Hosted at
+       Shopify Toronto")
+     - Date + time chip, venue chip
+     - Tag chips (topic, track, participant note)
+     - Host/sponsor logo, right-aligned
+     - CTA: **"View Recap"** — opens an anchored recap block that
+       surfaces:
+       - Linked Google Photos album
+       - Linked YouTube recording (Guppy Talks / talk)
+       - Speaker list (name + talk title)
+       - One-line host/sponsor thank-you
+   - A dedicated `/events/<slug>` detail route is explicitly out of
+     scope for v1; recaps are an inline expansion plus external
+     links. Revisit only if organizers want editorial write-ups.
 
-5. **"Can't make it?" block**
-   - Link to Slack ("stay in the loop") and YouTube ("watch past talks").
+5. **Dual end-of-page CTA**
+   - Two side-by-side cards:
+     - **Never miss an event.** "Subscribe to our Luma calendar to be
+       notified when the next event goes live." — CTA: "Follow on
+       Luma".
+     - **Want to contribute?** "Speak, host, sponsor, or volunteer
+       for the next one." — CTA: "Get involved" → `/how-it-works`.
+
+6. **Contact strip**
+   - Overline kicker: `GET IN TOUCH`.
+   - Direct-email contact card: `techtankto@gmail.com` with one
+     line — "For hosting, sponsorship, and media inquiries."
 
 ## 5. Calls to action (priority order)
 
 1. RSVP to the next event (Luma)
-2. Subscribe on Luma / Meetup
-3. Watch past talks on YouTube
+2. View a past recap (builds trust → pushes them into Slack / CTAs)
+3. Subscribe on Luma / Meetup
+4. Get involved → `/how-it-works`
 
 ## 6. Functional requirements
 
+- Events are read from structured content (MDX or JSON) shared with
+  the home page. See PRD §6.1.
 - Luma embed loaded lazily; page must render above-the-fold content
-  before the embed resolves.
-- `.ics` / Google Calendar subscription link functional.
-- `schema.org/Event` structured data on each surfaced event (when the
-  fallback list is active).
-- Embed must not break keyboard navigation or screen-reader access.
+  (hero + Next Up card) before the embed resolves.
+- `.ics` / Google Calendar / Luma subscription links functional.
+- `schema.org/Event` structured data on surfaced events when the
+  fallback list is active.
+- Embed and timeline must not break keyboard navigation or
+  screen-reader access — each card is a single reachable landmark
+  with clear labeled CTAs.
+- Past-event cards render server-side; the "View Recap" expansion
+  uses progressive disclosure (no layout shift on open).
+- If Google Photos or YouTube URLs are missing for a past event, the
+  card renders without the `RECAP AVAILABLE` chip rather than
+  broken links.
 
 ## 7. Acceptance criteria
 
 - A visitor can RSVP to the next event in under three taps from this
   page on mobile.
-- If Luma's embed is down, the page still communicates the next event
-  and offers an RSVP path (Meetup fallback).
+- A visitor who has never heard of TechTank can scroll the Past
+  Events timeline and see at least 3 prior events with recap
+  evidence (photos or recording) before reaching the footer.
+- The Next Up card always carries an explicit host/sponsor
+  attribution or a "Looking for a host" link — never blank space.
+- If Luma's embed is down, the page still communicates the next
+  event and offers an RSVP path (Meetup fallback).
+- Every number on the page (event count, capacity, etc.) comes from
+  structured content, not hardcoded copy.

--- a/prd/pages/home.md
+++ b/prd/pages/home.md
@@ -35,6 +35,7 @@ not product copy.
 ## 4. Content sections (top to bottom)
 
 1. **Hero**
+   - Overline kicker: `TORONTO · MONTHLY · SINCE 2022`.
    - Brand lockup + one-sentence mission.
    - Primary CTA: **"RSVP on Luma"** → `/events`.
    - Secondary CTA: "Join our Slack".
@@ -42,8 +43,10 @@ not product copy.
      collage motif from the current site, treated more elegantly).
 
 2. **Trust strip / fast facts**
-   - "100–120 attendees per event", "50+ talks", "X companies hosted",
-     "Monthly since 2022" (confirm numbers with organizers).
+   - Fast facts pulled from the structured events content — for
+     example attendees per event, talks delivered, events hosted,
+     monthly cadence. Any number that organizers haven't confirmed
+     is flagged "finalize with organizers", not invented.
    - Renders as a thin band of large numerals under the hero.
 
 3. **Testimonials**
@@ -55,31 +58,57 @@ not product copy.
    - Grayscale logos of companies that have hosted or sponsored.
    - Caption: "Companies that have supported TechTank".
 
-5. **How to get involved**
-   - Four role cards linking into the onboarding hub:
-     - **Speak** → `/how-it-works/speaker`
-     - **Host** → `/how-it-works/host`
-     - **Sponsor** → `/how-it-works/sponsor`
-     - **Volunteer** → `/how-it-works/volunteer`
-   - Overline: "Become part of it" / Caption under: "Every TechTank event
-     runs on the time of community members like you."
+5. **Ways to get involved (role cards)**
+   - Overline kicker: `WAYS TO GET INVOLVED`.
+   - Headline: "Become part of it."
+   - Sub-headline: "Every TechTank event runs on the time of
+     community members like you."
+   - Four role cards sharing one shape (see PRD §5.7):
+     - **Speak** — `Share what you know` → `/how-it-works/speaker`
+     - **Host** — `Bring us to your space` → `/how-it-works/host`
+     - **Sponsor** — `Support the community` → `/how-it-works/sponsor`
+     - **Volunteer** — `Help run the crew` → `/how-it-works/volunteer`
+   - Each card: icon → overline → headline → one-paragraph pitch →
+     three checkmark bullets of what the contributor gets.
 
-6. **Upcoming events preview**
-   - Next 2–3 events pulled from Luma.
-   - CTA: "See all events" → `/events`.
+6. **Recent Events (preview of the archive)**
+   - Overline kicker: `RECENT EVENTS`.
+   - Right-aligned link: "View all events →" → `/events`.
+   - The next upcoming event (if any) plus the two most recent past
+     events, rendered with the same event-card shape used on
+     `/events` (status badge, date, title, tag chips, host/sponsor
+     attribution, CTA).
+   - CTAs per card:
+     - Upcoming → "RSVP on Luma"
+     - Past with recap → "View Recap"
+     - Past without recap → "Photos" / "Watch talk" as available
 
-7. **From the community (social previews)**
-   - Preview tiles linking to:
-     - Recent Google Photos album(s)
-     - Instagram grid (last 6 posts)
-     - YouTube: latest Guppy Talks / recorded talks
-   - Goal: prove the community is alive and active.
+7. **Latest Highlights (social proof)**
+   - Overline kicker: `LATEST HIGHLIGHTS`.
+   - Two-up layout:
+     - Left: an embedded Instagram reel or Google Photos preview from
+       the most recent event.
+     - Right: short copy — e.g. "See what we built at <event name>." —
+       plus "Follow on Instagram" and "Join our Slack" links.
+   - Goal: prove the community is alive and active this month.
 
 8. **Values teaser**
    - Four-pillar strip (Community, Innovation, Teamwork, Respect) with a
      link to `/about`.
 
-9. **Footer** (global)
+9. **Dual end-of-page CTA**
+   - Two side-by-side cards above the footer:
+     - **Never miss an event.** Subscribe to the Luma calendar — CTA
+       "Follow on Luma".
+     - **Want to contribute?** Speak, host, sponsor, or volunteer —
+       CTA "Get involved" → `/how-it-works`.
+
+10. **Supported-by strip**
+    - Single-line "Supported by <host/sponsor logos>" acknowledgment
+      directly above the footer. Distinct from the logo cloud in
+      section 4.
+
+11. **Footer** (global)
 
 ## 5. Calls to action (priority order)
 
@@ -90,18 +119,27 @@ not product copy.
 
 ## 6. Functional requirements
 
-- Upcoming-events module refreshes from Luma (API or scheduled build).
+- Recent Events module reads from the shared structured event content
+  (see PRD §6.1) — same source as `/events`. The home preview is a
+  filtered slice, not a duplicate list.
 - Testimonials and logos live in structured content (MDX / JSON), not
   hard-coded in components.
 - Google Photos and Instagram previews degrade gracefully if embeds fail.
 - All external links open in a new tab with `rel="noopener noreferrer"`.
 - Mobile-first layout; hero collage remains legible at 375px.
 - Open Graph / Twitter card metadata with TechTank branding.
+- Role cards and event cards share their component with
+  `/how-it-works` and `/events` respectively — no bespoke variants.
 
 ## 7. Acceptance criteria
 
 - A visitor can, within one scroll on desktop, see: who TechTank is,
   proof it is active, the next event, and where to join.
 - Every "role" card is reachable within one tap from the hero on mobile.
-- Social-proof section (testimonials + logos) is visible before the
-  visitor reaches the footer on mobile.
+- Social-proof section (testimonials + logos + recent events) is
+  visible before the visitor reaches the footer on mobile.
+- The "Recent Events" preview is never empty: if no events are
+  scheduled, it falls back to the two most recent past events with
+  recap links.
+- Numbers in the trust strip are traceable back to structured content
+  or explicitly flagged as organizer-confirmed. No invented figures.

--- a/prd/pages/home.md
+++ b/prd/pages/home.md
@@ -40,7 +40,8 @@ not product copy.
    - Primary CTA: **"RSVP on Luma"** → `/events`.
    - Secondary CTA: "Join our Slack".
    - Hero visual: a curated collage of real event photos (retain the
-     collage motif from the current site, treated more elegantly).
+     collage motif from the current site, treated with more intentional
+     composition and whitespace).
 
 2. **Trust strip / fast facts**
    - Fast facts pulled from the structured events content — for

--- a/prd/pages/how-it-works/index.md
+++ b/prd/pages/how-it-works/index.md
@@ -39,17 +39,39 @@ intake.
 ## 5. Content sections (on `/how-it-works` itself)
 
 1. **Hero**
-   - Headline: "Get Involved".
-   - Sub-headline: "TechTank runs on the Toronto tech community. Here's
-     how you can be part of it."
+   - Overline kicker: `GET INVOLVED`.
+   - Headline: "Let's build TechTank together."
+   - Sub-headline: "TechTank runs on the Toronto tech community —
+     speakers, hosts, sponsors, and volunteers who show up every
+     month. Pick the role that fits you right now."
 
-2. **The four roles**
-   - Four large cards, each linking to its sub-page:
-     - **Speak** — share what you know at a meetup.
-     - **Host** — provide a venue and food for an event.
-     - **Sponsor** — support the community as a corporate partner.
-     - **Volunteer** — help run the community behind the scenes.
-   - Each card shows: one-line pitch, time commitment, primary CTA.
+2. **Ways to get involved (four role cards)**
+   - Overline kicker: `WAYS TO GET INVOLVED`.
+   - Four equal-weight cards rendered with the shared role-card
+     component (see PRD §5.7). Each card follows the same shape:
+     - Icon
+     - Overline (role kicker — e.g. `SHARE WHAT YOU KNOW`)
+     - Headline (e.g. "Speak at an event")
+     - One-paragraph pitch
+     - Three checkmark bullets of what you get / what's required
+     - Primary CTA linking into the sub-page
+   - Card content:
+     - **Speak** → `/how-it-works/speaker`
+       - Overline: `SHARE WHAT YOU KNOW`
+       - Checkmarks: 30–45 min talk + Q&A · Any tech topic · Recorded
+         and published to YouTube
+     - **Host** → `/how-it-works/host`
+       - Overline: `BRING US TO YOUR SPACE`
+       - Checkmarks: 100–120 attendees · 6:00–8:30pm weeknight · Logo
+         on event marketing
+     - **Sponsor** → `/how-it-works/sponsor`
+       - Overline: `SUPPORT THE COMMUNITY`
+       - Checkmarks: Logo on website and marketing · Speaker slot
+         options · Tasteful brand visibility
+     - **Volunteer** → `/how-it-works/volunteer`
+       - Overline: `HELP RUN THE CREW`
+       - Checkmarks: Event-day or ongoing · No speaking required ·
+         Portfolio-quality work for creatives
 
 3. **Why get involved**
    - Three columns reused across sub-pages:
@@ -63,16 +85,31 @@ intake.
    - "Can I volunteer without speaking / hosting?" (Yes.)
    - "How fast will you get back to me?" (Target: within one week.)
 
+5. **Contact strip (end of page)**
+   - Overline kicker: `READY TO CONNECT?`
+   - Headline: "Drop us a line."
+   - Copy: "We respond to every message — hosts, sponsors, speakers,
+     and volunteers. Whichever role fits, we'd love to hear from you."
+   - Direct-email contact card: `techtankto@gmail.com` with a one-line
+     caption ("For hosting, sponsorship, speaking, and community
+     inquiries.").
+
 ## 6. Calls to action (priority order)
 
 1. Pick a role (Speak / Host / Sponsor / Volunteer)
-2. Join our Slack
+2. Email `techtankto@gmail.com`
+3. Join our Slack
 
 ## 7. Functional requirements
 
 - Shared layout renders in all `/how-it-works/*` routes.
 - Sub-nav highlights the active sub-page.
 - Each role card has a stable anchor for deep-linking.
+- The role-card component is shared with the home page (see
+  `pages/home.md` section 5) so the four paths stay visually and
+  structurally identical.
+- The direct-email contact card offers copy-to-clipboard as well as a
+  `mailto:` link.
 
 ## 8. Acceptance criteria
 
@@ -80,3 +117,7 @@ intake.
   click of `/how-it-works`.
 - A visitor understands the difference between Host and Sponsor without
   having to read both sub-pages.
+- All four role cards are reachable without horizontal scroll on
+  mobile and render identically (same height, same bullet count).
+- The contact email is visible and interactive without scrolling past
+  the footer.

--- a/prd/prompts/v0-stitch.md
+++ b/prd/prompts/v0-stitch.md
@@ -28,7 +28,7 @@ accounts or ticketing.
   students, career-changers, senior engineers, and corporate sponsors
   alike. Concrete, not aspirational. Confident without being
   exclusionary. Avoid anything that reads as playful, youthful, or
-  consumer-app-like; the tone should be credible enough that a
+  the tone should be credible enough that a
   sponsor's marketing team feels comfortable associating their brand
   here.
 - **Palette (use these exactly — do not invent colours):**

--- a/prd/prompts/v0-stitch.md
+++ b/prd/prompts/v0-stitch.md
@@ -24,8 +24,13 @@ accounts or ticketing.
 
 ## Brand & tone
 
-- **Voice:** warm, welcoming, beginner-safe, Toronto-local, confident.
-  Concrete, not aspirational.
+- **Voice:** welcoming and inclusive to everyone in the tech space —
+  students, career-changers, senior engineers, and corporate sponsors
+  alike. Concrete, not aspirational. Confident without being
+  exclusionary. Avoid anything that reads as playful, youthful, or
+  consumer-app-like; the tone should be credible enough that a
+  sponsor's marketing team feels comfortable associating their brand
+  here.
 - **Palette (use these exactly — do not invent colours):**
   - Gradient: three-stop background motif — warm peach/coral
     (`#F5C4A8`) → soft lavender (`#D8CEED`) → pale aqua teal
@@ -36,10 +41,12 @@ accounts or ticketing.
   - Body text: near-black on light surfaces.
   - Do not introduce hot pink, true blue, or colours outside this
     family.
-  - Professional and elegant, not corporate. Generous whitespace.
-    Editorial rhythm.
-- **Typography:** one editorial serif or distinctive display face for
-  headlines, one humanist sans for body.
+  - Professional and welcoming, not corporate. Generous whitespace.
+    Clean, structured rhythm.
+- **Typography:** a strong, neutral display typeface (geometric or
+  grotesque sans preferred — avoid decorative serifs, script faces, or
+  anything that reads as playful). A legible humanist sans for body.
+  The pairing should feel industry-conference-grade.
 - **Imagery:** real event photography first. No stock illustration.
 - **Motif:** fish/"Tank" mark is a subtle detail, not a dominant motif.
 

--- a/prd/prompts/v0-stitch.md
+++ b/prd/prompts/v0-stitch.md
@@ -26,10 +26,18 @@ accounts or ticketing.
 
 - **Voice:** warm, welcoming, beginner-safe, Toronto-local, confident.
   Concrete, not aspirational.
-- **Palette:** professional and elegant, not corporate. Start from a
-  near-black ink base with a single vibrant accent (TechTank's
-  pink→blue→teal gradient can show up as a signature accent, not the
-  whole canvas). Generous whitespace. Editorial rhythm.
+- **Palette (use these exactly — do not invent colours):**
+  - Gradient: three-stop background motif — warm peach/coral
+    (`#F5C4A8`) → soft lavender (`#D8CEED`) → pale aqua teal
+    (`#B5E0D9`). Used for hero and section banding. Not pink.
+  - Logo teal: `#3DC4C0` — primary brand colour, fish mark.
+  - Logo amber: `#F0AA00` — lightning bolt highlight; use sparingly.
+  - Surface dark / CTA: `#141926` — pill buttons, footer background.
+  - Body text: near-black on light surfaces.
+  - Do not introduce hot pink, true blue, or colours outside this
+    family.
+  - Professional and elegant, not corporate. Generous whitespace.
+    Editorial rhythm.
 - **Typography:** one editorial serif or distinctive display face for
   headlines, one humanist sans for body.
 - **Imagery:** real event photography first. No stock illustration.

--- a/prd/prompts/v0-stitch.md
+++ b/prd/prompts/v0-stitch.md
@@ -1,0 +1,216 @@
+# TechTank TO — v0 / Stitch prompt
+
+Drop-in prompt for v0.dev or Google Stitch. Covers the full redesign
+spec at enough fidelity for the tool to generate a coherent first
+pass. Full spec lives in `../PRD.md` and `../pages/`.
+
+---
+
+Design a marketing website for **TechTank TO**, Toronto's volunteer-run
+tech community (monthly in-person meetups, founded 2022). The redesign
+replaces a flat link-tree with a conversion-oriented onboarding hub.
+The site funnels visitors to external platforms — it does not own
+accounts or ticketing.
+
+## Stack & delivery
+
+- Next.js 14 App Router, TypeScript, Tailwind CSS.
+- Shared layouts for `/how-it-works/*` (sticky sub-nav) and `/legal/*`
+  (document column + ToC).
+- Mobile-first. Breakpoints 640 / 1024 / 1280.
+- WCAG 2.1 AA: visible focus, alt text, semantic headings,
+  keyboard-reachable forms, reduced-motion support.
+- Core Web Vitals "Good"; LCP < 2.5s on 4G mobile.
+
+## Brand & tone
+
+- **Voice:** warm, welcoming, beginner-safe, Toronto-local, confident.
+  Concrete, not aspirational.
+- **Palette:** professional and elegant, not corporate. Start from a
+  near-black ink base with a single vibrant accent (TechTank's
+  pink→blue→teal gradient can show up as a signature accent, not the
+  whole canvas). Generous whitespace. Editorial rhythm.
+- **Typography:** one editorial serif or distinctive display face for
+  headlines, one humanist sans for body.
+- **Imagery:** real event photography first. No stock illustration.
+- **Motif:** fish/"Tank" mark is a subtle detail, not a dominant motif.
+
+## Information architecture
+
+```
+/
+├── about
+├── how-it-works            (onboarding hub — shared layout)
+│   ├── speaker
+│   ├── host
+│   ├── sponsor
+│   └── volunteer
+├── events                  (Luma calendar + event archive)
+├── press-kit
+└── legal                   (shared layout)
+    ├── terms-of-service
+    ├── privacy-policy
+    └── code-of-conduct
+```
+
+**Global nav:** About · How it Works · Events · Press Kit.
+**Header CTAs:** primary "Join our Slack", secondary "RSVP on Luma".
+**Footer columns:** Community (Meetup, Luma, Slack, LinkedIn,
+Instagram, GitHub, YouTube) · Get Involved (Speak, Host, Sponsor,
+Volunteer) · Resources (Press Kit, Events) · Legal. Contact:
+`techtankto@gmail.com`.
+
+## Recurring UI primitives (use consistently across pages)
+
+1. **Overline kicker** — short all-caps label above every major
+   section headline (e.g. `WAYS TO GET INVOLVED`, `NEXT UP`, `RECENT
+   EVENTS`, `LATEST HIGHLIGHTS`, `GET IN TOUCH`, `READY TO CONNECT?`).
+2. **Role card** — icon → overline → headline → one-paragraph pitch →
+   three checkmark bullets → primary CTA. Reused identically for the
+   four roles (Speak / Host / Sponsor / Volunteer) on `/` and
+   `/how-it-works`.
+3. **Event card** — status badge (`UPCOMING` / `RECAP AVAILABLE`),
+   event number + date badge, title, one-line pitch, chips for date/
+   time/venue, tag chips (topic, beginner-friendly, capacity),
+   host/sponsor attribution ("Supported by <logo>"), CTA ("RSVP on
+   Luma" or "View Recap"). Reused on `/` and `/events`.
+4. **Supported-by strip** — single-line host/sponsor logo
+   acknowledgment directly above the footer on `/` and `/events`.
+5. **Dual end-of-page CTA** — two side-by-side cards closing long
+   pages: "Never miss an event" (Luma subscribe) + "Want to
+   contribute?" (→ `/how-it-works`).
+6. **Direct-email contact card** — prominent, copy-friendly card
+   showing `techtankto@gmail.com` + one-line context. Appears at the
+   end of `/how-it-works`, `/how-it-works/*`, and `/press-kit`.
+7. **Testimonial** — quote, name, role, company, small photo, linked
+   to LinkedIn where available.
+8. **Logo cloud** — grayscale, evenly-spaced, with caption "Companies
+   that have supported TechTank". Distinct from the "Supported by"
+   strip.
+
+## Page-by-page
+
+### `/` (Home)
+
+Hero with overline kicker `TORONTO · MONTHLY · SINCE 2022`, brand
+lockup, one-sentence mission, primary CTA "RSVP on Luma", secondary
+"Join our Slack". Hero visual: curated real-event photo collage.
+
+Sections below the hero, in order:
+1. Trust strip — large numerals (attendees per event, talks, events
+   hosted, cadence). Numbers sourced from structured content; never
+   invented.
+2. Testimonials — 3–6 quotes.
+3. Logo cloud of past hosts/sponsors.
+4. **Ways to get involved** — overline + headline "Become part of it"
+   + four role cards (Speak / Host / Sponsor / Volunteer).
+5. **Recent Events** — overline `RECENT EVENTS`, right-aligned "View
+   all events →". Shows the next upcoming event plus the two most
+   recent past events using the event-card component.
+6. **Latest Highlights** — overline + two-up: left is an embedded
+   Instagram reel or Google Photos preview from the most recent
+   event; right is short copy + "Follow on Instagram" and "Join our
+   Slack" links.
+7. Four-pillar values teaser (Community, Innovation, Teamwork,
+   Respect) linking to `/about`.
+8. Dual end-of-page CTA cards.
+9. Supported-by strip.
+10. Footer.
+
+### `/about`
+
+Values manifesto built on four pillars (Community, Innovation,
+Teamwork, Respect). Each pillar gets an overline, headline,
+paragraph, and supporting photo or quote. Mission statement block.
+Timeline of the community since 2022. Link out to Code of Conduct.
+
+### `/how-it-works` (onboarding hub)
+
+Shared layout: sticky sub-nav (Overview / Speaker / Host / Sponsor /
+Volunteer) that collapses to a segmented control on mobile; persistent
+"Join our Slack" CTA; shared "Why get involved" strip.
+
+Overview page content:
+1. Hero — overline `GET INVOLVED`, headline "Let's build TechTank
+   together."
+2. Four role cards (same shape as `/`):
+   - **Speak** — `SHARE WHAT YOU KNOW` · 30–45 min talk + Q&A · Any
+     tech topic · Recorded & published to YouTube.
+   - **Host** — `BRING US TO YOUR SPACE` · 100–120 attendees ·
+     6:00–8:30pm weeknight · Logo on event marketing.
+   - **Sponsor** — `SUPPORT THE COMMUNITY` · Logo on website &
+     marketing · Speaker slot options · Tasteful brand visibility.
+   - **Volunteer** — `HELP RUN THE CREW` · Event-day or ongoing · No
+     speaking required · Portfolio-quality work for creatives.
+3. "Why get involved" — three columns (Marketing & Brand, Recruiting,
+   Karma).
+4. FAQ (speaker seniority, host cost, volunteer gating, response time).
+5. Contact strip — overline `READY TO CONNECT?`, headline "Drop us a
+   line.", direct-email contact card.
+
+### `/how-it-works/<role>` (Speaker, Host, Sponsor, Volunteer)
+
+Each sub-page follows the same structure:
+- Hero with overline, headline, sub-headline, primary CTA to intake
+  form.
+- "Why <role>" three-column.
+- Logistics (Speaker: talk length, format, audience, recording;
+  Host: capacity 100–120, timing 6:00–8:30pm, AV, food, TTC access;
+  Sponsor: what sponsorship supports, soft tier hints; Volunteer:
+  roles + time commitment).
+- "What TechTank handles" vs. "What you provide" two-up.
+- "What you get" checklist.
+- Social proof (testimonials + logo cloud or current crew photos).
+- Embedded Google Form intake (one per role).
+- Direct-email contact card at the bottom.
+
+### `/events`
+
+1. Hero — overline `TECHTANK TO`, headline "All Events", sub-headline
+   "Every TechTank meetup — most recent first." Right-aligned counter
+   "<N> EVENTS · SINCE 2022" from structured content.
+2. **Next Up** — featured full-width event card (`UPCOMING` badge,
+   date, title, tag chips, supported-by right rail). Primary CTA
+   "RSVP on Luma", secondary "View details". If no sponsor confirmed,
+   right rail shows "Looking for a host" linking to
+   `/how-it-works/host`.
+3. Full-width Luma calendar embed. Fallback: next-5-events list if the
+   embed fails.
+4. **Past Events** — vertical timeline of past-event cards, most
+   recent first. Each card: event number + date badge, `RECAP
+   AVAILABLE` chip, title + host attribution, chips, host/sponsor
+   logo, "View Recap" CTA that expands inline to Google Photos
+   album + YouTube recording + speaker list + host/sponsor thank-you.
+5. Dual end-of-page CTA (subscribe / get involved).
+6. Contact strip with direct-email card.
+
+### `/press-kit`
+
+Standalone single-page brand kit. Logo downloads (SVG + PNG in ZIP),
+brand guidelines PDF, fast facts, leadership bios (if provided),
+media contact (`techtankto@gmail.com`), past press mentions, social
+handles, embed of the latest Guppy Talks YouTube video. Direct-email
+contact card at the bottom.
+
+### `/legal/*`
+
+Shared layout: narrow document column with editorial typography, a
+sticky table-of-contents sidebar on desktop, "Last updated"
+timestamp at top. Three docs: Terms of Service, Privacy Policy, Code
+of Conduct. Inline links between them. Consistent heading rhythm.
+
+## External destinations (all links open in a new tab, rel="noopener
+noreferrer")
+
+Meetup · Luma · Slack (invite) · LinkedIn · Instagram · YouTube ·
+GitHub · Google Photos (per-event albums) · Google Forms (one per
+`/how-it-works/*` intake).
+
+## Must-not
+
+- Don't invent numbers (attendance, tiers, talk counts). Leave a
+  visible "finalize with organizers" placeholder instead.
+- Don't re-introduce standalone `/speak`, `/host`, `/mentors`,
+  `/donate` pages — those are consolidated under `/how-it-works/*`.
+- Don't use stock illustration in place of real event photography.
+- Don't dilute the "one dominant CTA per page" rule.


### PR DESCRIPTION
## Summary

This PR adds a comprehensive drop-in prompt for AI code generation tools (v0.dev, Google Stitch) and refines the product specification across multiple pages to establish clearer patterns, content structure, and functional requirements for the TechTank TO redesign.

## Key Changes

### New Content
- **`prd/prompts/v0-stitch.md`** — A 230-line drop-in prompt for v0/Stitch that covers the full redesign spec at sufficient fidelity for AI tools to generate a coherent first pass. Includes:
  - Stack & delivery requirements (Next.js 14, TypeScript, Tailwind, WCAG 2.1 AA, Core Web Vitals)
  - Brand guidelines with exact color values (gradient, logo teal `#3DC4C0`, logo amber `#F0AA00`, surface dark `#141926`)
  - Complete information architecture and page-by-page content outlines
  - Recurring UI primitives (overline kickers, role cards, event cards, contact strips, etc.)
  - Must-not constraints (no invented numbers, no stock illustration, no standalone pages)

### Specification Refinements

**`prd/PRD.md`**
- Clarified visual tone: "professional and welcoming" (not corporate, not casual) with credibility for sponsor association
- Expanded typography guidance: geometric/grotesque sans for display (not decorative serifs), humanist sans for body; industry-conference-grade pairing
- Detailed color palette with hex approximations and explicit constraints (no hot pink, true blue, or out-of-family colors)
- Added §5.6 (Event archive & recap pattern) — event records carry number/date badge, title, venue/time chips, tag chips, host/sponsor attribution, status, and recap links
- Added §5.7 (Recurring UI patterns) — formalized overline kickers, role cards with checkmarks, supported-by strips, dual end-of-page CTAs, and direct-email contact cards
- Updated §6 (Functional Requirements) to specify structured event content (MDX/JSON) powering both `/events` and home-page preview

**`prd/pages/home.md`**
- Added overline kicker `TORONTO · MONTHLY · SINCE 2022` to hero
- Refined trust strip to pull from structured event content (no invented numbers; flag unconfirmed figures)
- Expanded "Ways to get involved" section with full role-card structure (icon, overline, headline, pitch, three checkmarks, CTA)
- Replaced generic "upcoming events preview" with "Recent Events" section showing next event + two most recent past events with recap CTAs
- Added "Latest Highlights" section (two-up: Instagram/Photos embed + copy + social links)
- Added "Dual end-of-page CTA" cards (Never miss an event / Want to contribute?)
- Added "Supported-by strip" above footer
- Clarified that role cards and event cards are shared components (no bespoke variants)

**`prd/pages/events.md`**
- Expanded role from "calendar embed only" to "single source of truth for upcoming and past events"
- Restructured hero with overline `TECHTANK TO`, headline "All Events", and right-aligned event counter
- Added "Next Up" featured card section with `UPCOMING` badge, event number/date badge, title, chips, host/sponsor attribution, and dual CTAs
- Added "Past Events timeline" section with vertical layout, `RECAP AVAILABLE` chips, and inline recap expansion (Google Photos + YouTube + speaker list + thank-you)
- Added "Dual end-of-page CTA" cards (Never miss an event / Want to contribute?)
- Added "Contact strip" with direct-email card
- Clarified that recaps are inline expansions + external links (no dedicated `/events/<slug>` detail route in v1)
- Updated functional requirements to specify structured event content, progressive disclosure for recap expansion, and graceful degradation for missing media

**`prd/pages/how-it-works/index.md`**
- Added overline kicker `GET INVOLVED` to hero
- Refined headline

https://claude.ai/code/session_01YV1Wj9kXSGNq4ZjQA7Ds5k