### PR TITLE
Fixes #79: Integrate Luma scraper into events page and add cover images

### DIFF
--- a/app/events/actions.tsx
+++ b/app/events/actions.tsx
@@ -45,6 +45,7 @@ const EventSchema = z.object({
     end_at: z.string(),
     timezone: z.string(),
     url: z.string(),
+    cover_url: z.string().optional(),
   }),
 });
 
@@ -67,6 +68,7 @@ function lumaCalendarResponseToEvents(parsed: LumaEventResponse[]): Event[] {
     status:
       Date.now() > new Date(event.start_at).valueOf() ? "past" : "upcoming",
     eventUrl: `https://luma.com/${event.url}`,
+    imagePath: event.cover_url,
   }));
 }
 

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -6,7 +6,8 @@ import { Section, SectionHeader } from "@/components/ui/section";
 import { EventBrowser } from "@/components/ui/event-browser";
 import { DualCTA } from "@/components/ui/dual-cta";
 import { ContactCard } from "@/components/ui/contact-card";
-import { getUpcomingEvents, events } from "@/constants/events";
+import { events } from "@/constants/events";
+import { getLumaEvents, getPastLumaEvents } from "./actions";
 
 export const metadata: Metadata = {
   title: "Events",
@@ -14,9 +15,36 @@ export const metadata: Metadata = {
     "All TechTank TO events — upcoming meetups and past recaps. Monthly in-person events in Toronto since 2023.",
 };
 
-export default function EventsPage() {
-  const upcomingEvents = getUpcomingEvents();
-  const nextEvent = upcomingEvents[0];
+export default async function EventsPage() {
+  const lumaEvents = await getLumaEvents();
+  const pastLumaEvents = await getPastLumaEvents();
+  const allLumaEvents = [...lumaEvents, ...pastLumaEvents];
+
+  const staticLumaSlugs = new Set(
+    events
+      .filter((e) => e.eventUrl?.includes("lu.ma/") || e.eventUrl?.includes("luma.com/"))
+      .map((e) => {
+        const url = e.eventUrl!;
+        const parts = url.split("/");
+        return parts[parts.length - 1].split("?")[0];
+      })
+  );
+
+  const mergedEvents = [...events];
+  for (const lumaEvent of allLumaEvents) {
+    if (!lumaEvent.eventUrl) continue;
+    const parts = lumaEvent.eventUrl.split("/");
+    const slug = parts[parts.length - 1].split("?")[0];
+
+    if (!staticLumaSlugs.has(slug)) {
+      mergedEvents.push(lumaEvent);
+    }
+  }
+
+  // Sort descending by date
+  mergedEvents.sort(
+    (a, b) => new Date(b.start_at).getTime() - new Date(a.start_at).getTime()
+  );
 
   return (
     <>
@@ -39,7 +67,7 @@ export default function EventsPage() {
             </div>
             <div className="shrink-0">
               <p className="text-sm font-semibold text-foreground">
-                {events.length} EVENTS · SINCE 2023
+                {mergedEvents.length} EVENTS · SINCE 2023
               </p>
             </div>
           </div>
@@ -99,7 +127,7 @@ export default function EventsPage() {
           description="Browse, filter, and search all TechTank meetups."
           className="mb-12"
         />
-        <EventBrowser events={events} />
+        <EventBrowser events={mergedEvents} />
       </Section>
 
       {/* Dual CTA */}

--- a/constants/events.ts
+++ b/constants/events.ts
@@ -4,7 +4,7 @@ import { sponsors, type Sponsor } from "./sponsors";
 export type { Sponsor };
 
 export const events: Event[] = [
-  // ─── Upcoming ────────────────────────────────────────────────────────────────
+  // ─── 2026 ────────────────────────────────────────────────────────────────────
   {
     id: "supercollider-spring-fling-2026",
     title: "SUPERCOLLIDER Spring Fling — Toronto Tech Communities Networking Night",
@@ -12,7 +12,7 @@ export const events: Event[] = [
     start_at: "2026-04-27T18:00:00",
     venue: "Left Field Brewery (Liberty Village)",
     tags: ["Networking", "Social", "Multi-community"],
-    status: "upcoming",
+    status: "past",
     eventUrl: "https://lu.ma/supercollider-spring-fling-2026",
     imagePath: "/images/luma/b3bae200-2226-4cd2-9796-5a7480abda7c.jpeg",
   },
@@ -23,11 +23,10 @@ export const events: Event[] = [
     start_at: "2026-05-02T11:00:00",
     venue: "Prema Coffee and Bar",
     tags: ["Coffee Chat", "CodeDiversity", "Social",],
-    status: "upcoming",
+    status: "past",
     eventUrl: "https://lu.ma/3ea6eq1s",
     imagePath: "/images/luma/bca86cee-3fdb-403a-bb09-ccc095690401.jpeg",
   },
-  // ─── 2026 ────────────────────────────────────────────────────────────────────
   {
     id: "techtank-turns-3",
     title: "This ain't my first rodeo 🤠🪩 TECHTANK 3 YEAR ANNIVERSARY",


### PR DESCRIPTION
# Summary

This PR updates the Events page to automatically fetch and display the latest events directly from the Luma API, eliminating the need for manual event additions. The `<EventsPage>` component now fetches `getLumaEvents` and `getPastLumaEvents` and merges them with the static data in `constants/events.ts`. This ensures we keep our rich static metadata (custom images, tags, speakers) while preventing duplicates.

## Screenshots

Before:
<img width="987" height="636" alt="image" src="https://github.com/user-attachments/assets/8f43bf85-ab7d-46d5-b0b5-68f00eaff05f" />
<img width="913" height="599" alt="image" src="https://github.com/user-attachments/assets/6de8062f-6f51-4736-b2a2-10ca542977e2" />

After:
<img width="1010" height="694" alt="image" src="https://github.com/user-attachments/assets/1fb6c1bc-a48c-4e2c-806f-e7426f85faa2" />
<img width="913" height="599" alt="image" src="https://github.com/user-attachments/assets/9fa91e29-2294-4978-84f1-e8b557826ba0" />

## Checklist

- [x] No new TypeScript errors (`pnpm build` and `pnpm lint:fix` passes)
- [x] Visually tested in the browser (desktop + mobile)
- [ ] PRD updated if information architecture, routes or design system is changed (`prd/`)
- [x] No placeholder content (`#`, `TODO`, Lorem Ipsum) left in production paths
- [x] Close the issue on merge
