### PR TITLE
Part of #42 mobile responsiveness fixes: Fixes on social and pillars sections on home and about pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -128,7 +128,7 @@ export default function AboutPage() {
           {pillars.map((pillar) => (
             <div
               key={pillar.title}
-              className="relative flex gap-6 bg-card rounded-2xl border border-border p-6 lg:p-8"
+              className="relative flex flex-col sm:flex-row gap-6 bg-card rounded-2xl border border-border p-6 lg:p-8"
             >
               <div
                 className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-xl ${

--- a/components/ui/event-browser.tsx
+++ b/components/ui/event-browser.tsx
@@ -238,7 +238,7 @@ function CardsView({ events }: { events: Event[] }) {
 
 function GridView({ events }: { events: Event[] }) {
   return (
-    <div className="grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
+    <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
       {events.map((event) => {
         const img = event.imagePath;
         const isUpcoming = event.status === "upcoming";

--- a/components/ui/social-feed.tsx
+++ b/components/ui/social-feed.tsx
@@ -102,7 +102,7 @@ export function SocialFeed() {
 
   return (
     <div className="space-y-8">
-      <div className="grid gap-6 grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {posts.map((post) => (
           <InstagramPostCard key={post.id} post={post} />
         ))}

--- a/components/ui/social-feed.tsx
+++ b/components/ui/social-feed.tsx
@@ -66,15 +66,15 @@ function InstagramPostCard({ post }: { post: InstagramPostWithId }) {
         </div>
       )}
       <div className="p-6 flex flex-col flex-1">
-        <div className="flex items-center gap-2 mb-4">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 mb-4">
           <span className="text-[#E4405F]">
             <InstagramIcon className="h-5 w-5" />
           </span>
-          <span className="text-xs text-muted-foreground uppercase tracking-wide font-medium">
+          <span className="text-xs text-muted-foreground uppercase tracking-wide font-medium shrink-0">
             Instagram
           </span>
-          <span className="text-xs text-muted-foreground/50">·</span>
-          <span className="text-xs text-muted-foreground">
+          <span className="text-xs text-muted-foreground/50 shrink-0">·</span>
+          <span className="text-xs text-muted-foreground min-w-[8.5em] shrink-0">
             {formatDate(post.date, post.createdAtRaw)}
           </span>
         </div>
@@ -102,7 +102,7 @@ export function SocialFeed() {
 
   return (
     <div className="space-y-8">
-      <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-4">
         {posts.map((post) => (
           <InstagramPostCard key={post.id} post={post} />
         ))}

--- a/components/ui/social-feed.tsx
+++ b/components/ui/social-feed.tsx
@@ -102,7 +102,7 @@ export function SocialFeed() {
 
   return (
     <div className="space-y-8">
-      <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-4 ">
+      <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-4">
         {posts.map((post) => (
           <InstagramPostCard key={post.id} post={post} />
         ))}

--- a/components/ui/social-feed.tsx
+++ b/components/ui/social-feed.tsx
@@ -102,7 +102,7 @@ export function SocialFeed() {
 
   return (
     <div className="space-y-8">
-      <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-4">
+      <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-4 ">
         {posts.map((post) => (
           <InstagramPostCard key={post.id} post={post} />
         ))}


### PR DESCRIPTION
# Summary

- Improve mobile and tablet responsiveness of social section on Home page
- Fix responsiveness of pillars section on About page

## Screenshots

After:
<img width="602" height="1687" alt="image" src="https://github.com/user-attachments/assets/606e3e2e-af47-4dcf-8937-c269159cdf80" />
  
<img width="1500" height="1652" alt="image" src="https://github.com/user-attachments/assets/e7c3a020-3932-4cbf-814e-199d62f5a91e" />
  
<img width="600" height="1457" alt="image" src="https://github.com/user-attachments/assets/df4768f7-303f-429c-ac35-2f51e49fd603" />
  
Before:
<img width="600" height="1663" alt="image" src="https://github.com/user-attachments/assets/b17b8361-39ea-45d9-b920-f593cd4d1b19" />
  
<img width="1502" height="1747" alt="Screenshot 2026-04-29 005159" src="https://github.com/user-attachments/assets/ca4f7a32-c96a-4dff-8f89-6fd09d9c98bc" />
  
<img width="600" height="1382" alt="image" src="https://github.com/user-attachments/assets/7884b526-b673-4f61-83d1-06f40293e2ef" />
  
## Checklist

- [x] No new TypeScript errors (`pnpm build` and `pnpm lint:fix` passes)
- [x] Visually tested in the browser (desktop + mobile)
- [x] PRD updated if information architecture, routes or design system is changed (`prd/`)
- [x] No placeholder content (`#`, `TODO`, Lorem Ipsum) left in production paths
