### PR TITLE
chore: add vercel.json with noindex header

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,18 @@ route, annotated with its purpose.
 ├── prd/                            # Product requirements documents (specs)
 ├── public/                         # Static assets (images, downloads, social media dumps)
 ├── next.config.ts
+├── vercel.json                     # Vercel deployment config (noindex header)
 └── tsconfig.json
 ```
 
 See [`prd/PRD.md`](./prd/PRD.md) for the full route map, shared-layout
 conventions, and per-page content requirements.
+
+## Deployment
+
+The site deploys to [Vercel](https://vercel.com/). Search engine indexing is
+disabled via an `X-Robots-Tag: noindex` header in [`vercel.json`](./vercel.json)
+— remove that header before launching to production.
 
 ## Contributing
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `vercel.json` with `X-Robots-Tag: noindex` on all routes to prevent search engine indexing on the Vercel deployment
- Adds a Deployment section to README documenting Vercel as the host and noting the noindex header should be removed before go-live

## Test plan

- [ ] Verify `X-Robots-Tag: noindex` appears in response headers on the Vercel preview
- [ ] Remove the noindex header before launching to production