### PR TITLE
style(design-system): overhaul theme system, gradient cascade, and design-system page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,8 @@ Components follow [shadcn/ui](https://ui.shadcn.com/) patterns with
 - Feature work happens on the branch specified in the session brief
   (currently `claude/techtank-toronto-prd-kuQxt`).
 - Create new commits rather than amending. Use HEREDOC commit messages.
-- Never force-push or skip hooks without explicit permission.
+- Never force-push to any branch, especially `main`. No exceptions.
+- Never skip hooks without explicit permission.
 - Do not open a pull request unless explicitly asked.
 - Do not sign commits or PRs as Claude, and do not include
   `claude.ai/code` session links, `Co-Authored-By: Claude` trailers,

--- a/app/about/team/page.tsx
+++ b/app/about/team/page.tsx
@@ -71,7 +71,7 @@ function AvatarSm({ name }: { name: string }) {
 
 function BoardCard({ name, pronouns, role, bio }: TeamMember) {
   return (
-    <div className="poster-card group relative overflow-hidden p-8 flex flex-col gap-6 shadow-soft-lg">
+    <div className="poster-card gradient-brand group relative overflow-hidden p-8 flex flex-col gap-6 shadow-soft-lg">
       {/* Decorative circle */}
       <div className="pointer-events-none absolute -top-8 -right-8 h-40 w-40 rounded-full bg-white/10 dark:bg-white/5" />
       <div className="pointer-events-none absolute -bottom-12 -left-6 h-32 w-32 rounded-full bg-white/10 dark:bg-white/5" />

--- a/app/globals.css
+++ b/app/globals.css
@@ -102,9 +102,8 @@
     var(--color-seafoam) 0%,
     #C9E4E5 22%,
     var(--color-sand) 45%,
-    #F2DCA8 65%,
-    var(--color-peach) 82%,
-    #F5C9B0 100%
+    #F4DFA8 82%,
+    #F2D870 100%
   );
 }
 
@@ -113,8 +112,7 @@
     180deg,
     var(--color-seafoam) 0%,
     var(--color-sand) 40%,
-    #F0D8A0 62%,
-    var(--color-peach) 100%
+    #F2DCA8 100%
   );
 }
 
@@ -124,7 +122,6 @@
     #B5DFE0 0%,
     #D4E8E5 20%,
     #F0E6DC 45%,
-    #F4DFA8 62%,
     #F5D4C1 80%,
     #F5C9B0 100%
   );
@@ -135,7 +132,6 @@
     135deg,
     #BEE0E2 0%,
     #F0E9E0 40%,
-    #F2DCA8 62%,
     #F5D4C1 100%
   );
 }
@@ -187,8 +183,7 @@
     #1A3D4A 0%,
     #1B4B5A 25%,
     #3A2E20 50%,
-    #352E18 68%,
-    #4A3018 100%
+    #352E18 100%
   );
 }
 
@@ -197,8 +192,7 @@
     180deg,
     #1A3D4A 0%,
     #2A3830 38%,
-    #352E18 62%,
-    #4A3018 100%
+    #352E18 100%
   );
 }
 
@@ -208,7 +202,6 @@
     #0B2E38 0%,
     #1A3D4A 22%,
     #2E3028 48%,
-    #352E18 66%,
     #4A2E1A 82%,
     #3A1E0E 100%
   );
@@ -219,7 +212,6 @@
     135deg,
     #1A3D4A 0%,
     #2A3028 38%,
-    #2E2A14 62%,
     #3A2818 100%
   );
 }
@@ -373,23 +365,6 @@
   position: relative;
   border-radius: var(--radius-xl);
   overflow: hidden;
-  background: linear-gradient(
-    145deg,
-    var(--color-seafoam) 0%,
-    var(--color-sand) 42%,
-    #F2DCA8 62%,
-    var(--color-peach) 100%
-  );
-}
-
-.dark .poster-card {
-  background: linear-gradient(
-    145deg,
-    #1A3D4A 0%,
-    #1B4B5A 38%,
-    #352E18 62%,
-    #0D2B35 100%
-  );
 }
 
 .poster-card::before {

--- a/app/globals.css
+++ b/app/globals.css
@@ -62,9 +62,18 @@
   --radius-xl: 1.75rem;
   --radius-2xl: 2rem;
   --radius-full: 9999px;
+
 }
 
 /* ─── Light Tokens & Gradients ─────────────────────────────────────────────── */
