### PR TITLE
fix(header): align mobile nav blur, pill styles, and sub-nav offset

### DIFF
--- a/app/get-involved/layout.tsx
+++ b/app/get-involved/layout.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { Button } from "@/components/ui/button";
 
 const subNav = [
   { name: "Overview", href: "/get-involved" },
@@ -33,17 +34,9 @@ export default function GetInvolvedLayout({
                     : pathname.startsWith(item.href);
 
                 return (
-                  <Link
-                    key={item.name}
-                    href={item.href}
-                    className={`px-4 py-2 text-sm font-medium rounded-full transition-colors ${
-                      isActive
-                        ? "bg-teal text-white"
-                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
-                    }`}
-                  >
-                    {item.name}
-                  </Link>
+                  <Button key={item.name} variant="nav" size="sm" isActive={isActive} asChild>
+                    <Link href={item.href}>{item.name}</Link>
+                  </Button>
                 );
               })}
             </div>

--- a/app/get-involved/layout.tsx
+++ b/app/get-involved/layout.tsx
@@ -21,7 +21,7 @@ export default function GetInvolvedLayout({
   return (
     <div className="min-h-screen">
       {/* Sticky Sub-Nav */}
-      <nav className="sticky top-[65px] z-40 bg-white/70 backdrop-blur-xl shadow-[inset_0_4px_8px_-4px_rgba(0,0,0,0.08)]">
+      <nav className="sticky top-18.5 z-40 bg-white/70 backdrop-blur-xl shadow-[inset_0_4px_8px_-4px_rgba(0,0,0,0.08)]">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="flex items-center justify-center py-3">
             {/* Sub-navigation */}

--- a/app/legal/layout.tsx
+++ b/app/legal/layout.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { Button } from "@/components/ui/button";
 
 const legalDocs = [
   { name: "Code of Conduct", href: "/legal/code-of-conduct" },
@@ -30,17 +31,9 @@ export default function LegalLayout({
                 {legalDocs.map((doc) => {
                   const isActive = pathname === doc.href;
                   return (
-                    <Link
-                      key={doc.href}
-                      href={doc.href}
-                      className={`block px-4 py-2 rounded-full text-sm font-medium transition-colors ${
-                        isActive
-                          ? "bg-teal text-white"
-                          : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
-                      }`}
-                    >
-                      {doc.name}
-                    </Link>
+                    <Button key={doc.href} variant="nav" size="sm" isActive={isActive} asChild>
+                      <Link href={doc.href}>{doc.name}</Link>
+                    </Button>
                   );
                 })}
               </nav>
@@ -65,17 +58,9 @@ export default function LegalLayout({
               {legalDocs.map((doc) => {
                 const isActive = pathname === doc.href;
                 return (
-                  <Link
-                    key={doc.href}
-                    href={doc.href}
-                    className={`shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-colors ${
-                      isActive
-                        ? "bg-teal text-white"
-                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
-                    }`}
-                  >
-                    {doc.name}
-                  </Link>
+                  <Button key={doc.href} variant="nav" size="sm" isActive={isActive} className="shrink-0" asChild>
+                    <Link href={doc.href}>{doc.name}</Link>
+                  </Button>
                 );
               })}
             </div>

--- a/app/legal/layout.tsx
+++ b/app/legal/layout.tsx
@@ -33,9 +33,9 @@ export default function LegalLayout({
                     <Link
                       key={doc.href}
                       href={doc.href}
-                      className={`block px-3 py-2 rounded-lg text-sm transition-colors ${
+                      className={`block px-4 py-2 rounded-full text-sm font-medium transition-colors ${
                         isActive
-                          ? "bg-teal/10 text-teal font-medium"
+                          ? "bg-teal text-white"
                           : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
                       }`}
                     >
@@ -71,7 +71,7 @@ export default function LegalLayout({
                     className={`shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-colors ${
                       isActive
                         ? "bg-teal text-white"
-                        : "bg-muted/60 text-muted-foreground hover:text-foreground"
+                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
                     }`}
                   >
                     {doc.name}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -70,7 +70,7 @@ export function Header() {
 
       {/* Mobile menu */}
       {mobileMenuOpen && (
-        <div className="lg:hidden border-t border-border/30 glass">
+        <div className="lg:hidden border-t border-white/20">
           <div className="px-4 py-4 space-y-4">
             {navigation.map((item) => (
               <Link

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -12,6 +12,11 @@ const buttonVariants = cva(
         secondary: "bg-amber text-teal-dark hover:bg-amber-dark hover:text-teal-dark focus-visible:ring-amber-dark",
         outline: "border-2 border-teal-dark text-teal-dark hover:bg-teal-dark hover:text-white focus-visible:ring-teal-dark",
         ghost: "text-teal-dark hover:bg-teal-dark/5 focus-visible:ring-teal-dark",
+        nav: "font-medium focus-visible:ring-teal",
+      },
+      isActive: {
+        true: "",
+        false: "",
       },
       size: {
         sm: "px-4 py-2 text-sm",
@@ -19,6 +24,18 @@ const buttonVariants = cva(
         lg: "px-8 py-4 text-lg",
       },
     },
+    compoundVariants: [
+      {
+        variant: "nav",
+        isActive: true,
+        className: "bg-teal text-white hover:bg-teal/90",
+      },
+      {
+        variant: "nav",
+        isActive: false,
+        className: "text-muted-foreground hover:text-foreground hover:bg-muted/60",
+      },
+    ],
     defaultVariants: {
       variant: "primary",
       size: "md",
@@ -33,11 +50,11 @@ export interface ButtonProps
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, isActive, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size }), className)}
+        className={cn(buttonVariants({ variant, size, isActive }), className)}
         ref={ref}
         {...props}
       />

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
         secondary: "bg-amber text-teal-dark hover:bg-amber-dark hover:text-teal-dark focus-visible:ring-amber-dark",
         outline: "border-2 border-teal-dark text-teal-dark hover:bg-teal-dark hover:text-white focus-visible:ring-teal-dark",
         ghost: "text-teal-dark hover:bg-teal-dark/5 focus-visible:ring-teal-dark",
-        nav: "font-medium focus-visible:ring-teal",
+        nav: "font-medium text-muted-foreground hover:text-foreground hover:bg-muted/60 focus-visible:ring-teal",
       },
       isActive: {
         true: "",
@@ -29,11 +29,6 @@ const buttonVariants = cva(
         variant: "nav",
         isActive: true,
         className: "bg-teal text-white hover:bg-teal/90",
-      },
-      {
-        variant: "nav",
-        isActive: false,
-        className: "text-muted-foreground hover:text-foreground hover:bg-muted/60",
       },
     ],
     defaultVariants: {


### PR DESCRIPTION
## Summary

- **Mobile dropdown blur**: Removed the `.glass` class from the mobile menu dropdown — it now inherits `backdrop-blur-xl` from the `<header>` parent, so the frosted-glass blur actually renders instead of being blocked by the parent's opaque background
- **Sub-nav sticky offset**: Corrected `top-[65px]` → `top-18.5` (74px) on the get-involved sub-nav to match the real header height (`py-4` × 2 + `h-10` logo + 1px border), stopping the sub-nav from scrolling up before sticking
- **Legal sidebar consistency**: Updated desktop sidebar links to use `rounded-full` + `bg-teal text-white` active state, matching the mobile pills and the get-involved sub-nav pills
- **Legal mobile pill hover**: Removed static `bg-muted/60` from inactive pill state; background now only shows on hover, consistent with get-involved

## Test plan

- [ ] On mobile, open the hamburger menu — the dropdown should have a visible frosted-glass blur over the page content below
- [ ] On `/get-involved` and sub-pages, scroll down — the sub-nav pill bar should stick immediately below the header with no upward drift
- [ ] On `/legal/*`, verify desktop sidebar links use pill shape (`rounded-full`) with teal fill on the active item
- [ ] On `/legal/*` on mobile, verify inactive pills have no background at rest and show `bg-muted/60` on hover
- [ ] All three nav surfaces (header, get-involved sub-nav, legal pills) should look visually consistent in active/inactive states

Closes #23