### PR TITLE
Part of #42 mobile responsiveness fixes: Use the same pill component from Get Involved page on Legal pages too

### DIFF
--- a/app/get-involved/layout.tsx
+++ b/app/get-involved/layout.tsx
@@ -22,7 +22,7 @@ export default function GetInvolvedLayout({
   return (
     <div className="min-h-screen">
       {/* Sticky Sub-Nav */}
-      <nav className="sticky top-18.5 z-40 bg-background/80 backdrop-blur-xl border-b border-border">
+      <nav className="sticky top-18 z-40 bg-background/80 backdrop-blur-xl border-b border-border">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="flex items-center justify-center py-3">
             {/* Sub-navigation */}
@@ -40,8 +40,6 @@ export default function GetInvolvedLayout({
                 );
               })}
             </div>
-
-
           </div>
         </div>
       </nav>

--- a/app/legal/code-of-conduct/page.tsx
+++ b/app/legal/code-of-conduct/page.tsx
@@ -20,8 +20,8 @@ export default function CodeOfConductPage() {
 
       {/* Quick Report */}
       <div className="bg-ring/5 border border-ring/20 rounded-xl p-6 mb-8">
-        <div className="flex items-start gap-4">
-          <Mail className="h-6 w-6 text-ring shrink-0 mt-0.5" />
+        <div className="flex flex-col sm:flex-row items-start gap-4">
+          <Mail className="h-6 w-6 text-ring shrink-0 sm:mt-0.5" />
           <div>
             <h2 className="font-semibold text-foreground mb-1">
               Need to report something?

--- a/app/legal/layout.tsx
+++ b/app/legal/layout.tsx
@@ -39,11 +39,11 @@ export default function LegalLayout({
       </nav>
 
       {/* Main Content */}
-      <div className="mx-auto max-w-7xl px-6 py-12 lg:px-8 lg:pb-16">
+      <main className="mx-auto max-w-7xl px-6 py-12 lg:px-8 lg:pb-16">
         <article className="prose prose-slate max-w-none">
           {children}
         </article>
-      </div>
+      </main>
     </div>
   );
 }

--- a/app/legal/layout.tsx
+++ b/app/legal/layout.tsx
@@ -19,60 +19,30 @@ export default function LegalLayout({
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="mx-auto max-w-7xl px-6 py-12 lg:px-8 lg:py-16">
-        <div className="lg:grid lg:grid-cols-12 lg:gap-12">
-          {/* Sidebar - Table of Contents */}
-          <aside className="hidden lg:block lg:col-span-3">
-            <div className="sticky top-24">
-              <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-4">
-                Legal Documents
-              </h2>
-              <nav className="space-y-1">
-                {legalDocs.map((doc) => {
-                  const isActive = pathname === doc.href;
-                  return (
-                    <Button key={doc.href} variant="nav" size="sm" isActive={isActive} asChild>
-                      <Link href={doc.href}>{doc.name}</Link>
-                    </Button>
-                  );
-                })}
-              </nav>
-
-              <div className="mt-8 pt-8 border-t border-border">
-                <p className="text-sm text-muted-foreground">
-                  Questions about these documents?
-                </p>
-                <a
-                  href="mailto:techtankto@gmail.com"
-                  className="text-sm font-medium text-ring hover:text-ring/80 transition-colors"
-                >
-                  Contact us
-                </a>
-              </div>
-            </div>
-          </aside>
-
-          {/* Mobile Navigation */}
-          <div className="lg:hidden mb-8">
-            <div className="flex gap-2 overflow-x-auto pb-2 -mx-4 px-4 scrollbar-hide">
+      {/* Sticky Sub-Nav */}
+      <nav className="sticky top-18 z-40 bg-background/80 backdrop-blur-xl border-b border-border">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="flex items-center justify-center py-3">
+            {/* Sub-navigation */}
+            <div className="flex flex-wrap items-center justify-center gap-1">
               {legalDocs.map((doc) => {
                 const isActive = pathname === doc.href;
                 return (
-                  <Button key={doc.href} variant="nav" size="sm" isActive={isActive} className="shrink-0" asChild>
+                  <Button key={doc.href} variant="nav" size="sm" isActive={isActive} asChild>
                     <Link href={doc.href}>{doc.name}</Link>
                   </Button>
                 );
               })}
             </div>
           </div>
-
-          {/* Main Content */}
-          <main className="lg:col-span-9">
-            <article className="prose prose-slate max-w-none">
-              {children}
-            </article>
-          </main>
         </div>
+      </nav>
+
+      {/* Main Content */}
+      <div className="mx-auto max-w-7xl px-6 py-12 lg:px-8 lg:pb-16">
+        <article className="prose prose-slate max-w-none">
+          {children}
+        </article>
       </div>
     </div>
   );


### PR DESCRIPTION
# Summary
- Addresses this sub-issue https://github.com/tech-tankorg/techtank-next/issues/42#issuecomment-4321899562
- Use the same pill component from Get Involved page on Legal pages too
- Mobile responsive fix for Code of Conduct subsection
- Fix the slight gap between navbar and sub-nav on Getting Involved page

## Screenshots
After:
<img width="624" height="941" alt="image" src="https://github.com/user-attachments/assets/7314614a-0668-4df7-af33-9f3631ccd434" />
  
<img width="2446" height="1212" alt="image" src="https://github.com/user-attachments/assets/8a1ec4f7-6987-4750-b7b1-ad114fb72ba7" />
  
<img width="1083" height="748" alt="image" src="https://github.com/user-attachments/assets/81d2131b-6972-4562-89e1-3a2c53baa4ab" />
  
Before:
<img width="501" height="1087" alt="image" src="https://github.com/user-attachments/assets/d1cd6c17-e531-446d-bc88-f112a206aaab" />
  
<img width="2413" height="1371" alt="image" src="https://github.com/user-attachments/assets/32ff854e-85c2-4e8f-8172-ff4784ae8db6" />
  
<img width="1083" height="751" alt="image" src="https://github.com/user-attachments/assets/96dbf616-701f-4853-aee9-65b7ec021a50" />
  
## Checklist

- [x] No new TypeScript errors (`pnpm build` and `pnpm lint:fix` passes)
- [x] Visually tested in the browser (desktop + mobile)
- [x] PRD updated if information architecture, routes or design system is changed (`prd/`)
- [x] No placeholder content (`#`, `TODO`, Lorem Ipsum) left in production paths