+
+/* Gradient defaults (light) — :root ensures var() resolves during SSR and before theme hydration */
+:root {
+  --gradient-brand: linear-gradient(135deg, #A8D5D8 0%, #C9E4E5 22%, #F7EDE2 45%, #F4DFA8 82%, #F2D870 100%);
+  --gradient-brand-vertical: linear-gradient(180deg, #A8D5D8 0%, #F7EDE2 40%, #F2DCA8 100%);
+  --gradient-hero: linear-gradient(160deg, #B5DFE0 0%, #D4E8E5 20%, #F0E6DC 45%, #F5D4C1 80%, #F5C9B0 100%);
+  --gradient-hero-soft: linear-gradient(135deg, #BEE0E2 0%, #F0E9E0 40%, #F5D4C1 100%);
+}
 
 .light {
   --color-background: #F9F6F2;
@@ -94,47 +103,17 @@
 
   --color-popover: #FFFFFF;
   --color-popover-foreground: #1B4B5A;
+
+  --gradient-brand: linear-gradient(135deg, #A8D5D8 0%, #C9E4E5 22%, #F7EDE2 45%, #F4DFA8 82%, #F2D870 100%);
+  --gradient-brand-vertical: linear-gradient(180deg, #A8D5D8 0%, #F7EDE2 40%, #F2DCA8 100%);
+  --gradient-hero: linear-gradient(160deg, #B5DFE0 0%, #D4E8E5 20%, #F0E6DC 45%, #F5D4C1 80%, #F5C9B0 100%);
+  --gradient-hero-soft: linear-gradient(135deg, #BEE0E2 0%, #F0E9E0 40%, #F5D4C1 100%);
 }
 
-.gradient-brand {
-  background: linear-gradient(
-    135deg,
-    var(--color-seafoam) 0%,
-    #C9E4E5 22%,
-    var(--color-sand) 45%,
-    #F4DFA8 82%,
-    #F2D870 100%
-  );
-}
-
-.gradient-brand-vertical {
-  background: linear-gradient(
-    180deg,
-    var(--color-seafoam) 0%,
-    var(--color-sand) 40%,
-    #F2DCA8 100%
-  );
-}
-
-.gradient-hero {
-  background: linear-gradient(
-    160deg,
-    #B5DFE0 0%,
-    #D4E8E5 20%,
-    #F0E6DC 45%,
-    #F5D4C1 80%,
-    #F5C9B0 100%
-  );
-}
-
-.gradient-brand-soft {
-  background: linear-gradient(
-    135deg,
-    #BEE0E2 0%,
-    #F0E9E0 40%,
-    #F5D4C1 100%
-  );
-}
+.gradient-brand          { background: var(--gradient-brand); }
+.gradient-brand-vertical { background: var(--gradient-brand-vertical); }
+.gradient-hero           { background: var(--gradient-hero); }
+.gradient-hero-soft      { background: var(--gradient-hero-soft); }
 
 .gradient-overlay-brand {
   background: linear-gradient(
@@ -175,45 +154,11 @@
 
   --color-popover: #1A3D4A;
   --color-popover-foreground: #E8F4F5;
-}
 
-.dark .gradient-brand {
-  background: linear-gradient(
-    135deg,
-    #1A3D4A 0%,
-    #1B4B5A 25%,
-    #3A2E20 50%,
-    #352E18 100%
-  );
-}
-
-.dark .gradient-brand-vertical {
-  background: linear-gradient(
-    180deg,
-    #1A3D4A 0%,
-    #2A3830 38%,
-    #352E18 100%
-  );
-}
-
-.dark .gradient-hero {
-  background: linear-gradient(
-    160deg,
-    #0B2E38 0%,
-    #1A3D4A 22%,
-    #2E3028 48%,
-    #4A2E1A 82%,
-    #3A1E0E 100%
-  );
-}
-
-.dark .gradient-brand-soft {
-  background: linear-gradient(
-    135deg,
-    #1A3D4A 0%,
-    #2A3028 38%,
-    #3A2818 100%
-  );
+  --gradient-brand: linear-gradient(135deg, #1A3D4A 0%, #1B4B5A 25%, #3A2E20 50%, #352E18 100%);
+  --gradient-brand-vertical: linear-gradient(180deg, #1A3D4A 0%, #2A3830 38%, #352E18 100%);
+  --gradient-hero: linear-gradient(160deg, #0B2E38 0%, #1A3D4A 22%, #2E3028 48%, #4A2E1A 82%, #3A1E0E 100%);
+  --gradient-hero-soft: linear-gradient(135deg, #1A3D4A 0%, #2A3028 38%, #3A2818 100%);
 }
 
 /* ─── Helper Classes ───────────────────────────────────────────────────────── */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -79,7 +79,7 @@ export default async function RootLayout({
       className={`${inter.variable} ${spaceGrotesk.variable} bg-background`}
     >
       <body className="min-h-screen flex flex-col font-sans antialiased">
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange themes={["light", "dark", "system"]}>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange themes={["light", "dark"]}>
           <Header />
           <main className="flex-1">{children}</main>
           <Footer />

--- a/app/resources/design-system/page.tsx
+++ b/app/resources/design-system/page.tsx
@@ -20,51 +20,51 @@ export const metadata: Metadata = {
 };
 
 const brandColors = [
-  { name: "teal", hex: "#2A6B7C", label: "Teal", usage: "Ring / focus, kicker labels" },
-  { name: "teal-dark", hex: "#1B4B5A", label: "Teal Dark", usage: "Primary (light mode)" },
-  { name: "amber", hex: "#FFBC55", label: "Amber", usage: "Warning / secondary CTA" },
-  { name: "amber-dark", hex: "#EFA020", label: "Amber Dark", usage: "Overlines, hover links" },
+  { name: "teal",       cls: "bg-teal",       label: "Teal",       hex: "#2A6B7C", usage: "Ring / focus, kicker labels" },
+  { name: "teal-dark",  cls: "bg-teal-dark",  label: "Teal Dark",  hex: "#1B4B5A", usage: "Primary (light mode)" },
+  { name: "amber",      cls: "bg-amber",      label: "Amber",      hex: "#FFBC55", usage: "Warning / secondary CTA" },
+  { name: "amber-dark", cls: "bg-amber-dark", label: "Amber Dark", hex: "#EFA020", usage: "Overlines, hover links" },
 ];
 
 const accentTokens = [
-  { name: "coral", hex: "#E87C4E", label: "Coral", usage: "Destructive / orange accent" },
-  { name: "mint", hex: "#5B9A8B", label: "Mint", usage: "Check icons, accent green" },
-  { name: "seafoam", hex: "#A8D5D8", label: "Seafoam", usage: "Secondary (light mode)" },
-  { name: "sand", hex: "#F7EDE2", label: "Sand", usage: "Warm off-white, gradients" },
-  { name: "peach", hex: "#F5D4C1", label: "Peach", usage: "Warm gradient base" },
-  { name: "blush", hex: "#EABFBF", label: "Blush", usage: "Pink accent" },
+  { name: "coral",   cls: "bg-coral",   label: "Coral",   hex: "#E87C4E", usage: "Destructive / orange accent" },
+  { name: "mint",    cls: "bg-mint",    label: "Mint",    hex: "#5B9A8B", usage: "Check icons, accent green" },
+  { name: "seafoam", cls: "bg-seafoam", label: "Seafoam", hex: "#A8D5D8", usage: "Secondary (light mode)" },
+  { name: "sand",    cls: "bg-sand",    label: "Sand",    hex: "#F7EDE2", usage: "Warm off-white, gradients" },
+  { name: "peach",   cls: "bg-peach",   label: "Peach",   hex: "#F5D4C1", usage: "Warm gradient base" },
+  { name: "blush",   cls: "bg-blush",   label: "Blush",   hex: "#EABFBF", usage: "Pink accent" },
 ];
 
 const semanticPairs = [
-  { bg: "background",   bgHex: "#F9F6F2",           darkBgHex: "#0D2B35",           bgAlias: "#F9F6F2",     darkBgAlias: "#0D2B35",
-    fg: "foreground",   fgHex: "#1B4B5A",           darkFgHex: "#E8F4F5",           fgAlias: "teal-dark",   darkFgAlias: "#E8F4F5" },
-  { bg: "muted",        bgHex: "#EBF3F4",           darkBgHex: "#1A3D4A",           bgAlias: "#EBF3F4",     darkBgAlias: "#1A3D4A",
-    fg: "muted-foreground", fgHex: "#4A6670",       darkFgHex: "#8BBEC6",           fgAlias: "#4A6670",     darkFgAlias: "#8BBEC6" },
-  { bg: "card",         bgHex: "rgba(255,255,255,0.7)", darkBgHex: "rgba(27,75,90,0.5)", bgAlias: "white / 70%", darkBgAlias: "teal-dark / 50%",
-    fg: "card-foreground", fgHex: "#1B4B5A",        darkFgHex: "#E8F4F5",           fgAlias: "teal-dark",   darkFgAlias: "#E8F4F5" },
-  { bg: "primary",      bgHex: "#1B4B5A",           darkBgHex: "#A8D5D8",           bgAlias: "teal-dark",   darkBgAlias: "seafoam",
-    fg: "primary-foreground", fgHex: "#FFFFFF",     darkFgHex: "#0D2B35",           fgAlias: "white",       darkFgAlias: "#0D2B35" },
-  { bg: "secondary",    bgHex: "#A8D5D8",           darkBgHex: "#1B4B5A",           bgAlias: "seafoam",     darkBgAlias: "teal-dark",
-    fg: "secondary-foreground", fgHex: "#1B4B5A",   darkFgHex: "#A8D5D8",           fgAlias: "teal-dark",   darkFgAlias: "seafoam" },
-  { bg: "accent",       bgHex: "#D4ECEE",           darkBgHex: "#1E4A58",           bgAlias: "seafoam / 20%", darkBgAlias: "#1E4A58",
-    fg: "accent-foreground", fgHex: "#1B4B5A",      darkFgHex: "#A8D5D8",           fgAlias: "teal-dark",   darkFgAlias: "seafoam" },
-  { bg: "destructive",  bgHex: "#E87C4E",           darkBgHex: "#E87C4E",           bgAlias: "coral",       darkBgAlias: "coral",
-    fg: "destructive-foreground", fgHex: "#FFFFFF",  darkFgHex: "#FFFFFF",           fgAlias: "white",       darkFgAlias: "white" },
-  { bg: "warning",      bgHex: "#FFBC55",           darkBgHex: "#FFBC55",           bgAlias: "amber",       darkBgAlias: "amber",
-    fg: "warning-foreground", fgHex: "#1B4B5A",     darkFgHex: "#1B4B5A",           fgAlias: "teal-dark",   darkFgAlias: "teal-dark" },
+  { bg: "background",  bgCls: "bg-background",  bgAlias: "#F9F6F2",       darkBgAlias: "#0D2B35",
+    fg: "foreground",  fgCls: "bg-[var(--color-foreground)]",  fgAlias: "teal-dark",    darkFgAlias: "#E8F4F5" },
+  { bg: "muted",       bgCls: "bg-muted",        bgAlias: "#EBF3F4",       darkBgAlias: "#1A3D4A",
+    fg: "muted-foreground",  fgCls: "bg-[var(--color-muted-foreground)]",  fgAlias: "#4A6670",     darkFgAlias: "#8BBEC6" },
+  { bg: "card",        bgCls: "bg-card",         bgAlias: "white / 70%",   darkBgAlias: "teal-dark / 50%",
+    fg: "card-foreground",   fgCls: "bg-[var(--color-card-foreground)]",   fgAlias: "teal-dark",    darkFgAlias: "#E8F4F5" },
+  { bg: "primary",     bgCls: "bg-primary",      bgAlias: "teal-dark",     darkBgAlias: "seafoam",
+    fg: "primary-foreground",  fgCls: "bg-[var(--color-primary-foreground)]",  fgAlias: "white",   darkFgAlias: "#0D2B35" },
+  { bg: "secondary",   bgCls: "bg-secondary",    bgAlias: "seafoam",       darkBgAlias: "teal-dark",
+    fg: "secondary-foreground",  fgCls: "bg-[var(--color-secondary-foreground)]",  fgAlias: "teal-dark",  darkFgAlias: "seafoam" },
+  { bg: "accent",      bgCls: "bg-accent",       bgAlias: "seafoam / 20%", darkBgAlias: "#1E4A58",
+    fg: "accent-foreground",   fgCls: "bg-[var(--color-accent-foreground)]",   fgAlias: "teal-dark",   darkFgAlias: "seafoam" },
+  { bg: "destructive", bgCls: "bg-destructive",  bgAlias: "coral",         darkBgAlias: "coral",
+    fg: "destructive-foreground",  fgCls: "bg-[var(--color-destructive-foreground)]",  fgAlias: "white",  darkFgAlias: "white" },
+  { bg: "warning",     bgCls: "bg-warning",      bgAlias: "amber",         darkBgAlias: "amber",
+    fg: "warning-foreground",  fgCls: "bg-[var(--color-warning-foreground)]",  fgAlias: "teal-dark",   darkFgAlias: "teal-dark" },
 ];
 
 const semanticUtilities = [
-  { token: "border", lightHex: "rgba(27,75,90,0.12)",  darkHex: "rgba(168,213,216,0.15)", lightAlias: "teal-dark / 12%", darkAlias: "seafoam / 15%" },
-  { token: "ring",   lightHex: "#2A6B7C",              darkHex: "#A8D5D8",                lightAlias: "teal",            darkAlias: "seafoam" },
-  { token: "input",  lightHex: "rgba(27,75,90,0.18)",  darkHex: "rgba(168,213,216,0.2)",  lightAlias: "teal-dark / 18%", darkAlias: "seafoam / 20%" },
+  { token: "border", bgCls: "bg-border", lightAlias: "teal-dark / 12%", darkAlias: "seafoam / 15%" },
+  { token: "ring",   bgCls: "bg-ring",   lightAlias: "teal",            darkAlias: "seafoam" },
+  { token: "input",  bgCls: "bg-input",  lightAlias: "teal-dark / 18%", darkAlias: "seafoam / 20%" },
 ];
 
 const gradients = [
-  { cls: "gradient-brand texture-grain", label: ".gradient-brand", desc: "135° — seafoam → sand → peach" },
+  { cls: "gradient-brand texture-grain",          label: ".gradient-brand",          desc: "135° — seafoam → sand → peach" },
   { cls: "gradient-brand-vertical texture-grain", label: ".gradient-brand-vertical", desc: "180° vertical — seafoam → sand → peach" },
-  { cls: "gradient-hero texture-grain", label: ".gradient-hero", desc: "160° — aqua → warm off-white → peach" },
-  { cls: "gradient-hero-soft", label: ".gradient-hero-soft", desc: "Soft brand gradient for CTA sections" },
+  { cls: "gradient-hero texture-grain",           label: ".gradient-hero",           desc: "160° — aqua → warm off-white → peach" },
+  { cls: "gradient-hero-soft",                    label: ".gradient-hero-soft",      desc: "Soft brand gradient for CTA sections" },
 ];
 
 export default function DesignSystemPage() {
@@ -98,7 +98,7 @@ export default function DesignSystemPage() {
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-px bg-border rounded-xl overflow-hidden border border-border">
               {brandColors.map((color) => (
                 <div key={color.name} className="bg-background">
-                  <div className="h-14" style={{ backgroundColor: color.hex }} />
+                  <div className={`h-14 ${color.cls}`} />
                   <div className="px-3 py-2.5">
                     <p className="text-xs font-medium text-foreground">{color.label}</p>
                     <code className="text-[10px] text-muted-foreground">{color.hex}</code>
@@ -115,7 +115,7 @@ export default function DesignSystemPage() {
             <div className="grid grid-cols-3 sm:grid-cols-6 gap-px bg-border rounded-xl overflow-hidden border border-border">
               {accentTokens.map((color) => (
                 <div key={color.name} className="bg-background">
-                  <div className="h-14" style={{ backgroundColor: color.hex }} />
+                  <div className={`h-14 ${color.cls}`} />
                   <div className="px-3 py-2.5">
                     <p className="text-xs font-medium text-foreground">{color.label}</p>
                     <code className="text-[10px] text-muted-foreground">{color.hex}</code>
@@ -137,65 +137,65 @@ export default function DesignSystemPage() {
 
         <div className="grid lg:grid-cols-2 gap-5">
           {/* Light panel */}
-          <div className="rounded-xl overflow-hidden border border-border" style={{ backgroundColor: "#F9F6F2" }}>
-            <div className="flex items-center gap-2 px-4 py-3 border-b" style={{ borderColor: "rgba(27,75,90,0.12)" }}>
-              <div className="h-2.5 w-2.5 rounded-full border" style={{ backgroundColor: "#F9F6F2", borderColor: "rgba(27,75,90,0.3)" }} />
-              <span className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#4A6670" }}>Light mode</span>
+          <div className="light rounded-xl overflow-hidden border border-border bg-background">
+            <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+              <div className="h-2.5 w-2.5 rounded-full bg-background border border-foreground/30" />
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Light mode</span>
             </div>
             {semanticPairs.map((pair) => (
-              <div key={pair.bg} className="px-4 py-2.5 border-b" style={{ borderColor: "rgba(27,75,90,0.07)" }}>
+              <div key={pair.bg} className="px-4 py-2.5 border-b border-border/60">
                 <div className="flex items-center gap-2.5 mb-1.5">
-                  <div className="h-4 w-4 rounded-[3px] border border-black/8 shrink-0" style={{ backgroundColor: pair.bgHex }} />
-                  <code className="text-[11px] font-semibold flex-1" style={{ color: "#1B4B5A" }}>bg-{pair.bg}</code>
-                  <span className="text-[10px] font-mono" style={{ color: "#6B8A92" }}>{pair.bgAlias}</span>
+                  <div className={`h-4 w-4 rounded-[3px] border border-foreground/20 shrink-0 ${pair.bgCls}`} />
+                  <code className="text-[11px] font-semibold flex-1 text-foreground">bg-{pair.bg}</code>
+                  <span className="text-[10px] font-mono text-muted-foreground">{pair.bgAlias}</span>
                 </div>
                 <div className="flex items-center gap-2.5">
-                  <div className="h-4 w-4 rounded-[3px] border border-black/8 shrink-0" style={{ backgroundColor: pair.fgHex }} />
-                  <code className="text-[11px] flex-1" style={{ color: "#4A6670" }}>text-{pair.fg}</code>
-                  <span className="text-[10px] font-mono" style={{ color: "#6B8A92" }}>{pair.fgAlias}</span>
+                  <div className={`h-4 w-4 rounded-[3px] border border-foreground/20 shrink-0 ${pair.fgCls}`} />
+                  <code className="text-[11px] flex-1 text-muted-foreground">text-{pair.fg}</code>
+                  <span className="text-[10px] font-mono text-muted-foreground">{pair.fgAlias}</span>
                 </div>
               </div>
             ))}
-            <div className="px-4 pt-3 pb-1 border-t" style={{ borderColor: "rgba(27,75,90,0.12)" }}>
-              <p className="text-[10px] font-semibold uppercase tracking-widest mb-2" style={{ color: "#4A6670" }}>Utilities</p>
+            <div className="px-4 pt-3 pb-1 border-t border-border">
+              <p className="text-[10px] font-semibold uppercase tracking-widest mb-2 text-muted-foreground">Utilities</p>
             </div>
             {semanticUtilities.map((u, i) => (
               <div key={u.token} className={`flex items-center gap-2.5 px-4 py-2${i === semanticUtilities.length - 1 ? " pb-4" : ""}`}>
-                <div className="h-4 w-4 rounded-[3px] border shrink-0" style={{ backgroundColor: u.lightHex, borderColor: "rgba(27,75,90,0.15)" }} />
-                <code className="text-[11px] font-semibold flex-1" style={{ color: "#1B4B5A" }}>{u.token}</code>
-                <span className="text-[10px] font-mono" style={{ color: "#6B8A92" }}>{u.lightAlias}</span>
+                <div className={`h-4 w-4 rounded-[3px] border border-foreground/20 shrink-0 ${u.bgCls}`} />
+                <code className="text-[11px] font-semibold flex-1 text-foreground">{u.token}</code>
+                <span className="text-[10px] font-mono text-muted-foreground">{u.lightAlias}</span>
               </div>
             ))}
           </div>
 
           {/* Dark panel */}
-          <div className="rounded-xl overflow-hidden border border-border" style={{ backgroundColor: "#0D2B35" }}>
-            <div className="flex items-center gap-2 px-4 py-3 border-b" style={{ borderColor: "rgba(168,213,216,0.12)" }}>
-              <div className="h-2.5 w-2.5 rounded-full border" style={{ backgroundColor: "#0D2B35", borderColor: "rgba(168,213,216,0.4)" }} />
-              <span className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#8BBEC6" }}>Dark mode</span>
+          <div className="dark rounded-xl overflow-hidden border border-border bg-background">
+            <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+              <div className="h-2.5 w-2.5 rounded-full bg-background border border-foreground/30" />
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Dark mode</span>
             </div>
             {semanticPairs.map((pair) => (
-              <div key={pair.bg} className="px-4 py-2.5 border-b" style={{ borderColor: "rgba(168,213,216,0.07)" }}>
+              <div key={pair.bg} className="px-4 py-2.5 border-b border-border/60">
                 <div className="flex items-center gap-2.5 mb-1.5">
-                  <div className="h-4 w-4 rounded-[3px] border border-white/10 shrink-0" style={{ backgroundColor: pair.darkBgHex }} />
-                  <code className="text-[11px] font-semibold flex-1" style={{ color: "#E8F4F5" }}>bg-{pair.bg}</code>
-                  <span className="text-[10px] font-mono" style={{ color: "#6B9EA6" }}>{pair.darkBgAlias}</span>
+                  <div className={`h-4 w-4 rounded-[3px] border border-foreground/20 shrink-0 ${pair.bgCls}`} />
+                  <code className="text-[11px] font-semibold flex-1 text-foreground">bg-{pair.bg}</code>
+                  <span className="text-[10px] font-mono text-muted-foreground">{pair.darkBgAlias}</span>
                 </div>
                 <div className="flex items-center gap-2.5">
-                  <div className="h-4 w-4 rounded-[3px] border border-white/10 shrink-0" style={{ backgroundColor: pair.darkFgHex }} />
-                  <code className="text-[11px] flex-1" style={{ color: "#8BBEC6" }}>text-{pair.fg}</code>
-                  <span className="text-[10px] font-mono" style={{ color: "#6B9EA6" }}>{pair.darkFgAlias}</span>
+                  <div className={`h-4 w-4 rounded-[3px] border border-foreground/20 shrink-0 ${pair.fgCls}`} />
+                  <code className="text-[11px] flex-1 text-muted-foreground">text-{pair.fg}</code>
+                  <span className="text-[10px] font-mono text-muted-foreground">{pair.darkFgAlias}</span>
                 </div>
               </div>
             ))}
-            <div className="px-4 pt-3 pb-1 border-t" style={{ borderColor: "rgba(168,213,216,0.12)" }}>
-              <p className="text-[10px] font-semibold uppercase tracking-widest mb-2" style={{ color: "#8BBEC6" }}>Utilities</p>
+            <div className="px-4 pt-3 pb-1 border-t border-border">
+              <p className="text-[10px] font-semibold uppercase tracking-widest mb-2 text-muted-foreground">Utilities</p>
             </div>
             {semanticUtilities.map((u, i) => (
               <div key={u.token} className={`flex items-center gap-2.5 px-4 py-2${i === semanticUtilities.length - 1 ? " pb-4" : ""}`}>
-                <div className="h-4 w-4 rounded-[3px] border shrink-0" style={{ backgroundColor: u.darkHex, borderColor: "rgba(168,213,216,0.2)" }} />
-                <code className="text-[11px] font-semibold flex-1" style={{ color: "#E8F4F5" }}>{u.token}</code>
-                <span className="text-[10px] font-mono" style={{ color: "#6B9EA6" }}>{u.darkAlias}</span>
+                <div className={`h-4 w-4 rounded-[3px] border border-foreground/20 shrink-0 ${u.bgCls}`} />
+                <code className="text-[11px] font-semibold flex-1 text-foreground">{u.token}</code>
+                <span className="text-[10px] font-mono text-muted-foreground">{u.darkAlias}</span>
               </div>
             ))}
           </div>
@@ -212,17 +212,17 @@ export default function DesignSystemPage() {
         <div className="grid lg:grid-cols-2 gap-5">
           {/* Light panel */}
           <div className="light rounded-xl overflow-hidden border border-border">
-            <div className="flex items-center gap-2 px-4 py-3 border-b" style={{ backgroundColor: "#F9F6F2", borderColor: "rgba(27,75,90,0.12)" }}>
-              <div className="h-2.5 w-2.5 rounded-full border" style={{ backgroundColor: "#F9F6F2", borderColor: "rgba(27,75,90,0.3)" }} />
-              <span className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#4A6670" }}>Light mode</span>
+            <div className="flex items-center gap-2 px-4 py-3 border-b border-border bg-background">
+              <div className="h-2.5 w-2.5 rounded-full bg-background border border-foreground/30" />
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Light mode</span>
             </div>
-            <div className="grid grid-cols-2 gap-px" style={{ backgroundColor: "rgba(27,75,90,0.07)" }}>
-              {gradients.map((g) => (
-                <div key={g.label} style={{ backgroundColor: "#F9F6F2" }}>
+            <div className="grid grid-cols-2">
+              {gradients.map((g, i) => (
+                <div key={g.label} className={`bg-background${i % 2 === 0 ? " border-r border-border" : ""}${i < 2 ? " border-b border-border" : ""}`}>
                   <div className={`h-28 w-full ${g.cls}`} />
                   <div className="px-3 py-2.5">
-                    <code className="text-[11px] font-semibold block" style={{ color: "#1B4B5A" }}>{g.label}</code>
-                    <p className="text-[10px] mt-0.5 leading-tight" style={{ color: "#4A6670" }}>{g.desc}</p>
+                    <code className="text-[11px] font-semibold block text-foreground">{g.label}</code>
+                    <p className="text-[10px] mt-0.5 leading-tight text-muted-foreground">{g.desc}</p>
                   </div>
                 </div>
               ))}
@@ -230,18 +230,18 @@ export default function DesignSystemPage() {
           </div>
 
           {/* Dark panel */}
-          <div className="dark rounded-xl overflow-hidden border border-[rgba(168,213,216,0.15)]">
-            <div className="flex items-center gap-2 px-4 py-3 border-b" style={{ backgroundColor: "#0D2B35", borderColor: "rgba(168,213,216,0.12)" }}>
-              <div className="h-2.5 w-2.5 rounded-full border" style={{ backgroundColor: "#0D2B35", borderColor: "rgba(168,213,216,0.4)" }} />
-              <span className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#8BBEC6" }}>Dark mode</span>
+          <div className="dark rounded-xl overflow-hidden border border-border">
+            <div className="flex items-center gap-2 px-4 py-3 border-b border-border bg-background">
+              <div className="h-2.5 w-2.5 rounded-full bg-background border border-foreground/30" />
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Dark mode</span>
             </div>
-            <div className="grid grid-cols-2 gap-px" style={{ backgroundColor: "rgba(168,213,216,0.07)" }}>
-              {gradients.map((g) => (
-                <div key={g.label} style={{ backgroundColor: "#0D2B35" }}>
+            <div className="grid grid-cols-2">
+              {gradients.map((g, i) => (
+                <div key={g.label} className={`bg-background${i % 2 === 0 ? " border-r border-border" : ""}${i < 2 ? " border-b border-border" : ""}`}>
                   <div className={`h-28 w-full ${g.cls}`} />
                   <div className="px-3 py-2.5">
-                    <code className="text-[11px] font-semibold block" style={{ color: "#E8F4F5" }}>{g.label}</code>
-                    <p className="text-[10px] mt-0.5 leading-tight" style={{ color: "#8BBEC6" }}>{g.desc}</p>
+                    <code className="text-[11px] font-semibold block text-foreground">{g.label}</code>
+                    <p className="text-[10px] mt-0.5 leading-tight text-muted-foreground">{g.desc}</p>
                   </div>
                 </div>
               ))}

--- a/app/resources/design-system/page.tsx
+++ b/app/resources/design-system/page.tsx
@@ -36,27 +36,35 @@ const accentTokens = [
 ];
 
 const semanticPairs = [
-  { bg: "background", bgHex: "#F9F6F2", darkBgHex: "#0D2B35", fg: "foreground", fgHex: "#1B4B5A", darkFgHex: "#E8F4F5", role: "Page background / body text" },
-  { bg: "muted", bgHex: "#EBF3F4", darkBgHex: "#1A3D4A", fg: "muted-foreground", fgHex: "#4A6670", darkFgHex: "#8BBEC6", role: "De-emphasized surface / secondary text" },
-  { bg: "card", bgHex: "rgba(255,255,255,0.7)", darkBgHex: "rgba(27,75,90,0.5)", fg: "card-foreground", fgHex: "#1B4B5A", darkFgHex: "#E8F4F5", role: "Glass card surface" },
-  { bg: "primary", bgHex: "#1B4B5A", darkBgHex: "#A8D5D8", fg: "primary-foreground", fgHex: "#FFFFFF", darkFgHex: "#0D2B35", role: "Primary actions, buttons" },
-  { bg: "secondary", bgHex: "#A8D5D8", darkBgHex: "#1B4B5A", fg: "secondary-foreground", fgHex: "#1B4B5A", darkFgHex: "#A8D5D8", role: "Secondary actions, icon fills" },
-  { bg: "accent", bgHex: "#D4ECEE", darkBgHex: "#1E4A58", fg: "accent-foreground", fgHex: "#1B4B5A", darkFgHex: "#A8D5D8", role: "Hover / active highlight states" },
-  { bg: "destructive", bgHex: "#E87C4E", darkBgHex: "#E87C4E", fg: "destructive-foreground", fgHex: "#FFFFFF", darkFgHex: "#FFFFFF", role: "Errors, destructive actions" },
-  { bg: "warning", bgHex: "#FFBC55", darkBgHex: "#FFBC55", fg: "warning-foreground", fgHex: "#1B4B5A", darkFgHex: "#1B4B5A", role: "Upcoming, caution states" },
+  { bg: "background",   bgHex: "#F9F6F2",           darkBgHex: "#0D2B35",           bgAlias: "#F9F6F2",     darkBgAlias: "#0D2B35",
+    fg: "foreground",   fgHex: "#1B4B5A",           darkFgHex: "#E8F4F5",           fgAlias: "teal-dark",   darkFgAlias: "#E8F4F5" },
+  { bg: "muted",        bgHex: "#EBF3F4",           darkBgHex: "#1A3D4A",           bgAlias: "#EBF3F4",     darkBgAlias: "#1A3D4A",
+    fg: "muted-foreground", fgHex: "#4A6670",       darkFgHex: "#8BBEC6",           fgAlias: "#4A6670",     darkFgAlias: "#8BBEC6" },
+  { bg: "card",         bgHex: "rgba(255,255,255,0.7)", darkBgHex: "rgba(27,75,90,0.5)", bgAlias: "white / 70%", darkBgAlias: "teal-dark / 50%",
+    fg: "card-foreground", fgHex: "#1B4B5A",        darkFgHex: "#E8F4F5",           fgAlias: "teal-dark",   darkFgAlias: "#E8F4F5" },
+  { bg: "primary",      bgHex: "#1B4B5A",           darkBgHex: "#A8D5D8",           bgAlias: "teal-dark",   darkBgAlias: "seafoam",
+    fg: "primary-foreground", fgHex: "#FFFFFF",     darkFgHex: "#0D2B35",           fgAlias: "white",       darkFgAlias: "#0D2B35" },
+  { bg: "secondary",    bgHex: "#A8D5D8",           darkBgHex: "#1B4B5A",           bgAlias: "seafoam",     darkBgAlias: "teal-dark",
+    fg: "secondary-foreground", fgHex: "#1B4B5A",   darkFgHex: "#A8D5D8",           fgAlias: "teal-dark",   darkFgAlias: "seafoam" },
+  { bg: "accent",       bgHex: "#D4ECEE",           darkBgHex: "#1E4A58",           bgAlias: "seafoam / 20%", darkBgAlias: "#1E4A58",
+    fg: "accent-foreground", fgHex: "#1B4B5A",      darkFgHex: "#A8D5D8",           fgAlias: "teal-dark",   darkFgAlias: "seafoam" },
+  { bg: "destructive",  bgHex: "#E87C4E",           darkBgHex: "#E87C4E",           bgAlias: "coral",       darkBgAlias: "coral",
+    fg: "destructive-foreground", fgHex: "#FFFFFF",  darkFgHex: "#FFFFFF",           fgAlias: "white",       darkFgAlias: "white" },
+  { bg: "warning",      bgHex: "#FFBC55",           darkBgHex: "#FFBC55",           bgAlias: "amber",       darkBgAlias: "amber",
+    fg: "warning-foreground", fgHex: "#1B4B5A",     darkFgHex: "#1B4B5A",           fgAlias: "teal-dark",   darkFgAlias: "teal-dark" },
 ];
 
 const semanticUtilities = [
-  { token: "border", lightHex: "rgba(27,75,90,0.12)", darkHex: "rgba(168,213,216,0.15)", role: "Dividers, card borders" },
-  { token: "ring", lightHex: "#2A6B7C", darkHex: "#A8D5D8", role: "Focus ring (keyboard nav)" },
-  { token: "input", lightHex: "rgba(27,75,90,0.18)", darkHex: "rgba(168,213,216,0.2)", role: "Input field borders" },
+  { token: "border", lightHex: "rgba(27,75,90,0.12)",  darkHex: "rgba(168,213,216,0.15)", lightAlias: "teal-dark / 12%", darkAlias: "seafoam / 15%" },
+  { token: "ring",   lightHex: "#2A6B7C",              darkHex: "#A8D5D8",                lightAlias: "teal",            darkAlias: "seafoam" },
+  { token: "input",  lightHex: "rgba(27,75,90,0.18)",  darkHex: "rgba(168,213,216,0.2)",  lightAlias: "teal-dark / 18%", darkAlias: "seafoam / 20%" },
 ];
 
 const gradients = [
   { cls: "gradient-brand texture-grain", label: ".gradient-brand", desc: "135° — seafoam → sand → peach" },
   { cls: "gradient-brand-vertical texture-grain", label: ".gradient-brand-vertical", desc: "180° vertical — seafoam → sand → peach" },
-  { cls: "gradient-hero texture-grain", label: ".gradient-hero", desc: "160° hero — aqua → warm off-white → peach" },
-  { cls: "gradient-brand-soft", label: ".gradient-brand-soft", desc: "Soft brand gradient for CTA sections" },
+  { cls: "gradient-hero texture-grain", label: ".gradient-hero", desc: "160° — aqua → warm off-white → peach" },
+  { cls: "gradient-hero-soft", label: ".gradient-hero-soft", desc: "Soft brand gradient for CTA sections" },
 ];
 
 export default function DesignSystemPage() {
@@ -79,117 +87,171 @@ export default function DesignSystemPage() {
         </div>
       </section>
 
-      {/* Colors — Brand */}
+      {/* Color palette */}
       <Section>
-        <SectionHeader overline="Colors" title="Brand palette" className="mb-12" />
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {brandColors.map((color) => (
-            <div key={color.name} className="bg-card rounded-xl border border-border overflow-hidden">
-              <div className="h-20" style={{ backgroundColor: color.hex }} />
-              <div className="p-4">
-                <div className="flex items-center justify-between mb-1">
-                  <p className="font-semibold text-foreground">{color.label}</p>
-                  <code className="text-xs text-muted-foreground">{color.hex}</code>
+        <SectionHeader overline="Colors" title="Color palette" className="mb-8" />
+
+        <div className="space-y-6">
+          {/* Brand */}
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-2">Brand</p>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-px bg-border rounded-xl overflow-hidden border border-border">
+              {brandColors.map((color) => (
+                <div key={color.name} className="bg-background">
+                  <div className="h-14" style={{ backgroundColor: color.hex }} />
+                  <div className="px-3 py-2.5">
+                    <p className="text-xs font-medium text-foreground">{color.label}</p>
+                    <code className="text-[10px] text-muted-foreground">{color.hex}</code>
+                    <p className="text-[10px] text-muted-foreground mt-0.5 leading-tight">{color.usage}</p>
+                  </div>
                 </div>
-                <p className="text-xs text-muted-foreground">{color.usage}</p>
-                <code className="text-xs text-ring/70 mt-1 block">bg-{color.name} / text-{color.name}</code>
-              </div>
+              ))}
             </div>
-          ))}
+          </div>
+
+          {/* Accent */}
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-2">Accent</p>
+            <div className="grid grid-cols-3 sm:grid-cols-6 gap-px bg-border rounded-xl overflow-hidden border border-border">
+              {accentTokens.map((color) => (
+                <div key={color.name} className="bg-background">
+                  <div className="h-14" style={{ backgroundColor: color.hex }} />
+                  <div className="px-3 py-2.5">
+                    <p className="text-xs font-medium text-foreground">{color.label}</p>
+                    <code className="text-[10px] text-muted-foreground">{color.hex}</code>
+                    <p className="text-[10px] text-muted-foreground mt-0.5 leading-tight">{color.usage}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </Section>
 
-      {/* Colors — Accent */}
-      <Section background="white">
-        <SectionHeader overline="Colors" title="Accent tokens" className="mb-12" />
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {accentTokens.map((color) => (
-            <div key={color.name} className="bg-background rounded-xl border border-border overflow-hidden">
-              <div className="h-20" style={{ backgroundColor: color.hex }} />
-              <div className="p-4">
-                <div className="flex items-center justify-between mb-1">
-                  <p className="font-semibold text-foreground">{color.label}</p>
-                  <code className="text-xs text-muted-foreground">{color.hex}</code>
-                </div>
-                <p className="text-xs text-muted-foreground">{color.usage}</p>
-                <code className="text-xs text-ring/70 mt-1 block">bg-{color.name} / text-{color.name}</code>
-              </div>
+      {/* Semantic tokens */}
+      <Section background="muted">
+        <SectionHeader overline="Theming" title="Semantic tokens" className="mb-4" />
+        <p className="text-sm text-muted-foreground mb-8 max-w-2xl">
+          Every token resolves differently in light and dark mode. Never use raw brand hex values for text, surfaces, or borders in components — always use the semantic name.
+        </p>
+
+        <div className="grid lg:grid-cols-2 gap-5">
+          {/* Light panel */}
+          <div className="rounded-xl overflow-hidden border border-border" style={{ backgroundColor: "#F9F6F2" }}>
+            <div className="flex items-center gap-2 px-4 py-3 border-b" style={{ borderColor: "rgba(27,75,90,0.12)" }}>
+              <div className="h-2.5 w-2.5 rounded-full border" style={{ backgroundColor: "#F9F6F2", borderColor: "rgba(27,75,90,0.3)" }} />
+              <span className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#4A6670" }}>Light mode</span>
             </div>
-          ))}
+            {semanticPairs.map((pair) => (
+              <div key={pair.bg} className="px-4 py-2.5 border-b" style={{ borderColor: "rgba(27,75,90,0.07)" }}>
+                <div className="flex items-center gap-2.5 mb-1.5">
+                  <div className="h-4 w-4 rounded-[3px] border border-black/8 shrink-0" style={{ backgroundColor: pair.bgHex }} />
+                  <code className="text-[11px] font-semibold flex-1" style={{ color: "#1B4B5A" }}>bg-{pair.bg}</code>
+                  <span className="text-[10px] font-mono" style={{ color: "#6B8A92" }}>{pair.bgAlias}</span>
+                </div>
+                <div className="flex items-center gap-2.5">
+                  <div className="h-4 w-4 rounded-[3px] border border-black/8 shrink-0" style={{ backgroundColor: pair.fgHex }} />
+                  <code className="text-[11px] flex-1" style={{ color: "#4A6670" }}>text-{pair.fg}</code>
+                  <span className="text-[10px] font-mono" style={{ color: "#6B8A92" }}>{pair.fgAlias}</span>
+                </div>
+              </div>
+            ))}
+            <div className="px-4 pt-3 pb-1 border-t" style={{ borderColor: "rgba(27,75,90,0.12)" }}>
+              <p className="text-[10px] font-semibold uppercase tracking-widest mb-2" style={{ color: "#4A6670" }}>Utilities</p>
+            </div>
+            {semanticUtilities.map((u, i) => (
+              <div key={u.token} className={`flex items-center gap-2.5 px-4 py-2${i === semanticUtilities.length - 1 ? " pb-4" : ""}`}>
+                <div className="h-4 w-4 rounded-[3px] border shrink-0" style={{ backgroundColor: u.lightHex, borderColor: "rgba(27,75,90,0.15)" }} />
+                <code className="text-[11px] font-semibold flex-1" style={{ color: "#1B4B5A" }}>{u.token}</code>
+                <span className="text-[10px] font-mono" style={{ color: "#6B8A92" }}>{u.lightAlias}</span>
+              </div>
+            ))}
+          </div>
+
+          {/* Dark panel */}
+          <div className="rounded-xl overflow-hidden border border-border" style={{ backgroundColor: "#0D2B35" }}>
+            <div className="flex items-center gap-2 px-4 py-3 border-b" style={{ borderColor: "rgba(168,213,216,0.12)" }}>
+              <div className="h-2.5 w-2.5 rounded-full border" style={{ backgroundColor: "#0D2B35", borderColor: "rgba(168,213,216,0.4)" }} />
+              <span className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#8BBEC6" }}>Dark mode</span>
+            </div>
+            {semanticPairs.map((pair) => (
+              <div key={pair.bg} className="px-4 py-2.5 border-b" style={{ borderColor: "rgba(168,213,216,0.07)" }}>
+                <div className="flex items-center gap-2.5 mb-1.5">
+                  <div className="h-4 w-4 rounded-[3px] border border-white/10 shrink-0" style={{ backgroundColor: pair.darkBgHex }} />
+                  <code className="text-[11px] font-semibold flex-1" style={{ color: "#E8F4F5" }}>bg-{pair.bg}</code>
+                  <span className="text-[10px] font-mono" style={{ color: "#6B9EA6" }}>{pair.darkBgAlias}</span>
+                </div>
+                <div className="flex items-center gap-2.5">
+                  <div className="h-4 w-4 rounded-[3px] border border-white/10 shrink-0" style={{ backgroundColor: pair.darkFgHex }} />
+                  <code className="text-[11px] flex-1" style={{ color: "#8BBEC6" }}>text-{pair.fg}</code>
+                  <span className="text-[10px] font-mono" style={{ color: "#6B9EA6" }}>{pair.darkFgAlias}</span>
+                </div>
+              </div>
+            ))}
+            <div className="px-4 pt-3 pb-1 border-t" style={{ borderColor: "rgba(168,213,216,0.12)" }}>
+              <p className="text-[10px] font-semibold uppercase tracking-widest mb-2" style={{ color: "#8BBEC6" }}>Utilities</p>
+            </div>
+            {semanticUtilities.map((u, i) => (
+              <div key={u.token} className={`flex items-center gap-2.5 px-4 py-2${i === semanticUtilities.length - 1 ? " pb-4" : ""}`}>
+                <div className="h-4 w-4 rounded-[3px] border shrink-0" style={{ backgroundColor: u.darkHex, borderColor: "rgba(168,213,216,0.2)" }} />
+                <code className="text-[11px] font-semibold flex-1" style={{ color: "#E8F4F5" }}>{u.token}</code>
+                <span className="text-[10px] font-mono" style={{ color: "#6B9EA6" }}>{u.darkAlias}</span>
+              </div>
+            ))}
+          </div>
         </div>
       </Section>
 
-      {/* Semantic Tokens & Gradients */}
+      {/* Gradient utilities */}
       <Section>
-        <SectionHeader overline="Theming" title="Semantic tokens &amp; gradients" className="mb-4" />
-        <p className="text-sm text-muted-foreground mb-10 max-w-2xl">
-          Every semantic token adapts across <code className="text-xs bg-muted px-1 py-0.5 rounded">.light</code> and{" "}
-          <code className="text-xs bg-muted px-1 py-0.5 rounded">.dark</code> — never reach for a raw brand token for text, backgrounds, or borders.
-          Use <code className="text-xs bg-muted px-1 py-0.5 rounded">bg-*</code> for surfaces and{" "}
-          <code className="text-xs bg-muted px-1 py-0.5 rounded">text-*-foreground</code> for text on top.
+        <SectionHeader overline="Theming" title="Gradient utilities" className="mb-4" />
+        <p className="text-sm text-muted-foreground mb-8 max-w-xl">
+          Each gradient has a paired dark variant in CSS — same class name, palette flips automatically.
         </p>
 
-        {/* Paired semantic swatches with light + dark columns */}
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
-          {semanticPairs.map((pair) => (
-            <div key={pair.bg} className="rounded-xl border border-border overflow-hidden">
-              {/* Light */}
-              <div className="flex h-10">
-                <div className="flex-1" style={{ backgroundColor: pair.bgHex }} />
-                <div className="flex-1" style={{ backgroundColor: pair.fgHex }} />
-              </div>
-              {/* Dark */}
-              <div className="flex h-10">
-                <div className="flex-1" style={{ backgroundColor: pair.darkBgHex }} />
-                <div className="flex-1" style={{ backgroundColor: pair.darkFgHex }} />
-              </div>
-              <div className="bg-card p-3">
-                <code className="text-xs font-semibold text-foreground block">bg-{pair.bg}</code>
-                <code className="text-xs text-ring/70 block">text-{pair.fg}</code>
-                <p className="text-[11px] text-muted-foreground mt-1">{pair.role}</p>
-              </div>
+        <div className="grid lg:grid-cols-2 gap-5">
+          {/* Light panel */}
+          <div className="light rounded-xl overflow-hidden border border-border">
+            <div className="flex items-center gap-2 px-4 py-3 border-b" style={{ backgroundColor: "#F9F6F2", borderColor: "rgba(27,75,90,0.12)" }}>
+              <div className="h-2.5 w-2.5 rounded-full border" style={{ backgroundColor: "#F9F6F2", borderColor: "rgba(27,75,90,0.3)" }} />
+              <span className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#4A6670" }}>Light mode</span>
             </div>
-          ))}
-        </div>
-
-        {/* Utility tokens */}
-        <div className="grid gap-4 sm:grid-cols-3 max-w-xl mb-12">
-          {semanticUtilities.map((u) => (
-            <div key={u.token} className="rounded-xl border border-border overflow-hidden">
-              <div className="flex h-8">
-                <div className="flex-1" style={{ backgroundColor: u.lightHex }} />
-                <div className="flex-1 bg-gray-900" style={{ backgroundColor: "#0D2B35" }}>
-                  <div className="h-full" style={{ backgroundColor: u.darkHex }} />
+            <div className="grid grid-cols-2 gap-px" style={{ backgroundColor: "rgba(27,75,90,0.07)" }}>
+              {gradients.map((g) => (
+                <div key={g.label} style={{ backgroundColor: "#F9F6F2" }}>
+                  <div className={`h-28 w-full ${g.cls}`} />
+                  <div className="px-3 py-2.5">
+                    <code className="text-[11px] font-semibold block" style={{ color: "#1B4B5A" }}>{g.label}</code>
+                    <p className="text-[10px] mt-0.5 leading-tight" style={{ color: "#4A6670" }}>{g.desc}</p>
+                  </div>
                 </div>
-              </div>
-              <div className="bg-card p-3">
-                <code className="text-xs font-semibold text-foreground block">{u.token}</code>
-                <p className="text-[11px] text-muted-foreground mt-1">{u.role}</p>
-              </div>
+              ))}
             </div>
-          ))}
-        </div>
+          </div>
 
-        {/* Gradients */}
-        <p className="text-sm font-semibold text-foreground mb-4 uppercase tracking-wider">Gradient utilities</p>
-        <p className="text-sm text-muted-foreground mb-6 max-w-xl">
-          Each gradient has a matching dark variant defined in CSS — the class name stays the same, the palette flips.
-        </p>
-        <div className="grid gap-6 lg:grid-cols-2">
-          {gradients.map((g) => (
-            <div key={g.label} className="rounded-2xl overflow-hidden border border-border">
-              <div className={`h-32 ${g.cls}`} />
-              <div className="bg-card p-4">
-                <code className="text-sm font-semibold text-foreground">{g.label}</code>
-                <p className="text-sm text-muted-foreground mt-1">{g.desc}</p>
-              </div>
+          {/* Dark panel */}
+          <div className="dark rounded-xl overflow-hidden border border-[rgba(168,213,216,0.15)]">
+            <div className="flex items-center gap-2 px-4 py-3 border-b" style={{ backgroundColor: "#0D2B35", borderColor: "rgba(168,213,216,0.12)" }}>
+              <div className="h-2.5 w-2.5 rounded-full border" style={{ backgroundColor: "#0D2B35", borderColor: "rgba(168,213,216,0.4)" }} />
+              <span className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#8BBEC6" }}>Dark mode</span>
             </div>
-          ))}
+            <div className="grid grid-cols-2 gap-px" style={{ backgroundColor: "rgba(168,213,216,0.07)" }}>
+              {gradients.map((g) => (
+                <div key={g.label} style={{ backgroundColor: "#0D2B35" }}>
+                  <div className={`h-28 w-full ${g.cls}`} />
+                  <div className="px-3 py-2.5">
+                    <code className="text-[11px] font-semibold block" style={{ color: "#E8F4F5" }}>{g.label}</code>
+                    <p className="text-[10px] mt-0.5 leading-tight" style={{ color: "#8BBEC6" }}>{g.desc}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </Section>
 
       {/* Typography */}
-      <Section background="white">
+      <Section background="muted">
         <SectionHeader overline="Typography" title="Type scale" className="mb-12" />
         <div className="space-y-8 max-w-3xl">
           <div className="pb-6 border-b border-border">
@@ -271,7 +333,7 @@ export default function DesignSystemPage() {
       </Section>
 
       {/* Tags */}
-      <Section background="white">
+      <Section background="muted">
         <SectionHeader overline="Components" title="Tags &amp; Badges" className="mb-12" />
         <div className="space-y-6">
           <div>
@@ -364,7 +426,7 @@ export default function DesignSystemPage() {
       </Section>
 
       {/* Surfaces */}
-      <Section background="white">
+      <Section background="muted">
         <SectionHeader overline="Components" title="Surfaces &amp; effects" className="mb-12" />
         <div className="grid gap-6 lg:grid-cols-3">
           <div className="glass rounded-2xl p-8">

--- a/components/ui/section.tsx
+++ b/components/ui/section.tsx
@@ -8,7 +8,7 @@ const sectionVariants = cva("py-10 lg:py-14", {
       muted: "bg-muted texture-grain",
       white: "bg-card border-y border-border",
       brand: "gradient-brand texture-grain",
-      "brand-soft": "gradient-brand-soft",
+      "brand-soft": "gradient-hero-soft",
       "brand-vertical": "gradient-brand-vertical texture-grain",
     },
   },

--- a/components/ui/theme-toggle.tsx
+++ b/components/ui/theme-toggle.tsx
@@ -1,28 +1,12 @@
 "use client";
 
-import { Monitor, Moon, Sun } from "lucide-react";
+import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 
-type Theme = "system" | "light" | "dark";
-
-const themes: Theme[] = ["system", "light", "dark"];
-
-const icons: Record<Theme, React.ReactNode> = {
-  system: <Monitor className="h-4 w-4" />,
-  light: <Sun className="h-4 w-4" />,
-  dark: <Moon className="h-4 w-4" />,
-};
-
-const labels: Record<Theme, string> = {
-  system: "System theme",
-  light: "Light theme",
-  dark: "Dark theme",
-};
-
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => setMounted(true), []);
@@ -31,22 +15,17 @@ export function ThemeToggle() {
     return <Button variant="ghost" size="icon" aria-label="Toggle theme" />;
   }
 
-  const current = (theme as Theme) ?? "system";
-
-  function cycleTheme() {
-    const next = themes[(themes.indexOf(current) + 1) % themes.length];
-    setTheme(next);
-  }
+  const isDark = resolvedTheme === "dark";
 
   return (
     <Button
       variant="ghost"
       size="icon"
-      onClick={cycleTheme}
-      aria-label={labels[current]}
-      title={labels[current]}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label={isDark ? "Switch to light theme" : "Switch to dark theme"}
+      title={isDark ? "Switch to light theme" : "Switch to dark theme"}
     >
-      {icons[current]}
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
     </Button>
   );
 }

--- a/prd/pages/resources/design-system.md
+++ b/prd/pages/resources/design-system.md
@@ -30,7 +30,7 @@ Contributors, designers, and Claude Code sessions working on this repository.
 1. **Brand palette** — primary teal / teal-dark / amber swatches with hex values and usage notes.
 2. **Accent tokens** — coral, mint, seafoam, sand, peach, blush.
 3. **Semantic tokens** — background, foreground, muted, border.
-4. **Gradient utilities** — `.gradient-brand`, `.gradient-brand-vertical`, `.gradient-hero`, `.gradient-brand-soft`.
+4. **Gradient utilities** — `.gradient-brand`, `.gradient-brand-vertical`, `.gradient-hero`, `.gradient-hero-soft`.
 5. **Type scale** — Space Grotesk display sizes (6xl–xl) and Inter body sizes (xl–xs); overline pattern.
 6. **Buttons** — all variants (primary, secondary, outline, ghost), sizes (lg, md, sm), icon usage, and disabled states.
 7. **Tags & Pills** — filled, outline, soft-teal, soft-amber, seafoam variants.


### PR DESCRIPTION
## Summary

Sorry a bit of a big change here - not following our PR standards a bit, but I added screenshots

This PR mostly targets the design-system page

- **Rename** `.gradient-brand-soft` → `.gradient-hero-soft` across CSS, section variant map, and design-system spec
- **Refactor gradient CSS** to use CSS custom properties (`--gradient-*`) defined in `:root` (light default), `.light`, and `.dark` blocks — gradient utilities now read `var()` so the closest ancestor's value wins, fixing forced light/dark preview strips in the design-system page
- **Theme toggle**: replace three-state cycle (system → light → dark) with a binary light ↔ dark toggle using `resolvedTheme`; system preference is still auto-detected via `enableSystem` on ThemeProvider and maps to the correct theme on first load
- **Design-system page overhaul**:
  - Color palette: compact connected strip layout (`gap-px` grid) replacing tall swatch cards; brand (4-col) and accent (6-col) grouped separately
  - Semantic tokens: split into explicit light/dark panels; each row shows `bg-*` and `text-*` as separate lines with source color alias (e.g. `teal-dark`, `seafoam`, `coral`) right-aligned
  - Gradient utilities: split into light/dark panels with 2×2 grid of full-width swatches; tile dividers match semantic token row separators
  - Section backgrounds: strict `default`/`muted` alternation across all nine sections (excluding hero and CTA)
- **CLAUDE.md**: add explicit rule prohibiting force-push to `main`

<details>
<summary>Screenshots</summary>

<img width="2048" height="13962" alt="localhost_3000_resources_design-system(iPad Pro)" src="https://github.com/user-attachments/assets/dd308e2f-912b-4f57-b562-0a18afb575db" />

</details>

## Test plan

- [x] Light/dark toggle works on all pages — system preference respected on first load
- [x] All gradient utilities render correctly in both light and dark mode
- [x] `/resources/design-system` light and dark panels show correct values regardless of active theme
- [x] `Section background="brand-soft"` CTA section still renders correctly