### PR TITLE
feat(about): add team bios page with about sub-nav

### DIFF
--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
+const subNav = [
+  { name: "TechTank", href: "/about" },
+  { name: "Team", href: "/about/team" },
+];
+
+export default function AboutLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  return (
+    <div className="min-h-screen">
+      <nav className="sticky top-18 z-40 bg-background/80 backdrop-blur-xl border-b border-border">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8">
+          <div className="flex items-center justify-center py-3">
+            <div className="flex flex-wrap items-center justify-center gap-1">
+              {subNav.map((item) => {
+                const isActive =
+                  item.href === "/about"
+                    ? pathname === "/about"
+                    : pathname.startsWith(item.href);
+
+                return (
+                  <Button key={item.name} variant="nav" size="sm" isActive={isActive} asChild>
+                    <Link href={item.href}>{item.name}</Link>
+                  </Button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      {children}
+    </div>
+  );
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -318,6 +318,9 @@ export default function AboutPage() {
             <Button variant="outline" size="lg" asChild>
               <Link href="/get-involved">Get involved</Link>
             </Button>
+            <Button variant="outline" size="lg" asChild>
+              <Link href="/about/team">Meet the team</Link>
+            </Button>
           </div>
         </div>
       </Section>

--- a/app/about/team/page.tsx
+++ b/app/about/team/page.tsx
@@ -10,18 +10,10 @@ export const metadata: Metadata = {
     "Meet the volunteers, organizers, and board members who make TechTank TO happen.",
 };
 
-// Deterministic color slot from name — cycles through brand palette
-const AVATAR_PALETTES = [
-  { bg: "bg-teal/15 dark:bg-teal/20", text: "text-teal dark:text-seafoam", ring: "ring-teal/20" },
-  { bg: "bg-amber/20 dark:bg-amber/15", text: "text-amber-dark dark:text-amber", ring: "ring-amber/25" },
-  { bg: "bg-mint/15 dark:bg-mint/20", text: "text-mint dark:text-seafoam", ring: "ring-mint/20" },
-  { bg: "bg-coral/10 dark:bg-coral/15", text: "text-coral dark:text-peach", ring: "ring-coral/20" },
-  { bg: "bg-seafoam/30 dark:bg-seafoam/10", text: "text-teal-dark dark:text-seafoam", ring: "ring-seafoam/30" },
-] as const;
+const AVATAR_PALETTE = { bg: "bg-teal/15 dark:bg-teal/20", text: "text-teal dark:text-seafoam", ring: "ring-teal/20" };
 
-function paletteFor(name: string) {
-  const sum = name.split("").reduce((acc, c) => acc + c.charCodeAt(0), 0);
-  return AVATAR_PALETTES[sum % AVATAR_PALETTES.length];
+function paletteFor(_name: string) {
+  return AVATAR_PALETTE;
 }
 
 function initials(name: string) {

--- a/app/about/team/page.tsx
+++ b/app/about/team/page.tsx
@@ -10,18 +10,10 @@ export const metadata: Metadata = {
     "Meet the volunteers, organizers, and board members who make TechTank TO happen.",
 };
 
-// Deterministic color slot from name — cycles through brand palette
-const AVATAR_PALETTES = [
-  { bg: "bg-teal/15 dark:bg-teal/20", text: "text-teal dark:text-seafoam", ring: "ring-teal/20" },
-  { bg: "bg-amber/20 dark:bg-amber/15", text: "text-amber-dark dark:text-amber", ring: "ring-amber/25" },
-  { bg: "bg-mint/15 dark:bg-mint/20", text: "text-mint dark:text-seafoam", ring: "ring-mint/20" },
-  { bg: "bg-coral/10 dark:bg-coral/15", text: "text-coral dark:text-peach", ring: "ring-coral/20" },
-  { bg: "bg-seafoam/30 dark:bg-seafoam/10", text: "text-teal-dark dark:text-seafoam", ring: "ring-seafoam/30" },
-] as const;
+const AVATAR_PALETTE = { bg: "bg-primary", text: "text-primary-foreground", ring: "ring-primary/30" };
 
-function paletteFor(name: string) {
-  const sum = name.split("").reduce((acc, c) => acc + c.charCodeAt(0), 0);
-  return AVATAR_PALETTES[sum % AVATAR_PALETTES.length];
+function paletteFor(_name: string) {
+  return AVATAR_PALETTE;
 }
 
 function initials(name: string) {

--- a/app/about/team/page.tsx
+++ b/app/about/team/page.tsx
@@ -10,10 +10,18 @@ export const metadata: Metadata = {
     "Meet the volunteers, organizers, and board members who make TechTank TO happen.",
 };
 
-const AVATAR_PALETTE = { bg: "bg-primary", text: "text-primary-foreground", ring: "ring-primary/30" };
+// Deterministic color slot from name — cycles through brand palette
+const AVATAR_PALETTES = [
+  { bg: "bg-teal/15 dark:bg-teal/20", text: "text-teal dark:text-seafoam", ring: "ring-teal/20" },
+  { bg: "bg-amber/20 dark:bg-amber/15", text: "text-amber-dark dark:text-amber", ring: "ring-amber/25" },
+  { bg: "bg-mint/15 dark:bg-mint/20", text: "text-mint dark:text-seafoam", ring: "ring-mint/20" },
+  { bg: "bg-coral/10 dark:bg-coral/15", text: "text-coral dark:text-peach", ring: "ring-coral/20" },
+  { bg: "bg-seafoam/30 dark:bg-seafoam/10", text: "text-teal-dark dark:text-seafoam", ring: "ring-seafoam/30" },
+] as const;
 
-function paletteFor(_name: string) {
-  return AVATAR_PALETTE;
+function paletteFor(name: string) {
+  const sum = name.split("").reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  return AVATAR_PALETTES[sum % AVATAR_PALETTES.length];
 }
 
 function initials(name: string) {

--- a/app/about/team/page.tsx
+++ b/app/about/team/page.tsx
@@ -1,0 +1,291 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Section, SectionHeader } from "@/components/ui/section";
+import { teamGroups, type TeamMember } from "@/constants/team";
+
+export const metadata: Metadata = {
+  title: "Team",
+  description:
+    "Meet the volunteers, organizers, and board members who make TechTank TO happen.",
+};
+
+// Deterministic color slot from name — cycles through brand palette
+const AVATAR_PALETTES = [
+  { bg: "bg-teal/15 dark:bg-teal/20", text: "text-teal dark:text-seafoam", ring: "ring-teal/20" },
+  { bg: "bg-amber/20 dark:bg-amber/15", text: "text-amber-dark dark:text-amber", ring: "ring-amber/25" },
+  { bg: "bg-mint/15 dark:bg-mint/20", text: "text-mint dark:text-seafoam", ring: "ring-mint/20" },
+  { bg: "bg-coral/10 dark:bg-coral/15", text: "text-coral dark:text-peach", ring: "ring-coral/20" },
+  { bg: "bg-seafoam/30 dark:bg-seafoam/10", text: "text-teal-dark dark:text-seafoam", ring: "ring-seafoam/30" },
+] as const;
+
+function paletteFor(name: string) {
+  const sum = name.split("").reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  return AVATAR_PALETTES[sum % AVATAR_PALETTES.length];
+}
+
+function initials(name: string) {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase();
+}
+
+// ─── Avatar sizes ────────────────────────────────────────────────────────────
+
+function AvatarLg({ name }: { name: string }) {
+  const p = paletteFor(name);
+  return (
+    <div
+      className={`flex h-24 w-24 shrink-0 items-center justify-center rounded-full ring-4 ${p.bg} ${p.ring} shadow-soft`}
+    >
+      <span className={`font-display text-2xl font-bold ${p.text}`}>
+        {initials(name)}
+      </span>
+    </div>
+  );
+}
+
+function AvatarMd({ name }: { name: string }) {
+  const p = paletteFor(name);
+  return (
+    <div
+      className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-full ring-2 ${p.bg} ${p.ring}`}
+    >
+      <span className={`font-display text-base font-bold ${p.text}`}>
+        {initials(name)}
+      </span>
+    </div>
+  );
+}
+
+function AvatarSm({ name }: { name: string }) {
+  const p = paletteFor(name);
+  return (
+    <div
+      className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${p.bg}`}
+    >
+      <span className={`font-display text-xs font-bold ${p.text}`}>
+        {initials(name)}
+      </span>
+    </div>
+  );
+}
+
+// ─── Card variants ───────────────────────────────────────────────────────────
+
+function BoardCard({ name, pronouns, role, bio }: TeamMember) {
+  return (
+    <div className="poster-card group relative overflow-hidden p-8 flex flex-col gap-6 shadow-soft-lg">
+      {/* Decorative circle */}
+      <div className="pointer-events-none absolute -top-8 -right-8 h-40 w-40 rounded-full bg-white/10 dark:bg-white/5" />
+      <div className="pointer-events-none absolute -bottom-12 -left-6 h-32 w-32 rounded-full bg-white/10 dark:bg-white/5" />
+
+      <AvatarLg name={name} />
+
+      <div>
+        <p className="font-display text-2xl font-bold text-foreground leading-tight">
+          {name}
+        </p>
+        <p className="text-sm text-muted-foreground mt-0.5">{pronouns}</p>
+        {role && (
+          <span className="mt-3 inline-block tag text-xs">
+            {role}
+          </span>
+        )}
+        {bio ? (
+          <p className="mt-4 text-sm text-muted-foreground leading-relaxed">{bio}</p>
+        ) : (
+          <p className="mt-4 text-sm text-muted-foreground/40 italic">Bio coming soon</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CoreCard({ name, pronouns, role, bio }: TeamMember) {
+  return (
+    <div className="flex gap-4 bg-card rounded-2xl border border-border p-5 shadow-soft hover:shadow-soft-lg transition-shadow">
+      <AvatarMd name={name} />
+      <div className="min-w-0">
+        <p className="font-display text-lg font-semibold text-foreground leading-tight">
+          {name}
+        </p>
+        <p className="text-xs text-muted-foreground mt-0.5">{pronouns}</p>
+        {role && (
+          <p className="mt-1 text-xs font-semibold text-ring uppercase tracking-wide">{role}</p>
+        )}
+        {bio ? (
+          <p className="mt-2 text-sm text-muted-foreground leading-relaxed">{bio}</p>
+        ) : (
+          <p className="mt-2 text-sm text-muted-foreground/40 italic">Bio coming soon</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CompactTile({ name, pronouns, role }: TeamMember) {
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3 hover:border-ring/30 hover:bg-accent/30 transition-colors">
+      <AvatarSm name={name} />
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-foreground truncate">{name}</p>
+        <p className="text-xs text-muted-foreground">{pronouns}{role ? ` · ${role}` : ""}</p>
+      </div>
+    </div>
+  );
+}
+
+// ─── Page ────────────────────────────────────────────────────────────────────
+
+export default function TeamPage() {
+  const boardCoChairs = teamGroups[0];
+  const boardTreasurer = teamGroups[1];
+  const coreTeam = teamGroups[2];
+  const websiteTeam = teamGroups[3];
+  const socialMedia = teamGroups[4];
+  const volunteers = teamGroups[5];
+
+  return (
+    <>
+      {/* Hero */}
+      <section className="relative overflow-hidden gradient-hero texture-grain">
+        <div className="relative mx-auto max-w-7xl px-6 py-20 lg:px-8 lg:py-32">
+          <div className="max-w-3xl">
+            <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
+              Our team
+            </span>
+            <h1 className="font-display text-4xl md:text-5xl font-semibold text-foreground lg:text-6xl text-balance mb-6">
+              The people behind TechTank
+            </h1>
+            <p className="text-xl text-muted-foreground leading-relaxed mb-8">
+              TechTank TO is powered entirely by volunteers — organizers, designers,
+              developers, and community builders who give their time to make
+              Toronto&apos;s tech community more inclusive and welcoming.
+            </p>
+            <Button variant="outline" size="lg" asChild>
+              <Link href="/get-involved/volunteer">Join the team</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* Board of Directors */}
+      <Section>
+        <SectionHeader
+          overline="Leadership"
+          title="Board of Directors"
+          description="The organizers who set the direction and keep TechTank running."
+          className="mb-12"
+        />
+
+        {/* Co-Chairs */}
+        <div className="mb-10">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-5">
+            Co-Chairs
+          </p>
+          <div className="grid gap-5 sm:grid-cols-2">
+            {boardCoChairs.members.map((m) => (
+              <BoardCard key={m.name} {...m} />
+            ))}
+          </div>
+        </div>
+
+        {/* Treasurer */}
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-5">
+            Treasurer
+          </p>
+          <div className="grid gap-5 sm:grid-cols-2">
+            {boardTreasurer.members.map((m) => (
+              <BoardCard key={m.name} {...m} />
+            ))}
+          </div>
+        </div>
+      </Section>
+
+      {/* Core Team */}
+      <Section background="white">
+        <SectionHeader
+          overline="Core team"
+          title="Organizers"
+          description="The people who keep events running, the community thriving, and the details polished."
+          className="mb-10"
+        />
+        <div className="grid gap-4 sm:grid-cols-2">
+          {coreTeam.members.map((m) => (
+            <CoreCard key={m.name} {...m} />
+          ))}
+        </div>
+      </Section>
+
+      {/* Website + Social side-by-side */}
+      <Section background="brand-soft">
+        <div className="grid gap-12 lg:grid-cols-2">
+          <div>
+            <SectionHeader
+              overline="Website team"
+              title="Developers & designers"
+              className="mb-8"
+            />
+            <div className="grid gap-3">
+              {websiteTeam.members.map((m) => (
+                <CompactTile key={m.name} {...m} />
+              ))}
+            </div>
+          </div>
+          <div>
+            <SectionHeader
+              overline="Social media"
+              title="Content & community"
+              className="mb-8"
+            />
+            <div className="grid gap-3">
+              {socialMedia.members.map((m) => (
+                <CompactTile key={m.name} {...m} />
+              ))}
+            </div>
+          </div>
+        </div>
+      </Section>
+
+      {/* Community Volunteers */}
+      <Section background="white">
+        <SectionHeader
+          overline="Community"
+          title="Volunteers"
+          description="Our community volunteers show up at every event to make sure everyone feels welcome."
+          className="mb-10"
+        />
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {volunteers.members.map((m) => (
+            <CompactTile key={m.name + (m.role ?? "")} {...m} />
+          ))}
+        </div>
+      </Section>
+
+      {/* CTA */}
+      <Section background="brand-soft">
+        <div className="max-w-2xl mx-auto text-center">
+          <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
+            Get involved
+          </span>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
+            Want to be part of the team?
+          </h2>
+          <p className="text-muted-foreground mb-8">
+            We&apos;re always looking for volunteers who want to help build
+            Toronto&apos;s most inclusive tech community.
+          </p>
+          <Button variant="primary" size="lg" asChild>
+            <Link href="/get-involved/volunteer">Volunteer with us</Link>
+          </Button>
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -15,6 +15,13 @@ const footerLinks = {
       { name: "YouTube", href: "https://youtube.com/@TechTankTo", external: true },
     ],
   },
+  about: {
+    title: "About",
+    links: [
+      { name: "TechTank", href: "/about", external: false },
+      { name: "Team", href: "/about/team", external: false },
+    ],
+  },
   getInvolved: {
     title: "Get Involved",
     links: [
@@ -47,7 +54,7 @@ export function Footer() {
     <footer className="bg-primary dark:bg-background text-primary-foreground dark:text-foreground">
       <div className="mx-auto max-w-7xl px-6 py-12 lg:px-8 lg:py-16">
         {/* Top section */}
-        <div className="grid grid-cols-2 gap-8 lg:grid-cols-5">
+        <div className="grid grid-cols-2 gap-8 lg:grid-cols-6">
           {/* Brand column */}
           <div className="col-span-2 lg:col-span-1">
             <Link href="/" className="flex items-center">

--- a/constants/team.ts
+++ b/constants/team.ts
@@ -73,6 +73,7 @@ export const teamGroups: TeamGroup[] = [
       { name: "Justin Bento", pronouns: "he/him" },
       { name: "Jyle Vergara", pronouns: "she/her" },
       { name: "John Malapit", pronouns: "he/him" },
+      { name: "Jacky Tea", pronouns: "he/him" },
     ],
   },
   {

--- a/constants/team.ts
+++ b/constants/team.ts
@@ -1,0 +1,101 @@
+export interface TeamMember {
+  name: string;
+  pronouns: string;
+  role?: string;
+  bio?: string;
+  avatar?: string;
+}
+
+export interface TeamGroup {
+  title: string;
+  subtitle?: string;
+  members: TeamMember[];
+}
+
+export const teamGroups: TeamGroup[] = [
+  {
+    title: "Board of Directors",
+    subtitle: "Co-Chairs",
+    members: [
+      {
+        name: "Danny Kim",
+        pronouns: "he/him",
+        role: "Co-Chair, Board Member & Organizer",
+      },
+      {
+        name: "Niki Fereidooni",
+        pronouns: "she/her",
+        role: "Co-Chair, Board Member & Organizer",
+      },
+    ],
+  },
+  {
+    title: "Board of Directors",
+    subtitle: "Treasurer",
+    members: [
+      {
+        name: "Sophia Kim",
+        pronouns: "she/her",
+        role: "Treasurer, Board Member & Organizer",
+      },
+    ],
+  },
+  {
+    title: "Core Team",
+    members: [
+      {
+        name: "Thannia Blanchet",
+        pronouns: "she/her",
+        role: "Organizer",
+      },
+      {
+        name: "Tony Ko",
+        pronouns: "he/him",
+        role: "Digital Lead & Organizer",
+      },
+      {
+        name: "Natasha Kasunic",
+        pronouns: "she/her",
+      },
+      {
+        name: "Eileen Xue",
+        pronouns: "she/her",
+      },
+    ],
+  },
+  {
+    title: "Website Team",
+    members: [
+      { name: "Tony Ko", pronouns: "he/him" },
+      { name: "Danny Kim", pronouns: "he/him" },
+      { name: "Rohan Villoth", pronouns: "he/him" },
+      { name: "Danyal Imran", pronouns: "he/him" },
+      { name: "Justin Bento", pronouns: "he/him" },
+      { name: "Jyle V.", pronouns: "she/her" },
+      { name: "John Malapit", pronouns: "he/him" },
+    ],
+  },
+  {
+    title: "Social Media",
+    members: [
+      { name: "Amanda Collantes", pronouns: "she/her" },
+      { name: "Beatrice Yu", pronouns: "she/her" },
+      { name: "Sophia Kim", pronouns: "she/her" },
+      { name: "Natasha Kasunic", pronouns: "she/her" },
+      { name: "Niki Fereidooni", pronouns: "she/her" },
+    ],
+  },
+  {
+    title: "Community Volunteers",
+    members: [
+      { name: "Charu Idnani", pronouns: "she/her", role: "CodeDiversity" },
+      { name: "Garv Gupta", pronouns: "she/her", role: "General" },
+      { name: "Nhi Nguyen", pronouns: "she/her", role: "General, CodeDiversity" },
+      { name: "Rana Soyak", pronouns: "she/her", role: "General" },
+      { name: "John Malapit", pronouns: "he/him", role: "General, Sashimis (Sports)" },
+      { name: "Rohan Villoth", pronouns: "he/him", role: "General" },
+      { name: "Danyal Imran", pronouns: "he/him", role: "General" },
+      { name: "Justin Bento", pronouns: "he/him", role: "General" },
+    ],
+  },
+];

--- a/constants/team.ts
+++ b/constants/team.ts
@@ -71,7 +71,7 @@ export const teamGroups: TeamGroup[] = [
       { name: "Rohan Villoth", pronouns: "he/him" },
       { name: "Danyal Imran", pronouns: "he/him" },
       { name: "Justin Bento", pronouns: "he/him" },
-      { name: "Jyle V.", pronouns: "she/her" },
+      { name: "Jyle Vergara", pronouns: "she/her" },
       { name: "John Malapit", pronouns: "he/him" },
     ],
   },


### PR DESCRIPTION
don't review yet

## Summary

- Adds `/about/team` page with a tiered card design: poster-card style for board members, medium hover-lift cards for the core team, and compact tiles for website, social media, and volunteer groups
- All member data lives in `constants/team.ts` with typed `TeamMember` / `TeamGroup` interfaces — profile photos and bios can be filled in later
- Adds `app/about/layout.tsx` sticky sub-nav (TechTank / Team) mirroring the existing get-involved pattern, no route changes
- Adds an "About" section to the footer with TechTank and Team links; removes team link from other footer sections

## Test plan

- [ ] Visit `/about` — sub-nav visible, "TechTank" tab active
- [ ] Visit `/about/team` — sub-nav visible, "Team" tab active
- [ ] Check all team groups render with correct names, pronouns, and roles
- [ ] Verify footer "About" section shows TechTank and Team links
- [ ] Check light and dark mode on both pages
- [ ] Verify mobile layout on team page (compact tiles stack correctly)

## Screenshots

<details>
<summary>Preview — /about/team (iPad Pro)</summary>

<img width="2048" height="8630" alt="localhost_3000_about_team(iPad Pro) (3)" src="https://github.com/user-attachments/assets/a9fceb62-3548-466b-b2a6-9ab25f27871e" />

</details>