### PR TITLE
Rename /how-it-works to /get-involved and redesign home CTA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files
+.env*
+!.env.example
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,12 +31,12 @@ For developer-facing setup (scripts, directory tree, route map), see
         ├── about.md               # /about
         ├── events.md              # /events
         ├── press-kit.md           # /press-kit
-        ├── how-it-works/          # Onboarding hub (shared layout)
-        │   ├── index.md           # /how-it-works
-        │   ├── speaker.md         # /how-it-works/speaker
-        │   ├── host.md            # /how-it-works/host
-        │   ├── sponsor.md         # /how-it-works/sponsor
-        │   └── volunteer.md       # /how-it-works/volunteer
+        ├── get-involved/          # Onboarding hub (shared layout)
+        │   ├── index.md           # /get-involved
+        │   ├── speaker.md         # /get-involved/speaker
+        │   ├── host.md            # /get-involved/host
+        │   ├── sponsor.md         # /get-involved/sponsor
+        │   └── volunteer.md       # /get-involved/volunteer
         └── legal/                 # Legal folder (shared layout)
             ├── terms-of-service.md
             ├── privacy-policy.md
@@ -55,14 +55,14 @@ The redesign replaces a flat "link-tree" layout with a
 - `/` — social-proof-driven home (testimonials, event photos, logo cloud).
 - `/about` — values manifesto built on four pillars: **Community,
   Innovation, Teamwork, Respect**.
-- `/how-it-works` — onboarding hub with four role sub-pages (Speaker,
+- `/get-involved` — onboarding hub with four role sub-pages (Speaker,
   Host, Sponsor, Volunteer), each ending in an intake action (email us
   at `techtankto@gmail.com`).
 - `/events` — embedded Luma calendar.
 - `/press-kit` — standalone brand assets and fast facts for media.
 - `/legal` — grouped compliance documents.
 
-The `/how-it-works` and `/legal` sections are designed for **Next.js
+The `/get-involved` and `/legal` sections are designed for **Next.js
 shared layouts** (sticky sub-nav, persistent CTA, consistent form/
 document styling).
 
@@ -87,14 +87,14 @@ document styling).
 - Concrete, not aspirational. If organizers haven't confirmed a number
   (attendance, tier, timing), flag it instead of inventing one.
 - Conversion-oriented: every page spec must declare **one dominant
-  CTA**, and `/how-it-works/*` must end in an intake action (email us).
+  CTA**, and `/get-involved/*` must end in an intake action (email us).
 - Social proof first: testimonials, real event photography, and
   logo clouds are required patterns, not decoration.
 
 ### Adding a new page
 
 1. Decide where it belongs in the IA. If it's a role, it goes under
-   `/how-it-works`; if it's legal, under `/legal`; if it's a resource,
+   `/get-involved`; if it's legal, under `/legal`; if it's a resource,
    it's probably a sibling of `/press-kit`.
 2. Create `prd/pages/<path>.md` following the existing section
    structure.
@@ -119,7 +119,7 @@ document styling).
   than to publish fiction.
 - Don't re-introduce the old flat structure (separate `/speak`,
   `/host`, `/mentors`, `/donate`, `/terms-conditions` pages) — those
-  were intentionally rolled into `/how-it-works/*` and `/legal/*`.
+  were intentionally rolled into `/get-involved/*` and `/legal/*`.
 - Don't touch settings or hooks without being asked.
 
 ## Git workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,3 +129,7 @@ document styling).
 - Create new commits rather than amending. Use HEREDOC commit messages.
 - Never force-push or skip hooks without explicit permission.
 - Do not open a pull request unless explicitly asked.
+- Do not sign commits or PRs as Claude, and do not include
+  `claude.ai/code` session links, `Co-Authored-By: Claude` trailers,
+  or any other "Generated with Claude Code" markers in commit messages
+  or PR bodies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,3 +133,31 @@ document styling).
   `claude.ai/code` session links, `Co-Authored-By: Claude` trailers,
   or any other "Generated with Claude Code" markers in commit messages
   or PR bodies.
