### PR TITLE
fix(events): UI polish — padding, controls card, lazy load, sort

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -48,7 +48,7 @@ export default function EventsPage() {
 
       {/* Next Up */}
       {nextEvent && (
-        <Section className="pt-0">
+        <Section>
           <SectionHeader overline="Next up" title="" className="mb-8" />
           <div className="rounded-2xl bg-card border border-border overflow-hidden">
             <div className="p-6 lg:p-8">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,8 +40,8 @@ export default function HomePage() {
     <>
       {/* Hero Section - Left aligned text, stacked overlapping photos right */}
       <section className="relative overflow-hidden gradient-hero texture-grain">
-        <div className="relative mx-auto max-w-7xl px-6 py-12 lg:px-8 lg:py-16">
-          <div className="grid lg:grid-cols-2 gap-8 lg:gap-6 items-center justify-center lg:justify-start text-center lg:text-left">
+        <div className="relative mx-auto max-w-7xl px-8 py-12 lg:px-8 lg:py-16">
+          <div className="grid lg:grid-cols-2 gap-8 lg:gap-6 items-center">
             {/* Left: Text content */}
             <div className="lg:max-w-xl py-8 lg:py-12">
               <span className="tag mb-4">
@@ -53,11 +53,11 @@ export default function HomePage() {
               <p className="text-lg text-muted-foreground leading-relaxed mb-6 lg:max-w-md">
                 Tech talks, panels, socials, sports, and more—hosted at companies across the city.
               </p>
-              <div className="flex flex-wrap gap-3 justify-center lg:justify-start">
-                <Button variant="primary" size="lg" asChild>
+              <div className="flex flex-wrap gap-3">
+                <Button variant="primary" size="md" asChild>
                   <Link href="/events">See events</Link>
                 </Button>
-                <Button variant="outline" size="lg" asChild>
+                <Button variant="outline" size="md" asChild>
                   <Link href="/get-involved">Get involved</Link>
                 </Button>
               </div>
@@ -159,7 +159,7 @@ export default function HomePage() {
 
         {/* CTAs */}
         <div className="flex flex-wrap items-center justify-center gap-3">
-          <Button variant="primary" size="sm" asChild>
+          <Button variant="primary" size="md" asChild>
             <a
               href="https://luma.com/techtank"
               target="_blank"
@@ -169,7 +169,7 @@ export default function HomePage() {
               <ExternalLink className="ml-2 h-4 w-4" />
             </a>
           </Button>
-          <Button variant="outline" size="sm" asChild>
+          <Button variant="outline" size="md" asChild>
             <Link href="/events">
               View all
               <ArrowRight className="ml-2 h-4 w-4" />

--- a/components/ui/event-browser.tsx
+++ b/components/ui/event-browser.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { LayoutGrid, List, Columns2, Calendar, Tag, MapPin, Camera, Play } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { EventCard } from "@/components/ui/event-card";
 import { cn } from "@/utils/theme";
 import type { Event } from "@/constants/events";
@@ -35,11 +36,14 @@ interface EventBrowserProps {
   events: Event[];
 }
 
+const PAGE_SIZE = 20;
+
 export function EventBrowser({ events }: EventBrowserProps) {
   const [category, setCategory] = useState<CategoryFilter>("all");
   const [timeFilter, setTimeFilter] = useState<TimeFilter>("all");
   const [displayMode, setDisplayMode] = useState<DisplayMode>("cards");
   const [sortBy, setSortBy] = useState<SortBy>("date");
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   const filtered = useMemo(() => {
     let result = events.filter((e) => {
@@ -62,6 +66,12 @@ export function EventBrowser({ events }: EventBrowserProps) {
     return result;
   }, [events, category, timeFilter, sortBy]);
 
+  useEffect(() => { setVisibleCount(PAGE_SIZE); }, [category, timeFilter, sortBy]);
+
+  const visible = filtered.slice(0, visibleCount);
+  const hasMore = visibleCount < filtered.length;
+
+
   const categories: { id: CategoryFilter; label: string }[] = [
     { id: "all", label: "All" },
     { id: "tech-talks", label: "Tech Talks" },
@@ -80,7 +90,7 @@ export function EventBrowser({ events }: EventBrowserProps) {
   return (
     <div>
       {/* Controls */}
-      <div className="flex flex-col gap-4 mb-8">
+      <div className="rounded-xl bg-card border border-border p-4 flex flex-col gap-4 mb-8">
         {/* Category filters */}
         <div className="flex flex-wrap gap-2">
           {categories.map((c) => (
@@ -121,12 +131,11 @@ export function EventBrowser({ events }: EventBrowserProps) {
           <div className="flex items-center gap-3">
             {/* Sort */}
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <span>Sort:</span>
               <button
                 onClick={() => setSortBy("date")}
                 className={cn(
-                  "px-2 py-1 rounded transition-colors",
-                  sortBy === "date" ? "text-foreground font-medium" : "hover:text-foreground"
+                  "px-3 py-1 rounded-md text-xs font-medium transition-colors",
+                  sortBy === "date" ? "bg-secondary text-secondary-foreground" : "text-muted-foreground hover:text-foreground"
                 )}
               >
                 Date
@@ -134,8 +143,8 @@ export function EventBrowser({ events }: EventBrowserProps) {
               <button
                 onClick={() => setSortBy("title")}
                 className={cn(
-                  "px-2 py-1 rounded transition-colors",
-                  sortBy === "title" ? "text-foreground font-medium" : "hover:text-foreground"
+                  "px-3 py-1 rounded-md text-xs font-medium transition-colors",
+                  sortBy === "title" ? "bg-secondary text-secondary-foreground" : "text-muted-foreground hover:text-foreground"
                 )}
               >
                 Title
@@ -180,7 +189,7 @@ export function EventBrowser({ events }: EventBrowserProps) {
       </div>
 
       {/* Result count */}
-      <p className="text-xs text-muted-foreground mb-6">
+      <p className="text-xs text-muted-foreground mb-6 text-center">
         {filtered.length} event{filtered.length !== 1 ? "s" : ""}
       </p>
 
@@ -190,11 +199,19 @@ export function EventBrowser({ events }: EventBrowserProps) {
           No events match the current filters.
         </div>
       ) : displayMode === "cards" ? (
-        <CardsView events={filtered} />
+        <CardsView events={visible} />
       ) : displayMode === "grid" ? (
-        <GridView events={filtered} />
+        <GridView events={visible} />
       ) : (
-        <ListView events={filtered} />
+        <ListView events={visible} />
+      )}
+
+      {hasMore && (
+        <div className="mt-8 text-center">
+          <Button variant="outline" onClick={() => setVisibleCount((n) => n + PAGE_SIZE)}>
+            Load more ({filtered.length - visibleCount} remaining)
+          </Button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- **Next Up section**: remove `pt-0` so mobile top padding matches other pages
- **Controls card**: wrap event browser filters in `bg-card` card; center result count
- **Load more**: paginated 20-at-a-time with outline button; resets on filter change
- **Sort controls**: match pill variant to time-filter buttons; remove "Sort:" label
- **Home hero**: left-align text/buttons at all breakpoints; increase mobile `px` to 8; downsize buttons to `md`