### PR TITLE
refactor(build): reduce turbopack bundle size

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  experimental: {
+    optimizePackageImports: ['lucide-react'],
+  },
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "TechTank TO - Toronto's tech community website",
   "type": "module",
   "private": true,
+  "sideEffects": false,
   "scripts": {
+    "analyze": "next experimental-analyze",
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
@@ -19,25 +21,27 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
-    "@tailwindcss/postcss": "^4.2.2",
-    "@types/node": "^25.6.0",
-    "@types/react": "^19.2.14",
-    "@types/react-dom": "^19.2.3",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
-    "autoprefixer": "^10.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",
     "next": "^16.2.4",
     "next-themes": "^0.4.6",
-    "postcss": "^8.5.10",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "tailwind-merge": "^3.5.0",
-    "tailwindcss": "^4.2.2",
-    "typescript": "^6.0.3",
     "zod": "^4.4.2",
     "zustand": "^5.0.12"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.2",
+    "@types/node": "^25.6.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "autoprefixer": "^10.5.0",
+    "postcss": "^8.5.10",
+    "tailwindcss": "^4.2.2",
+    "typescript": "^6.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,27 +16,12 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
-      '@tailwindcss/postcss':
-        specifier: ^4.2.2
-        version: 4.2.2
-      '@types/node':
-        specifier: ^25.6.0
-        version: 25.6.0
-      '@types/react':
-        specifier: ^19.2.14
-        version: 19.2.14
-      '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.14)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@vercel/speed-insights':
         specifier: ^2.0.0
         version: 2.0.0(next@16.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
-      autoprefixer:
-        specifier: ^10.5.0
-        version: 10.5.0(postcss@8.5.10)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -52,9 +37,6 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      postcss:
-        specifier: ^8.5.10
-        version: 8.5.10
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -64,18 +46,37 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
-      tailwindcss:
-        specifier: ^4.2.2
-        version: 4.2.2
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
       zod:
         specifier: ^4.4.2
         version: 4.4.2
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.5)
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.2.2
+        version: 4.2.2
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      autoprefixer:
+        specifier: ^10.5.0
+        version: 10.5.0(postcss@8.5.10)
+      postcss:
+        specifier: ^8.5.10
+        version: 8.5.10
+      tailwindcss:
+        specifier: ^4.2.2
+        version: 4.2.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 


### PR DESCRIPTION
# Summary

- reference doc for more details on turbopack optimizations https://nextjs.org/docs/app/guides/package-bundling
- you can run `pnpm analyze` and visit [`http://localhost:4000/`](http://localhost:4000/) to view the bundle visualization
- marked the icon library under [`optimizePackageImports`](https://nextjs.org/docs/app/guides/package-bundling#packages-with-many-exports) to only import icons that are used
- moved some dependencies to devDependencies as they are needed in the final build
- disable `sideEffects` to ensure more aggressive tree-shaking by turbopack
- added `analyze` commands to visually view bundle sizes

## Screenshots

**Client Builds Before 1.66mb**

<img width="2559" height="1295" alt="client_build_before" src="https://github.com/user-attachments/assets/efab5f96-9b73-4824-b879-0d6b1c52a775" />

**Client Builds After 1.40mb**

<img width="2559" height="1308" alt="client_build_after" src="https://github.com/user-attachments/assets/342e6237-4c1d-414c-8ad7-0fd4bc07f09e" />

## Checklist

- [x] No new TypeScript errors (`pnpm build` and `pnpm lint:fix` passes)
- [x] No placeholder content (`#`, `TODO`, Lorem Ipsum) left in production paths
- [x] Close the issue on merge