+
+### Conventional commits
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/)
+  for every commit subject:
+  `<type>(<optional scope>): <imperative summary>`
+- Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`,
+  `test`, `build`, `ci`, `chore`, `revert`.
+- Pick a scope that matches the page or area (`about`, `events`,
+  `get-involved/sponsor`, `prd`, `legal`, etc.) when one is obvious;
+  omit it when the change is global.
+- Keep the subject under ~72 characters, lowercase, no trailing
+  period; explain the *why* in the body if the diff alone doesn't.
+- Use `!` (e.g. `feat(get-involved)!: …`) and a `BREAKING CHANGE:`
+  footer for changes that move URLs, rename routes, or alter
+  documented behavior.
+
+### Branch naming
+
+- Branches follow `<type>/<short-kebab-summary>` using the same
+  type vocabulary as commits — e.g. `feat/sponsor-intake-form`,
+  `fix/events-luma-fallback`, `docs/prd-route-map`,
+  `refactor/get-involved-layout`.
+- Session-managed Claude branches keep the `claude/<slug>` prefix
+  given in the session brief; treat the slug as the conventional
+  summary and don't rename it.
+- Keep slugs short (≤40 chars), lowercase, hyphen-separated, and
+  reference the affected area rather than the ticket number.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ route, annotated with its purpose.
 │   ├── page.tsx                    # /                    Social-proof-driven home
 │   ├── about/                      # /about               Values & community manifesto
 │   ├── events/                     # /events              Upcoming (Luma) + past event timeline
-│   ├── how-it-works/               # /how-it-works        Onboarding hub (shared layout)
+│   ├── get-involved/               # /get-involved        Onboarding hub (shared layout)
 │   │   ├── speaker/                #   /speaker           Speaker intake
 │   │   ├── host/                   #   /host              Host intake
 │   │   ├── sponsor/                #   /sponsor           Sponsor intake
@@ -81,5 +81,5 @@ conventions, and per-page content requirements.
    structural changes — they define the IA, brand, and content conventions.
 2. When adding or renaming a route, update both the route table in
    `prd/PRD.md` §2.1 and the corresponding spec in `prd/pages/`.
-3. Keep one dominant CTA per page. Role pages under `/how-it-works/*` must end
+3. Keep one dominant CTA per page. Role pages under `/get-involved/*` must end
    in an intake action (email us).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The initial UI scaffold was generated from the PRD via v0 —
 - React 19 + TypeScript
 - [Tailwind CSS 4](https://tailwindcss.com/)
 - [Radix UI primitives](https://www.radix-ui.com/) (via `@radix-ui/react-slot`)
-- [lucide-react](https://lucide.dev/) and [@icons-pack/react-simple-icons](https://github.com/icons-pack/react-simple-icons) for icons
+- [lucide-react](https://lucide.dev/) for icons
 - Inter + Space Grotesk via `next/font`
 - pnpm 10 for package management
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Users, Lightbulb, Handshake, Heart, ExternalLink } from "lucide-react";
+import { Users, Lightbulb, Handshake, Heart } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Section, SectionHeader } from "@/components/ui/section";
-import { DualCTA } from "@/components/ui/dual-cta";
 
 export const metadata: Metadata = {
   title: "About",
@@ -59,7 +58,7 @@ const timeline = [
     year: "2024",
     title: "Community programs launch",
     description:
-      "Guppy Talks for first-time speakers. Study Tank for learning groups. The volunteer crew expanded to support larger events.",
+      "Code Diversity for underrepresented voices. The volunteer crew expanded to support larger events.",
   },
   {
     year: "2025",
@@ -181,8 +180,7 @@ export default function AboutPage() {
               </p>
               <p>
                 <strong className="text-foreground">Community programs:</strong>{" "}
-                Guppy Talks for first-time speakers. Study Tank for learning
-                groups. Code Diversity for underrepresented voices.
+                Code Diversity for underrepresented voices in tech.
               </p>
             </div>
           </div>
@@ -211,10 +209,10 @@ export default function AboutPage() {
           </p>
           <div className="flex flex-wrap gap-4 justify-center">
             <Button variant="primary" asChild>
-              <Link href="/how-it-works/host">Host an event</Link>
+              <Link href="/get-involved/host">Host an event</Link>
             </Button>
             <Button variant="outline" asChild>
-              <Link href="/how-it-works/sponsor">Become a sponsor</Link>
+              <Link href="/get-involved/sponsor">Become a sponsor</Link>
             </Button>
           </div>
         </div>
@@ -280,25 +278,13 @@ export default function AboutPage() {
           </p>
           <div className="flex flex-wrap gap-4 justify-center">
             <Button variant="primary" size="lg" asChild>
-              <a
-                href="https://luma.com/techtank"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                RSVP to the next event
-                <ExternalLink className="ml-2 h-5 w-5" />
-              </a>
+              <Link href="/events">See upcoming events</Link>
             </Button>
             <Button variant="outline" size="lg" asChild>
-              <Link href="/how-it-works">Get involved</Link>
+              <Link href="/get-involved">Get involved</Link>
             </Button>
           </div>
         </div>
-      </Section>
-
-      {/* Dual CTA */}
-      <Section>
-        <DualCTA />
       </Section>
     </>
   );

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -273,14 +273,14 @@ export default function AboutPage() {
 
       {/* Closing CTA */}
       <Section className="gradient-brand-soft">
-        <div className="text-center max-w-2xl mx-auto">
+        <div className="max-w-2xl mx-auto text-center">
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-teal mb-4">
             Join us
           </span>
-          <h2 className="font-display text-3xl lg:text-4xl font-semibold text-foreground mb-6">
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
             Ready to be part of TechTank?
           </h2>
-          <p className="text-lg text-muted mb-8">
+          <p className="text-muted mb-8">
             Whether you want to attend, speak, host, or volunteer — there&apos;s
             a place for you here.
           </p>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -87,13 +87,21 @@ export default function AboutPage() {
             <h1 className="font-display text-4xl font-semibold text-foreground lg:text-5xl text-balance mb-6">
               We build the community we wanted to find
             </h1>
-            <p className="text-xl text-muted leading-relaxed">
+            <p className="text-xl text-muted leading-relaxed mb-8">
               TechTank TO is a volunteer-run, Toronto-based tech community
               founded in 2022. We host monthly in-person events where
               developers, designers, PMs, and tech-curious people gather to
               learn, share, and connect. No gatekeeping—just people
               helping people grow in tech.
             </p>
+            <div className="flex flex-wrap gap-3">
+              <Button variant="primary" size="lg" asChild>
+                <Link href="/events">See upcoming events</Link>
+              </Button>
+              <Button variant="outline" size="lg" asChild>
+                <Link href="/get-involved">Get involved</Link>
+              </Button>
+            </div>
           </div>
         </div>
       </section>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -173,8 +173,8 @@ export default function AboutPage() {
             <div className="space-y-4 text-muted leading-relaxed">
               <p>
                 <strong className="text-foreground">Monthly meetups:</strong>{" "}
-                In-person events featuring technical talks, networking, and free
-                food. 100-120 attendees, hosted at companies across Toronto.
+                In-person events featuring technical talks and networking.
+                40-100 attendees, hosted at companies across Toronto.
               </p>
               <p>
                 <strong className="text-foreground">Slack community:</strong>{" "}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -145,7 +145,7 @@ export default function EventsPage() {
                         Want to bring TechTank to your space?
                       </p>
                       <Button variant="outline" size="sm" asChild>
-                        <Link href="/how-it-works/host">Learn about hosting</Link>
+                        <Link href="/get-involved/host">Learn about hosting</Link>
                       </Button>
                     </div>
                   )}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -33,7 +33,9 @@ export default function EventsPage() {
                 All Events
               </h1>
               <p className="text-xl text-muted">
-                Every TechTank meetup — most recent first.
+                RSVP to what&apos;s next — and scroll back through the
+                talks, photos, and recaps from every meetup we&apos;ve
+                hosted since 2022.
               </p>
             </div>
             <div className="shrink-0">

--- a/app/get-involved/host/page.tsx
+++ b/app/get-involved/host/page.tsx
@@ -43,7 +43,7 @@ const logistics = [
 
 const techTankHandles = [
   "Speaker sourcing (unless you want to bring your own)",
-  "Marketing (Meetup, Slack, LinkedIn, Instagram)",
+  "Marketing (Slack, LinkedIn, Instagram)",
   "Registration and attendee tracking",
   "Event coordination and MCing",
   "Recording and publishing to YouTube",

--- a/app/get-involved/layout.tsx
+++ b/app/get-involved/layout.tsx
@@ -4,14 +4,14 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const subNav = [
-  { name: "Overview", href: "/how-it-works" },
-  { name: "Speaker", href: "/how-it-works/speaker" },
-  { name: "Host", href: "/how-it-works/host" },
-  { name: "Sponsor", href: "/how-it-works/sponsor" },
-  { name: "Volunteer", href: "/how-it-works/volunteer" },
+  { name: "Overview", href: "/get-involved" },
+  { name: "Speaker", href: "/get-involved/speaker" },
+  { name: "Host", href: "/get-involved/host" },
+  { name: "Sponsor", href: "/get-involved/sponsor" },
+  { name: "Volunteer", href: "/get-involved/volunteer" },
 ];
 
-export default function HowItWorksLayout({
+export default function GetInvolvedLayout({
   children,
 }: {
   children: React.ReactNode;
@@ -28,8 +28,8 @@ export default function HowItWorksLayout({
             <div className="flex items-center justify-center gap-1 overflow-x-auto -mx-4 px-4 lg:mx-0 lg:px-0 scrollbar-hide">
               {subNav.map((item) => {
                 const isActive =
-                  item.href === "/how-it-works"
-                    ? pathname === "/how-it-works"
+                  item.href === "/get-involved"
+                    ? pathname === "/get-involved"
                     : pathname.startsWith(item.href);
 
                 return (

--- a/app/get-involved/page.tsx
+++ b/app/get-involved/page.tsx
@@ -5,7 +5,7 @@ import { RoleCard, roleCardsData } from "@/components/ui/role-card";
 import { ContactCard } from "@/components/ui/contact-card";
 
 export const metadata: Metadata = {
-  title: "How It Works",
+  title: "Get Involved",
   description:
     "Get involved with TechTank TO. Speak, host, sponsor, or volunteer — there are multiple ways to contribute to Toronto's tech community.",
 };
@@ -54,7 +54,7 @@ const faqs = [
   },
 ];
 
-export default function HowItWorksPage() {
+export default function GetInvolvedPage() {
   return (
     <>
       {/* Hero */}

--- a/app/get-involved/speaker/page.tsx
+++ b/app/get-involved/speaker/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import { Check, Clock, Users, Video, Mic, FileText } from "lucide-react";
+import Link from "next/link";
+import { Check, Clock, Users, Video, Mic, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Section, SectionHeader } from "@/components/ui/section";
 import { ContactCard } from "@/components/ui/contact-card";
@@ -41,7 +42,7 @@ const logistics = [
 
 const techTankHandles = [
   "Venue and catering (via a host company)",
-  "Marketing (Meetup, Slack, LinkedIn, Instagram)",
+  "Marketing (Slack, LinkedIn, Instagram)",
   "Run-of-show coordination and MCing",
   "Recording and post-production",
   "Feedback and rehearsal sessions for first-time speakers",
@@ -194,48 +195,23 @@ export default function SpeakerPage() {
 
       {/* Speaker Resources */}
       <Section>
-        <SectionHeader
-          overline="Resources"
-          title="Speaker toolkit"
-          className="mb-12"
-        />
-        <div className="grid gap-6 lg:grid-cols-3">
-          <a
-            href="#"
-            className="group bg-white rounded-xl border border-border p-6 hover:border-teal/50 transition-all"
-          >
-            <FileText className="h-8 w-8 text-teal mb-4" />
-            <h4 className="font-semibold text-foreground group-hover:text-teal transition-colors mb-2">
-              Slide deck template
-            </h4>
-            <p className="text-sm text-muted">
-              Branded Google Slides template to get you started.
-            </p>
-          </a>
-          <a
-            href="#"
-            className="group bg-white rounded-xl border border-border p-6 hover:border-teal/50 transition-all"
-          >
-            <FileText className="h-8 w-8 text-teal mb-4" />
-            <h4 className="font-semibold text-foreground group-hover:text-teal transition-colors mb-2">
-              Run-of-show PDF
-            </h4>
-            <p className="text-sm text-muted">
-              What to expect on event night, minute by minute.
-            </p>
-          </a>
-          <a
-            href="#"
-            className="group bg-white rounded-xl border border-border p-6 hover:border-teal/50 transition-all"
-          >
-            <FileText className="h-8 w-8 text-teal mb-4" />
-            <h4 className="font-semibold text-foreground group-hover:text-teal transition-colors mb-2">
-              First-time speaker tips
-            </h4>
-            <p className="text-sm text-muted">
-              Practical advice from speakers who started at TechTank.
-            </p>
-          </a>
+        <div className="max-w-3xl mx-auto text-center">
+          <span className="inline-block text-xs font-semibold uppercase tracking-widest text-teal mb-4">
+            Resources
+          </span>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
+            Speaker toolkit in the Press Kit
+          </h2>
+          <p className="text-muted mb-8">
+            Brand assets, slide templates, run-of-show guidance, and tips for
+            first-time speakers all live in our Press Kit.
+          </p>
+          <Button variant="outline" asChild>
+            <Link href="/press-kit">
+              Open the Press Kit
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
         </div>
       </Section>
 

--- a/app/get-involved/sponsor/page.tsx
+++ b/app/get-involved/sponsor/page.tsx
@@ -9,7 +9,7 @@ import { ContactCard } from "@/components/ui/contact-card";
 export const metadata: Metadata = {
   title: "Sponsor TechTank",
   description:
-    "Support Toronto's most inclusive tech community. Tasteful brand visibility, recruiting pipeline, and community karma.",
+    "Support Toronto's most inclusive tech community. Request sponsorship info and see how you can help the community thrive.",
 };
 
 const whySponsor = [
@@ -35,8 +35,7 @@ const whySponsor = [
 
 const whatSponsorshipSupports = [
   "Monthly event operations when no host venue is available",
-  "Speaker travel and honoraria where applicable",
-  "Community programs: Guppy Talks, Study Tank, Code Diversity",
+  "Community programs like Code Diversity for underrepresented voices",
   "Equipment, recording, and production costs",
   "Slack community and online resources",
 ];
@@ -49,19 +48,18 @@ const sponsorTiers = [
   },
   {
     name: "Event Sponsor",
-    description: "Logo + callouts across a quarter of events",
+    description: "Logo + callouts tied to sponsored events",
     highlight: false,
   },
   {
     name: "Annual Partner",
-    description: "Year-long placement, speaker slot, attendee list access",
+    description: "Year-long placement and a speaker slot",
     highlight: true,
   },
 ];
 
 const basePackage = [
   "Placement on techtankto.com logo cloud",
-  "Listed in Press Kit as a supporter",
   "Mentions in event marketing",
   "Social shout-outs (LinkedIn, Instagram)",
   "Option to speak at an event",
@@ -86,7 +84,7 @@ export default function SponsorPage() {
             </p>
             <Button variant="primary" size="lg" asChild>
               <a href="mailto:techtankto@gmail.com?subject=Sponsorship%20Inquiry%20-%20TechTank">
-                Request sponsorship package
+                Request sponsorship info
               </a>
             </Button>
           </div>
@@ -152,7 +150,7 @@ export default function SponsorPage() {
         <SectionHeader
           overline="Sponsorship tiers"
           title="Ways to support"
-          description="We offer flexible sponsorship options. Request our sponsorship package for full details."
+          description="We offer flexible sponsorship options. Request our sponsorship info for full details."
           className="mb-12"
         />
         <div className="grid gap-6 lg:grid-cols-3">
@@ -178,7 +176,7 @@ export default function SponsorPage() {
           ))}
         </div>
         <p className="text-center text-sm text-muted mt-8">
-          Exact pricing and benefits in our sponsorship package. Tiers are
+          Exact pricing and benefits in our sponsorship info. Tiers are
           illustrative — we&apos;ll work with your budget.
         </p>
       </Section>
@@ -233,7 +231,7 @@ export default function SponsorPage() {
             programs, or multiple events.
           </p>
           <Button variant="outline" asChild>
-            <Link href="/how-it-works/host">Learn about hosting</Link>
+            <Link href="/get-involved/host">Learn about hosting</Link>
           </Button>
         </div>
       </Section>
@@ -245,11 +243,11 @@ export default function SponsorPage() {
             Ready to sponsor?
           </span>
           <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            Get the sponsorship package
+            Get the sponsorship info
           </h2>
           <p className="text-muted mb-8">
             Tell us about your company and goals. We&apos;ll send our full
-            sponsorship deck within a week.
+            sponsorship details within a week.
           </p>
           <Button variant="primary" size="lg" asChild>
             <a href="mailto:techtankto@gmail.com?subject=Sponsorship%20Inquiry%20-%20TechTank">

--- a/app/get-involved/volunteer/page.tsx
+++ b/app/get-involved/volunteer/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Check, Users, Palette, Camera, MessageSquare, Calendar, Settings, Code } from "lucide-react";
+import { Check, Users, Palette, Camera, MessageSquare, Calendar, Settings } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Section, SectionHeader } from "@/components/ui/section";
 import { ContactCard } from "@/components/ui/contact-card";
@@ -68,12 +68,6 @@ const volunteerRoles = [
     title: "Organizing",
     description: "Help plan events, outreach, speaker sourcing",
     commitment: "Variable; onboarding conversation first",
-  },
-  {
-    icon: Code,
-    title: "Code & open source",
-    description: "Contribute to our website, tools, and open source projects on GitHub",
-    commitment: "Project-based, flexible async work",
   },
 ];
 
@@ -197,7 +191,8 @@ export default function VolunteerPage() {
             Ready to join the crew?
           </h2>
           <p className="text-muted mb-8">
-            Sign up to volunteer, contribute code on GitHub, or come to an event first to meet the team.
+            Sign up to volunteer, or come to an event first to meet the team in
+            person.
           </p>
           <div className="flex flex-wrap items-center justify-center gap-3">
             <Button variant="primary" size="sm" asChild>
@@ -206,16 +201,7 @@ export default function VolunteerPage() {
               </a>
             </Button>
             <Button variant="outline" size="sm" asChild>
-              <a
-                href="https://github.com/tech-tankorg"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                GitHub
-              </a>
-            </Button>
-            <Button variant="outline" size="sm" asChild>
-              <Link href="/events">See events</Link>
+              <Link href="/events">Meet the team</Link>
             </Button>
           </div>
         </div>

--- a/app/legal/privacy-policy/page.tsx
+++ b/app/legal/privacy-policy/page.tsx
@@ -75,7 +75,7 @@ export default function PrivacyPolicyPage() {
           </p>
           <ul className="list-disc pl-6 space-y-2 text-muted">
             <li>
-              <strong>Meetup / Luma:</strong> Event RSVPs and attendee lists
+              <strong>Luma:</strong> Event RSVPs and attendee lists
             </li>
             <li>
               <strong>Google Forms:</strong> Intake submissions (speaker, host,

--- a/app/legal/terms-of-service/page.tsx
+++ b/app/legal/terms-of-service/page.tsx
@@ -58,9 +58,9 @@ export default function TermsOfServicePage() {
             3. External Platforms
           </h2>
           <p className="text-muted">
-            TechTank uses third-party platforms for event registration
-            (Meetup, Luma), community discussion (Slack), and content hosting
-            (YouTube, GitHub). Use of these platforms is subject to their
+            TechTank uses third-party platforms for event registration (Luma),
+            community discussion (Slack), and content hosting (YouTube,
+            GitHub). Use of these platforms is subject to their
             respective terms of service. TechTank is not responsible for the
             policies or practices of these third parties.
           </p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
-import { ArrowRight, Calendar, ExternalLink, Heart, Users } from "lucide-react";
+import { ArrowRight, Calendar, ExternalLink, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Section, SectionHeader } from "@/components/ui/section";
 import { HeroStatsMarquee } from "@/components/ui/hero-stats-marquee";
@@ -61,9 +61,6 @@ export default function HomePage() {
                 </Button>
                 <Button variant="outline" size="lg" asChild>
                   <Link href="/get-involved">Get involved</Link>
-                </Button>
-                <Button variant="outline" size="lg" asChild>
-                  <Link href="/about">About us</Link>
                 </Button>
               </div>
             </div>
@@ -205,15 +202,15 @@ export default function HomePage() {
         </div>
       </Section>
 
-      {/* Three-flow CTA */}
+      {/* Two-flow CTA */}
       <Section id="join-us" className="gradient-brand-vertical texture-grain py-8 lg:py-12">
         <SectionHeader
           overline="Take the next step"
           title="Where to next?"
-          description="Three ways to plug in right now."
+          description="Two ways to plug in right now."
           className="mb-8"
         />
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-2">
           <Link
             href="/events"
             className="group relative overflow-hidden rounded-xl glass p-5 lg:p-6 transition-all hover:scale-[1.01]"
@@ -253,28 +250,6 @@ export default function HomePage() {
               </p>
               <span className="inline-flex items-center text-sm font-semibold text-teal-dark group-hover:text-coral transition-colors">
                 Pick your path
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </span>
-            </div>
-          </Link>
-
-          <Link
-            href="/about"
-            className="group relative overflow-hidden rounded-xl glass p-5 lg:p-6 transition-all hover:scale-[1.01]"
-          >
-            <Heart className="absolute top-4 right-4 h-14 w-14 text-teal-dark/10" />
-            <div className="relative">
-              <span className="inline-block text-xs font-semibold uppercase tracking-widest text-coral mb-2">
-                Know who we are
-              </span>
-              <h3 className="font-display text-lg lg:text-xl font-bold text-teal-dark mb-2">
-                About us
-              </h3>
-              <p className="text-sm text-muted mb-4">
-                Our values, our story, and the people behind TechTank.
-              </p>
-              <span className="inline-flex items-center text-sm font-semibold text-teal-dark group-hover:text-coral transition-colors">
-                Meet the community
                 <ArrowRight className="ml-2 h-4 w-4" />
               </span>
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,12 @@
 import Link from "next/link";
 import Image from "next/image";
-import { ArrowRight, ExternalLink } from "lucide-react";
+import { ArrowRight, Calendar, ExternalLink, Heart, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Section, SectionHeader } from "@/components/ui/section";
 import { HeroStatsMarquee } from "@/components/ui/hero-stats-marquee";
 import { LogoCloud } from "@/components/ui/logo-cloud";
 import { RoleCard, roleCardsData } from "@/components/ui/role-card";
 import { EventCard } from "@/components/ui/event-card";
-import { DualCTA } from "@/components/ui/dual-cta";
 import { SocialFeed } from "@/components/ui/social-feed";
 import { getRecentEvents } from "@/constants/events";
 
@@ -58,17 +57,13 @@ export default function HomePage() {
               </p>
               <div className="flex flex-wrap gap-3">
                 <Button variant="primary" size="lg" asChild>
-                  <a
-                    href="https://luma.com/techtank"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    See what&apos;s next
-                    <ExternalLink className="ml-2 h-4 w-4" />
-                  </a>
+                  <Link href="/events">See events</Link>
                 </Button>
                 <Button variant="outline" size="lg" asChild>
-                  <Link href="/#join-us">Join us</Link>
+                  <Link href="/get-involved">Get involved</Link>
+                </Button>
+                <Button variant="ghost" size="lg" asChild>
+                  <Link href="/about">About us</Link>
                 </Button>
               </div>
             </div>
@@ -210,9 +205,81 @@ export default function HomePage() {
         </div>
       </Section>
 
-      {/* Dual CTA */}
+      {/* Three-flow CTA */}
       <Section id="join-us" className="gradient-brand-vertical texture-grain py-8 lg:py-12">
-        <DualCTA />
+        <SectionHeader
+          overline="Take the next step"
+          title="Where to next?"
+          description="Three ways to plug in right now."
+          className="mb-8"
+        />
+        <div className="grid gap-4 md:grid-cols-3">
+          <Link
+            href="/about"
+            className="group relative overflow-hidden rounded-xl glass p-5 lg:p-6 transition-all hover:scale-[1.01]"
+          >
+            <Heart className="absolute top-4 right-4 h-14 w-14 text-teal-dark/10" />
+            <div className="relative">
+              <span className="inline-block text-xs font-semibold uppercase tracking-widest text-coral mb-2">
+                Know who we are
+              </span>
+              <h3 className="font-display text-lg lg:text-xl font-bold text-teal-dark mb-2">
+                About us
+              </h3>
+              <p className="text-sm text-muted mb-4">
+                Our values, our story, and the people behind TechTank.
+              </p>
+              <span className="inline-flex items-center text-sm font-semibold text-teal-dark group-hover:text-coral transition-colors">
+                Meet the community
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </span>
+            </div>
+          </Link>
+
+          <Link
+            href="/events"
+            className="group relative overflow-hidden rounded-xl glass p-5 lg:p-6 transition-all hover:scale-[1.01]"
+          >
+            <Calendar className="absolute top-4 right-4 h-14 w-14 text-teal-dark/10" />
+            <div className="relative">
+              <span className="inline-block text-xs font-semibold uppercase tracking-widest text-coral mb-2">
+                Show up
+              </span>
+              <h3 className="font-display text-lg lg:text-xl font-bold text-teal-dark mb-2">
+                Upcoming events
+              </h3>
+              <p className="text-sm text-muted mb-4">
+                See what&apos;s coming up and RSVP to the next meetup.
+              </p>
+              <span className="inline-flex items-center text-sm font-semibold text-teal-dark group-hover:text-coral transition-colors">
+                See events
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </span>
+            </div>
+          </Link>
+
+          <Link
+            href="/get-involved"
+            className="group relative overflow-hidden rounded-xl glass p-5 lg:p-6 transition-all hover:scale-[1.01]"
+          >
+            <Users className="absolute top-4 right-4 h-14 w-14 text-coral/10" />
+            <div className="relative">
+              <span className="inline-block text-xs font-semibold uppercase tracking-widest text-coral mb-2">
+                Contribute
+              </span>
+              <h3 className="font-display text-lg lg:text-xl font-bold text-teal-dark mb-2">
+                Get involved
+              </h3>
+              <p className="text-sm text-muted mb-4">
+                Speak, host, sponsor, or volunteer with the crew.
+              </p>
+              <span className="inline-flex items-center text-sm font-semibold text-teal-dark group-hover:text-coral transition-colors">
+                Pick your path
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </span>
+            </div>
+          </Link>
+        </div>
       </Section>
     </>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -62,7 +62,7 @@ export default function HomePage() {
                 <Button variant="outline" size="lg" asChild>
                   <Link href="/get-involved">Get involved</Link>
                 </Button>
-                <Button variant="ghost" size="lg" asChild>
+                <Button variant="outline" size="lg" asChild>
                   <Link href="/about">About us</Link>
                 </Button>
               </div>
@@ -215,28 +215,6 @@ export default function HomePage() {
         />
         <div className="grid gap-4 md:grid-cols-3">
           <Link
-            href="/about"
-            className="group relative overflow-hidden rounded-xl glass p-5 lg:p-6 transition-all hover:scale-[1.01]"
-          >
-            <Heart className="absolute top-4 right-4 h-14 w-14 text-teal-dark/10" />
-            <div className="relative">
-              <span className="inline-block text-xs font-semibold uppercase tracking-widest text-coral mb-2">
-                Know who we are
-              </span>
-              <h3 className="font-display text-lg lg:text-xl font-bold text-teal-dark mb-2">
-                About us
-              </h3>
-              <p className="text-sm text-muted mb-4">
-                Our values, our story, and the people behind TechTank.
-              </p>
-              <span className="inline-flex items-center text-sm font-semibold text-teal-dark group-hover:text-coral transition-colors">
-                Meet the community
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </span>
-            </div>
-          </Link>
-
-          <Link
             href="/events"
             className="group relative overflow-hidden rounded-xl glass p-5 lg:p-6 transition-all hover:scale-[1.01]"
           >
@@ -275,6 +253,28 @@ export default function HomePage() {
               </p>
               <span className="inline-flex items-center text-sm font-semibold text-teal-dark group-hover:text-coral transition-colors">
                 Pick your path
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </span>
+            </div>
+          </Link>
+
+          <Link
+            href="/about"
+            className="group relative overflow-hidden rounded-xl glass p-5 lg:p-6 transition-all hover:scale-[1.01]"
+          >
+            <Heart className="absolute top-4 right-4 h-14 w-14 text-teal-dark/10" />
+            <div className="relative">
+              <span className="inline-block text-xs font-semibold uppercase tracking-widest text-coral mb-2">
+                Know who we are
+              </span>
+              <h3 className="font-display text-lg lg:text-xl font-bold text-teal-dark mb-2">
+                About us
+              </h3>
+              <p className="text-sm text-muted mb-4">
+                Our values, our story, and the people behind TechTank.
+              </p>
+              <span className="inline-flex items-center text-sm font-semibold text-teal-dark group-hover:text-coral transition-colors">
+                Meet the community
                 <ArrowRight className="ml-2 h-4 w-4" />
               </span>
             </div>

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -50,10 +50,10 @@ const footerLinks = {
   getInvolved: {
     title: "Get Involved",
     links: [
-      { name: "Speak", href: "/how-it-works/speaker", external: false },
-      { name: "Host", href: "/how-it-works/host", external: false },
-      { name: "Sponsor", href: "/how-it-works/sponsor", external: false },
-      { name: "Volunteer", href: "/how-it-works/volunteer", external: false },
+      { name: "Speak", href: "/get-involved/speaker", external: false },
+      { name: "Host", href: "/get-involved/host", external: false },
+      { name: "Sponsor", href: "/get-involved/sponsor", external: false },
+      { name: "Volunteer", href: "/get-involved/volunteer", external: false },
     ],
   },
   resources: {

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 
 const navigation = [
   { name: "About", href: "/about" },
-  { name: "How It Works", href: "/how-it-works" },
+  { name: "Get Involved", href: "/get-involved" },
   { name: "Events", href: "/events" },
   { name: "Code of Conduct", href: "/legal/code-of-conduct" },
 ];

--- a/components/ui/dual-cta.tsx
+++ b/components/ui/dual-cta.tsx
@@ -77,7 +77,7 @@ export function DualCTA() {
           </p>
           <div className="flex flex-wrap gap-2">
             <Button variant="primary" size="sm" asChild>
-              <Link href="/how-it-works">Get involved</Link>
+              <Link href="/get-involved">Get involved</Link>
             </Button>
             {contributeLinks.map((link) => (
               <Button

--- a/components/ui/role-card.tsx
+++ b/components/ui/role-card.tsx
@@ -80,7 +80,7 @@ export const roleCardsData: RoleCardProps[] = [
       "Any tech topic welcome",
       "Recorded and published to YouTube",
     ],
-    href: "/how-it-works/speaker",
+    href: "/get-involved/speaker",
     ctaText: "Apply to speak",
   },
   {
@@ -94,7 +94,7 @@ export const roleCardsData: RoleCardProps[] = [
       "6:00-8:30pm weeknight",
       "Logo on event marketing",
     ],
-    href: "/how-it-works/host",
+    href: "/get-involved/host",
     ctaText: "Host an event",
   },
   {
@@ -108,7 +108,7 @@ export const roleCardsData: RoleCardProps[] = [
       "Speaker slot options",
       "Reach Toronto tech talent",
     ],
-    href: "/how-it-works/sponsor",
+    href: "/get-involved/sponsor",
     ctaText: "Sponsor TechTank",
   },
   {
@@ -122,7 +122,7 @@ export const roleCardsData: RoleCardProps[] = [
       "No speaking required",
       "Portfolio-quality work",
     ],
-    href: "/how-it-works/volunteer",
+    href: "/get-involved/volunteer",
     ctaText: "Join the crew",
   },
 ];

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "license": "ISC",
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
-    "@icons-pack/react-simple-icons": "^13.13.0",
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^25.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@icons-pack/react-simple-icons':
-        specifier: ^13.13.0
-        version: 13.13.0(react@19.2.5)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
@@ -59,12 +56,6 @@ packages:
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
-  '@icons-pack/react-simple-icons@13.13.0':
-    resolution: {integrity: sha512-B5HhQMIpcSH4z8IZ8HFhD59CboHceKYMpPC9kAwGyKntvPdyJJv26DLu4Z1wAjcCLyrJhf11tMhiQGom9Rxb9g==}
-    engines: {node: '>=24', pnpm: '>=10'}
-    peerDependencies:
-      react: ^16.13 || ^17 || ^18 || ^19
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -660,10 +651,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
-
-  '@icons-pack/react-simple-icons@13.13.0(react@19.2.5)':
-    dependencies:
-      react: 19.2.5
 
   '@img/colour@1.1.0':
     optional: true

--- a/prd/PRD.md
+++ b/prd/PRD.md
@@ -18,7 +18,7 @@ visitors into active contributors — attendees, speakers, hosts, sponsors,
 and volunteers.
 
 The site remains content-driven marketing: it does not own accounts or
-ticketing. It funnels visitors to external platforms (Meetup, Luma, Slack,
+ticketing. It funnels visitors to external platforms (Luma, Slack,
 LinkedIn, GitHub, YouTube, Instagram) and captures intake via email to
 `techtankto@gmail.com`.
 
@@ -45,7 +45,7 @@ levels can explore, create, and thrive in technology.
 ### 1.4 Event types
 
 - **Tech talks** — Lightning talks, deep dives, and technical presentations
-- **Socials / Meetups** — Casual networking and community building
+- **Socials** — Casual networking and community building
 - **Sports** — Active events like volleyball and softball
 - **Code Diversity** — Inclusive events for underrepresented groups in tech
 - **Panels** — Multi-speaker discussions on industry topics
@@ -59,7 +59,7 @@ have associated costs. Do not advertise all events as "free".
 1. Build social trust via **social proof** — testimonials, event
    photography, sponsor/host logo cloud.
 2. Convert visitors into specific roles through a dedicated onboarding
-   funnel (`/how-it-works/*`).
+   funnel (`/get-involved/*`).
 3. Keep event discovery effortless (embedded Luma calendar).
 4. Provide a professional, one-stop resource for press and sponsors.
 5. Centralize legal / compliance docs cleanly.
@@ -85,7 +85,7 @@ under Ontario/Canadian jurisdiction.
 ### 1.6 Success metrics
 
 - Intake emails per role (speaker / host / sponsor / volunteer)
-- RSVP click-throughs to Meetup / Luma
+- RSVP click-throughs to Luma
 - Press Kit downloads
 - Scroll depth and CTA click-through rate on `/` and `/about`
 - Returning visitors and newsletter / Slack joins
@@ -97,7 +97,7 @@ under Ontario/Canadian jurisdiction.
 ```
 /
 ├── about
-├── how-it-works                 (onboarding hub — shared layout)
+├── get-involved                 (onboarding hub — shared layout)
 │   ├── speaker
 │   ├── host
 │   ├── sponsor
@@ -116,11 +116,11 @@ under Ontario/Canadian jurisdiction.
 |---|---|---|
 | `/` | Home | Social-proof-driven overview and primary CTAs |
 | `/about` | About | Values & community manifesto (the four pillars) |
-| `/how-it-works` | Get Involved | Onboarding hub; routes visitors to a role |
-| `/how-it-works/speaker` | Speak | Speaker logistics + intake action (email us) |
-| `/how-it-works/host` | Host | Venue logistics (40–100 cap, 6–8:30pm) + intake action (email us) |
-| `/how-it-works/sponsor` | Sponsor | Corporate partner pitch + intake action (email us) |
-| `/how-it-works/volunteer` | Volunteer | Crew onboarding + intake action (email us) |
+| `/get-involved` | Get Involved | Onboarding hub; routes visitors to a role |
+| `/get-involved/speaker` | Speak | Speaker logistics + intake action (email us) |
+| `/get-involved/host` | Host | Venue logistics (40–100 cap, 6–8:30pm) + intake action (email us) |
+| `/get-involved/sponsor` | Sponsor | Corporate partner pitch + intake action (email us) |
+| `/get-involved/volunteer` | Volunteer | Crew onboarding + intake action (email us) |
 | `/events` | Events | Upcoming events via Luma calendar |
 | `/press-kit` | Press Kit | Brand guidelines, logos, fast facts |
 | `/legal/terms-of-service` | Terms of Service | — |
@@ -130,7 +130,7 @@ under Ontario/Canadian jurisdiction.
 ### 2.2 Shared layouts (Next.js)
 
 - **Root layout** — global header, footer, theme, SEO defaults.
-- **`/how-it-works` layout** — sticky sub-nav (Speaker / Host / Sponsor /
+- **`/get-involved` layout** — sticky sub-nav (Speaker / Host / Sponsor /
   Volunteer), persistent "Join our Slack" CTA, shared "Why get involved"
   strip, consistent intake CTA styling (email us).
 - **`/legal` layout** — document-style narrow column, table of contents
@@ -138,10 +138,10 @@ under Ontario/Canadian jurisdiction.
 
 ### 2.3 Global navigation
 
-- **Primary nav:** About, How it Works, Events, Code of Conduct
+- **Primary nav:** About, Get Involved, Events, Code of Conduct
 - **Header CTA:** "Join our Slack" (secondary: "RSVP on Luma")
 - **Footer:**
-  - Column 1 — Community: Meetup, Luma, Slack, LinkedIn, Instagram, GitHub, YouTube
+  - Column 1 — Community: Luma, Slack, LinkedIn, Instagram, GitHub, YouTube
   - Column 2 — Get Involved: Speak, Host, Sponsor, Volunteer
   - Column 3 — Resources: Press Kit, Events
   - Column 4 — Legal: Terms of Service, Privacy Policy, Code of Conduct
@@ -149,7 +149,6 @@ under Ontario/Canadian jurisdiction.
 
 ### 2.4 External destinations
 
-- Meetup: https://www.meetup.com/techtank-to/
 - Luma: https://luma.com/techtank
 - Slack: direct invite link
 - LinkedIn: https://ca.linkedin.com/company/techtank-to
@@ -157,7 +156,7 @@ under Ontario/Canadian jurisdiction.
 - YouTube: https://www.youtube.com/@TechTankTo
 - GitHub: https://github.com/tech-tankorg
 - Google Photos albums (per-event)
-- Email intake: `techtankto@gmail.com` (one inbox for all `/how-it-works/*` roles)
+- Email intake: `techtankto@gmail.com` (one inbox for all `/get-involved/*` roles)
 
 ---
 
@@ -165,13 +164,13 @@ under Ontario/Canadian jurisdiction.
 
 1. **Curious newcomer** → `/` (sees event photos, testimonials, logo
    cloud) → `/about` (values) → `/events` (RSVPs on Luma) → joins Slack.
-2. **Aspiring speaker** → `/` → `/how-it-works/speaker` → emails
+2. **Aspiring speaker** → `/` → `/get-involved/speaker` → emails
    `techtankto@gmail.com` with their talk proposal.
-3. **Company host** → `/` or `/how-it-works` → `/how-it-works/host` →
+3. **Company host** → `/` or `/get-involved` → `/get-involved/host` →
    submits intake → receives sponsorship package via email.
-4. **Corporate sponsor** → `/press-kit` or `/how-it-works/sponsor` →
+4. **Corporate sponsor** → `/press-kit` or `/get-involved/sponsor` →
    downloads brand assets → submits sponsor intake.
-5. **Volunteer** → Slack invite or `/` → `/how-it-works/volunteer` →
+5. **Volunteer** → Slack invite or `/` → `/get-involved/volunteer` →
    submits intake.
 6. **Journalist / partner** → `/press-kit` → downloads logos + fast-facts
    → emails `techtankto@gmail.com`.
@@ -187,11 +186,11 @@ relative to this file, `prd/PRD.md`):
 - [pages/home.md](pages/home.md)
 - [pages/about.md](pages/about.md)
 - [pages/events.md](pages/events.md)
-- [pages/how-it-works/index.md](pages/how-it-works/index.md)
-- [pages/how-it-works/speaker.md](pages/how-it-works/speaker.md)
-- [pages/how-it-works/host.md](pages/how-it-works/host.md)
-- [pages/how-it-works/sponsor.md](pages/how-it-works/sponsor.md)
-- [pages/how-it-works/volunteer.md](pages/how-it-works/volunteer.md)
+- [pages/get-involved/index.md](pages/get-involved/index.md)
+- [pages/get-involved/speaker.md](pages/get-involved/speaker.md)
+- [pages/get-involved/host.md](pages/get-involved/host.md)
+- [pages/get-involved/sponsor.md](pages/get-involved/sponsor.md)
+- [pages/get-involved/volunteer.md](pages/get-involved/volunteer.md)
 - [pages/press-kit.md](pages/press-kit.md)
 - [pages/legal/terms-of-service.md](pages/legal/terms-of-service.md)
 - [pages/legal/privacy-policy.md](pages/legal/privacy-policy.md)
@@ -219,7 +218,7 @@ Every page must have exactly **one dominant CTA** that moves the visitor
 toward interacting (Join Slack / RSVP / Email us). Secondary
 CTAs are fine; tertiary links belong in the footer.
 
-### 5.3 Social proof patterns (required on `/` and relevant `/how-it-works/*`)
+### 5.3 Social proof patterns (required on `/` and relevant `/get-involved/*`)
 
 - **Social feed over testimonials:** Embedded LinkedIn and Instagram posts
   from organizers showing real, organic community moments. No curated
@@ -230,7 +229,7 @@ CTAs are fine; tertiary links belong in the footer.
   events + 20+ CodeDiversity events), monthly cadence since 2023
 - Sponsor / host logo cloud
 - Linked previews of recent Google Photos albums and Instagram posts
-- YouTube links to recent Guppy Talks / talks
+- YouTube links to recent talks
 
 ### 5.4 Accessibility
 
@@ -240,7 +239,7 @@ CTAs are fine; tertiary links belong in the footer.
 ### 5.5 Responsiveness
 
 - Mobile-first. Break at 640 / 1024 / 1280. The sticky sub-nav on
-  `/how-it-works` must collapse into a single-line segmented control on
+  `/get-involved` must collapse into a single-line segmented control on
   mobile.
 
 ### 5.6 Event archive & recap pattern
@@ -273,8 +272,8 @@ and is explicitly out of scope for the initial launch.
   all-caps kicker (e.g. `WAYS TO GET INVOLVED`, `NEXT UP`, `RECENT
   EVENTS`, `LATEST HIGHLIGHTS`, `GET IN TOUCH`) above the headline.
   Establishes a clear scanning rhythm.
-- **Role cards with checkmarks.** The four `/how-it-works` role
-  teasers share one shape on `/` and `/how-it-works`: icon → overline
+- **Role cards with checkmarks.** The four `/get-involved` role
+  teasers share one shape on `/` and `/get-involved`: icon → overline
   → headline → one-paragraph pitch → three bulleted checkmarks of
   what the contributor gets. Reused verbatim so the four paths feel
   like siblings.
@@ -284,11 +283,11 @@ and is explicitly out of scope for the initial launch.
   complementary to, the logo cloud higher up the page.
 - **Dual end-of-page CTA cards.** Long pages close with a two-up
   card block: one "stay in the loop" card (Luma / Slack) and one
-  "collaborate with us" card (email / `/how-it-works`). Used on `/`
+  "collaborate with us" card (email / `/get-involved`). Used on `/`
   and `/events`.
 - **Direct-email contact card.** `techtankto@gmail.com` appears as a
   prominent, copy-friendly contact card (not just a hyperlink) at the
-  end of `/how-it-works`, `/how-it-works/*`, and `/press-kit`. One
+  end of `/get-involved`, `/get-involved/*`, and `/press-kit`. One
   line of context explains what we respond to.
 
 ---
@@ -297,7 +296,7 @@ and is explicitly out of scope for the initial launch.
 
 ### 6.1 Must-have
 
-- Next.js App Router with shared layouts for `/how-it-works` and `/legal`.
+- Next.js App Router with shared layouts for `/get-involved` and `/legal`.
 - Global header + footer on every route.
 - `/events` renders an embedded Luma calendar (or API-backed list),
   **and** a hand-curated "Next Up" + "Past Events" timeline driven by
@@ -306,7 +305,7 @@ and is explicitly out of scope for the initial launch.
   carries: date, venue, title, tags, host/sponsor attribution, status
   (`upcoming` | `past`), RSVP URL, Google Photos album URL, YouTube
   recording URL. Powers both `/events` and the home-page preview.
-- Prominent intake action on each `/how-it-works/*` page — a
+- Prominent intake action on each `/get-involved/*` page — a
   `mailto:techtankto@gmail.com` CTA with a role-specific subject line
   and a suggested-details scaffold (copy-to-clipboard friendly).
 - Press Kit exposes a downloadable ZIP of logos + a brand-guidelines PDF.
@@ -320,7 +319,7 @@ and is explicitly out of scope for the initial launch.
 - Newsletter / Slack invite capture block in footer.
 - Google Photos album preview cards (Home and event detail).
 - Branded slide deck template (Google Slides / PPTX) linked from
-  `/how-it-works/speaker` and `/press-kit`.
+  `/get-involved/speaker` and `/press-kit`.
 - Speaker run-of-show and host checklist (linked PDFs).
 - Per-event recap surface: Google Photos album + YouTube recording +
   host/sponsor acknowledgment, reached via "View Recap" from the
@@ -386,7 +385,7 @@ and is explicitly out of scope for the initial launch.
 ## 9. Event Support (Organizer Tooling)
 
 Not user-facing pages, but assets produced and surfaced via `/press-kit`
-and `/how-it-works/speaker`:
+and `/get-involved/speaker`:
 
 - Branded Google Slides / Keynote / PPTX templates (speaker + title card)
 - Host checklist PDF (AV, food, timing)
@@ -399,19 +398,19 @@ and `/how-it-works/speaker`:
 ## 10. Out of Scope
 
 - Member accounts / login
-- Paid ticketing (RSVPs remain on Meetup / Luma)
+- Paid ticketing (RSVPs remain on Luma)
 - Merchandise store
 - Native mobile app
 - On-site donation processing (individual donations de-prioritized;
-  corporate support happens via `/how-it-works/sponsor`)
+  corporate support happens via `/get-involved/sponsor`)
 
 ---
 
 ## 11. Open Questions
 
-- Do we keep a first-party blog, or continue relying on YouTube / Guppy
-  Talks for long-form content?
-- Should `/how-it-works/volunteer` gate behind Slack membership, or stay
+- Do we keep a first-party blog, or continue relying on YouTube for
+  long-form content?
+- Should `/get-involved/volunteer` gate behind Slack membership, or stay
   open?
 - Is individual donation still a funded path, or fully replaced by
   corporate sponsorship?

--- a/prd/pages/about.md
+++ b/prd/pages/about.md
@@ -48,12 +48,12 @@ page a potential speaker, host, sponsor, or member can point to and say
    - Monthly in-person events (technical talk + networking).
    - Recorded talks on YouTube.
    - Slack community for ongoing discussion.
-   - Optional programs (Guppy Talks, Study Tank, Code Diversity) — keep
-     a short list with links; avoid sprawling content here.
+   - Optional programs (Code Diversity) — keep a short list with links;
+     avoid sprawling content here.
 
 5. **How we fund it**
    - Companies provide venue + food; TechTank does the rest. Link to
-     `/how-it-works/sponsor` and `/how-it-works/host`.
+     `/get-involved/sponsor` and `/get-involved/host`.
 
 6. **Code of Conduct teaser**
    - Short callout linking to `/legal/code-of-conduct`.

--- a/prd/pages/about.md
+++ b/prd/pages/about.md
@@ -42,7 +42,7 @@ page a potential speaker, host, sponsor, or member can point to and say
 
 3. **Origin story**
    - One or two paragraphs: founded in 2022 in Toronto; grown to monthly
-     events with 100–120 attendees; entirely volunteer-run.
+     events with 40–100 attendees; entirely volunteer-run.
 
 4. **What we do**
    - Monthly in-person events (technical talk + networking).

--- a/prd/pages/events.md
+++ b/prd/pages/events.md
@@ -50,7 +50,7 @@ giving them a full past-events timeline with recaps.
      - Secondary CTA: "View details" → Luma event URL (anchor)
      - Right-rail "Supported by" block with host/sponsor logo; if
        none confirmed, shows "Looking for a host" with a link to
-       `/how-it-works/host`.
+       `/get-involved/host`.
    - If no event is scheduled yet, the card degrades to a "Next event
      announcing soon — join Slack to be first to hear" state.
 
@@ -75,7 +75,7 @@ giving them a full past-events timeline with recaps.
      - CTA: **"View Recap"** — opens an anchored recap block that
        surfaces:
        - Linked Google Photos album
-       - Linked YouTube recording (Guppy Talks / talk)
+       - Linked YouTube recording (talk)
        - Speaker list (name + talk title)
        - One-line host/sponsor thank-you
    - A dedicated `/events/<slug>` detail route is explicitly out of
@@ -88,7 +88,7 @@ giving them a full past-events timeline with recaps.
        notified when the next event goes live." — CTA: "Follow on
        Luma".
      - **Want to contribute?** "Speak, host, sponsor, or volunteer
-       for the next one." — CTA: "Get involved" → `/how-it-works`.
+       for the next one." — CTA: "Get involved" → `/get-involved`.
 
 6. **Contact strip**
    - Overline kicker: `GET IN TOUCH`.
@@ -99,8 +99,8 @@ giving them a full past-events timeline with recaps.
 
 1. RSVP to the next event (Luma)
 2. View a past recap (builds trust → pushes them into Slack / CTAs)
-3. Subscribe on Luma / Meetup
-4. Get involved → `/how-it-works`
+3. Subscribe on Luma
+4. Get involved → `/get-involved`
 
 ## 6. Functional requirements
 
@@ -130,6 +130,6 @@ giving them a full past-events timeline with recaps.
 - The Next Up card always carries an explicit host/sponsor
   attribution or a "Looking for a host" link — never blank space.
 - If Luma's embed is down, the page still communicates the next
-  event and offers an RSVP path (Meetup fallback).
+  event and offers an RSVP path via the structured event fallback.
 - Every number on the page (event count, capacity, etc.) comes from
   structured content, not hardcoded copy.

--- a/prd/pages/get-involved/host.md
+++ b/prd/pages/get-involved/host.md
@@ -1,6 +1,6 @@
-# Host — `/how-it-works/host`
+# Host — `/get-involved/host`
 
-**URL:** https://www.techtankto.com/how-it-works/host
+**URL:** https://www.techtankto.com/get-involved/host
 **Page title:** Host a TechTank Event — TechTank TO
 **Role:** Recruit Toronto companies to provide venue and food for a
 TechTank monthly meetup.
@@ -51,7 +51,7 @@ host" action is the single most important CTA.
 
 4. **What TechTank handles**
    - Speaker sourcing (unless you want to bring your own).
-   - Marketing (Meetup, Slack, LinkedIn, Instagram).
+   - Marketing (Slack, LinkedIn, Instagram).
    - Registration and attendee tracking.
    - Event coordination and MCing.
    - Recording + publishing to YouTube.

--- a/prd/pages/get-involved/index.md
+++ b/prd/pages/get-involved/index.md
@@ -1,7 +1,7 @@
-# How It Works — `/how-it-works`
+# Get Involved — `/get-involved`
 
-**URL:** https://www.techtankto.com/how-it-works
-**Page title:** How It Works — TechTank TO
+**URL:** https://www.techtankto.com/get-involved
+**Page title:** Get Involved — TechTank TO
 **Role:** Onboarding hub. Primary entry point for anyone who wants to
 contribute to TechTank, routing them to the role that fits.
 
@@ -36,7 +36,7 @@ intake.
   sub-page (karma, community, marketing, skills).
 - Consistent intake CTA card style (email us) reused across all four sub-pages.
 
-## 5. Content sections (on `/how-it-works` itself)
+## 5. Content sections (on `/get-involved` itself)
 
 1. **Hero**
    - Overline kicker: `GET INVOLVED`.
@@ -56,19 +56,19 @@ intake.
      - Three checkmark bullets of what you get / what's required
      - Primary CTA linking into the sub-page
    - Card content:
-     - **Speak** → `/how-it-works/speaker`
+     - **Speak** → `/get-involved/speaker`
        - Overline: `SHARE WHAT YOU KNOW`
        - Checkmarks: 30–45 min talk + Q&A · Any tech topic · Recorded
          and published to YouTube
-     - **Host** → `/how-it-works/host`
+     - **Host** → `/get-involved/host`
        - Overline: `BRING US TO YOUR SPACE`
        - Checkmarks: 40–100 attendees · 6:00–8:30pm weeknight · Logo
          on event marketing
-     - **Sponsor** → `/how-it-works/sponsor`
+     - **Sponsor** → `/get-involved/sponsor`
        - Overline: `SUPPORT THE COMMUNITY`
        - Checkmarks: Logo on website and marketing · Speaker slot
          options · Tasteful brand visibility
-     - **Volunteer** → `/how-it-works/volunteer`
+     - **Volunteer** → `/get-involved/volunteer`
        - Overline: `HELP RUN THE CREW`
        - Checkmarks: Event-day or ongoing · No speaking required ·
          Portfolio-quality work for creatives
@@ -102,7 +102,7 @@ intake.
 
 ## 7. Functional requirements
 
-- Shared layout renders in all `/how-it-works/*` routes.
+- Shared layout renders in all `/get-involved/*` routes.
 - Sub-nav highlights the active sub-page.
 - Each role card has a stable anchor for deep-linking.
 - The role-card component is shared with the home page (see
@@ -114,7 +114,7 @@ intake.
 ## 8. Acceptance criteria
 
 - Every role in the community has a clearly-labeled path within one
-  click of `/how-it-works`.
+  click of `/get-involved`.
 - A visitor understands the difference between Host and Sponsor without
   having to read both sub-pages.
 - All four role cards are reachable without horizontal scroll on

--- a/prd/pages/get-involved/speaker.md
+++ b/prd/pages/get-involved/speaker.md
@@ -1,6 +1,6 @@
-# Speaker — `/how-it-works/speaker`
+# Speaker — `/get-involved/speaker`
 
-**URL:** https://www.techtankto.com/how-it-works/speaker
+**URL:** https://www.techtankto.com/get-involved/speaker
 **Page title:** Speak at TechTank — TechTank TO
 **Role:** Convince qualified technologists to speak at a TechTank event
 and capture their intake.
@@ -46,7 +46,7 @@ audience, format, logistics, what they get, and how to sign up.
 
 4. **What TechTank handles**
    - Venue and catering (via a host company).
-   - Marketing (Meetup, Slack, LinkedIn, Instagram).
+   - Marketing (Slack, LinkedIn, Instagram).
    - Run-of-show coordination and MCing.
    - Recording and post-production.
    - Optional: feedback / rehearsal sessions for first-time speakers.

--- a/prd/pages/get-involved/sponsor.md
+++ b/prd/pages/get-involved/sponsor.md
@@ -1,6 +1,6 @@
-# Sponsor — `/how-it-works/sponsor`
+# Sponsor — `/get-involved/sponsor`
 
-**URL:** https://www.techtankto.com/how-it-works/sponsor
+**URL:** https://www.techtankto.com/get-involved/sponsor
 **Page title:** Sponsor TechTank — TechTank TO
 **Role:** Recruit corporate sponsors to support TechTank financially or
 in-kind, separately from hosting an individual event.
@@ -25,7 +25,7 @@ partnership, swag, travel budget for speakers, etc.).
 - TechTank is volunteer-run and non-commercial.
 - Sponsorship keeps the community sustainable beyond single events.
 - Sponsor brand visibility is tasteful, not spammy.
-- We'll send a sponsorship package on request with tier details.
+- We'll send sponsorship info on request with tier details.
 
 ## 4. Content sections
 
@@ -33,7 +33,7 @@ partnership, swag, travel budget for speakers, etc.).
    - Headline: "Sponsor the Toronto tech community."
    - Sub-headline: "Support the monthly events, speakers, and programs
      that bring the community together."
-   - Primary CTA: "Request sponsorship package" → email us (`techtankto@gmail.com`).
+   - Primary CTA: "Request sponsorship info" → email us (`techtankto@gmail.com`).
 
 2. **Why sponsor**
    - **Brand** — align with Toronto's most inclusive tech community.
@@ -42,19 +42,17 @@ partnership, swag, travel budget for speakers, etc.).
 
 3. **What sponsorship supports**
    - Monthly event operations (when no host is available).
-   - Speaker travel and honoraria where applicable.
-   - Programs like Guppy Talks, Study Tank, Code Diversity.
+   - Programs like Code Diversity for underrepresented voices.
    - Equipment (AV, recording) and production costs.
 
 4. **Sponsor tiers (illustrative; finalize with organizers)**
    - **Friend of the Community** — logo on site + mentions.
-   - **Event Sponsor** — logo + callouts across a quarter of events.
-   - **Annual Partner** — year-long placement, speaker slot, attendee
-     list.
-   - Exact numbers intentionally soft until we send the deck.
+   - **Event Sponsor** — logo + callouts tied to sponsored events.
+   - **Annual Partner** — year-long placement and a speaker slot.
+   - Exact numbers intentionally soft until we send the info.
 
 5. **What sponsors get (base package)**
-   - Placement on the `/` logo cloud and in Press Kit.
+   - Placement on the `/` logo cloud.
    - Mentions in event marketing.
    - Social shout-outs (LinkedIn, Instagram).
    - Option to speak at an event.
@@ -62,7 +60,7 @@ partnership, swag, travel budget for speakers, etc.).
 6. **Past sponsors (social proof)**
    - Logo cloud + 1–2 partner quotes.
 
-7. **Sponsorship package download**
+7. **Sponsorship info delivery**
    - Sent by email on request; not hosted as a public download.
 
 8. **Intake action (email us)**
@@ -76,16 +74,16 @@ partnership, swag, travel budget for speakers, etc.).
 
 ## 5. Calls to action (priority order)
 
-1. Email `techtankto@gmail.com` to request the sponsorship package
+1. Email `techtankto@gmail.com` to request sponsorship info
 2. Visit `/press-kit` for brand context
-3. Read about hosting (`/how-it-works/host`) if a single-event fit is better
+3. Read about hosting (`/get-involved/host`) if a single-event fit is better
 
 ## 6. Functional requirements
 
 - Prominent intake CTA (`mailto:techtankto@gmail.com`) with a clear
   button and suggested-details scaffold.
 - Page clearly distinguishes sponsoring vs. hosting and links to
-  `/how-it-works/host`.
+  `/get-involved/host`.
 - Sponsor logos render server-side and include a link where possible.
 
 ## 7. Acceptance criteria

--- a/prd/pages/get-involved/volunteer.md
+++ b/prd/pages/get-involved/volunteer.md
@@ -1,6 +1,6 @@
-# Volunteer — `/how-it-works/volunteer`
+# Volunteer — `/get-involved/volunteer`
 
-**URL:** https://www.techtankto.com/how-it-works/volunteer
+**URL:** https://www.techtankto.com/get-involved/volunteer
 **Page title:** Volunteer with TechTank — TechTank TO
 **Role:** Onboard the crew that keeps TechTank running — organizers,
 event-day volunteers, content volunteers, community moderators.

--- a/prd/pages/home.md
+++ b/prd/pages/home.md
@@ -73,10 +73,10 @@ professional and credible.
    - Sub-headline: "Every TechTank event runs on the time of
      community members like you."
    - Four role cards sharing one shape (see PRD §5.7):
-     - **Speak** — `Share what you know` → `/how-it-works/speaker`
-     - **Host** — `Bring us to your space` → `/how-it-works/host`
-     - **Sponsor** — `Support the community` → `/how-it-works/sponsor`
-     - **Volunteer** — `Help run the crew` → `/how-it-works/volunteer`
+     - **Speak** — `Share what you know` → `/get-involved/speaker`
+     - **Host** — `Bring us to your space` → `/get-involved/host`
+     - **Sponsor** — `Support the community` → `/get-involved/sponsor`
+     - **Volunteer** — `Help run the crew` → `/get-involved/volunteer`
    - Each card: icon → overline → headline → one-paragraph pitch →
      three checkmark bullets of what the contributor gets.
 
@@ -110,7 +110,7 @@ professional and credible.
      - **Never miss an event.** Subscribe to the Luma calendar — CTA
        "Follow on Luma".
      - **Want to contribute?** Speak, host, sponsor, or volunteer —
-       CTA "Get involved" → `/how-it-works`.
+       CTA "Get involved" → `/get-involved`.
 
 10. **Supported-by strip**
     - Single-line "Supported by <host/sponsor logos>" acknowledgment
@@ -123,7 +123,7 @@ professional and credible.
 
 1. RSVP to the next event (Luma)
 2. Join our Slack
-3. Pick a role → `/how-it-works`
+3. Pick a role → `/get-involved`
 4. View Press Kit (for press/partners)
 
 ## 6. Functional requirements
@@ -138,7 +138,7 @@ professional and credible.
 - Mobile-first layout; hero collage remains legible at 375px.
 - Open Graph / Twitter card metadata with TechTank branding.
 - Role cards and event cards share their component with
-  `/how-it-works` and `/events` respectively — no bespoke variants.
+  `/get-involved` and `/events` respectively — no bespoke variants.
 
 ## 7. Acceptance criteria
 

--- a/prd/pages/legal/code-of-conduct.md
+++ b/prd/pages/legal/code-of-conduct.md
@@ -17,14 +17,14 @@ issues. This document operationalizes the **Respect** pillar from
 ## 2. Primary audience
 
 - All attendees at TechTank events
-- All members of TechTank-operated channels (Slack, Meetup, etc.)
+- All members of TechTank-operated channels (Slack, etc.)
 - Speakers, hosts, sponsors, and volunteers
 
 ## 3. Structure
 
 Rendered in the `/legal` shared layout with a narrow column, table of
 contents sidebar, and a last-updated stamp. Linked prominently from
-`/about`, `/events`, and every `/how-it-works/*` page.
+`/about`, `/events`, and every `/get-involved/*` page.
 
 ## 4. Content sections
 
@@ -79,7 +79,7 @@ contents sidebar, and a last-updated stamp. Linked prominently from
 
 - Shared `/legal` layout with table of contents.
 - Linked from primary nav / footer and from `/about`, `/events`,
-  `/how-it-works/*`.
+  `/get-involved/*`.
 - Last-updated timestamp rendered from source metadata.
 - License notice rendered at the bottom if the document derives from a
   licensed template.

--- a/prd/pages/legal/privacy-policy.md
+++ b/prd/pages/legal/privacy-policy.md
@@ -11,7 +11,7 @@ it's used, and who it's shared with.
 
 Be transparent about TechTank's minimal-PII stance. The community
 collects almost nothing directly; most data lives with external
-platforms (Luma, Meetup, Slack) or arrives via email to
+platforms (Luma, Slack) or arrives via email to
 `techtankto@gmail.com`.
 
 ## 2. Primary audience
@@ -45,7 +45,7 @@ a narrow column, table of contents sidebar, and a last-updated stamp.
 
 4. **Third-party platforms**
    - Explicit list of platforms and what they process:
-     - **Meetup / Luma** — RSVPs, attendee lists.
+     - **Luma** — RSVPs, attendee lists.
      - **Slack** — community messages.
      - **YouTube, Instagram, LinkedIn, GitHub** — embedded content.
    - Each platform has its own privacy policy; links included.

--- a/prd/pages/legal/terms-of-service.md
+++ b/prd/pages/legal/terms-of-service.md
@@ -41,7 +41,7 @@ narrow column, table of contents sidebar, and a last-updated stamp.
      without attribution, impersonation, etc.).
 
 4. **External platforms**
-   - Meetup, Luma, Slack, GitHub, YouTube, Instagram are third parties
+   - Luma, Slack, GitHub, YouTube, Instagram are third parties
      with their own terms; attending / joining binds you to theirs as
      well.
 

--- a/prd/pages/press-kit.md
+++ b/prd/pages/press-kit.md
@@ -80,7 +80,7 @@ press kit signals that the community is serious.
 
 1. Download all assets (ZIP)
 2. Email `techtankto@gmail.com` for press / partnership inquiries
-3. Visit `/how-it-works/sponsor` for corporate support
+3. Visit `/get-involved/sponsor` for corporate support
 
 ## 6. Functional requirements
 

--- a/prd/pages/press-kit.md
+++ b/prd/pages/press-kit.md
@@ -41,7 +41,7 @@ press kit signals that the community is serious.
    - Founded: 2022
    - Location: Toronto, Canada
    - Cadence: monthly in-person events + ongoing Slack community
-   - Typical attendance: 100–120 / event
+   - Typical attendance: 40–100 / event
    - Volunteer-run, non-commercial
    - Contact: `techtankto@gmail.com`
    - Finalize all numbers with organizers before publishing.


### PR DESCRIPTION
## Summary
This PR renames the onboarding hub route from `/how-it-works` to `/get-involved` throughout the codebase and redesigns the home page's call-to-action section from a dual-CTA component to a three-card flow layout.

## Key Changes

### Route Restructuring
- Renamed `/how-it-works` directory to `/get-involved` with all sub-routes (speaker, host, sponsor, volunteer)
- Updated all internal links, navigation references, and documentation to point to `/get-involved`
- Updated layout component from `HowItWorksLayout` to `GetInvolvedLayout`

### Home Page CTA Redesign
- Replaced `DualCTA` component with inline three-card grid layout in the "Where to next?" section
- Added three new icon imports (`Calendar`, `Heart`, `Users`) for the card visual hierarchy
- Each card links to a key destination: `/about`, `/events`, `/get-involved`
- Cards feature glass-morphism styling with hover scale effects and icon accents

### Navigation & Header Updates
- Updated primary navigation to display "Get Involved" instead of "How It Works"
- Updated footer links to use `/get-involved/*` paths
- Updated role card data to point to new `/get-involved/*` routes

### Content Simplifications
- Removed references to "Meetup" platform across all pages (keeping only Luma for event registration)
- Simplified community programs references (removed "Guppy Talks" and "Study Tank", kept "Code Diversity")
- Streamlined speaker resources section to link to Press Kit instead of inline cards
- Removed "Code & open source" volunteer role option
- Updated sponsorship tier descriptions and removed "Press Kit listing" from base package

### Documentation Updates
- Updated PRD and CLAUDE.md to reflect new route structure
- Updated all page metadata and descriptions
- Added `.gitignore` file with standard Next.js/Node.js patterns

## Implementation Details
- The three-card CTA uses Next.js `Link` components for internal navigation
- Cards maintain consistent styling with existing glass-morphism design system
- All route changes are backward-compatible within the new structure (no legacy redirects needed as this is a pre-launch refactor)
- Removed unused `DualCTA` component import from home page

https://claude.ai/code/session_01E3Nq3tizqNwDYrKSbmnGYY