### PR TITLE
Closes #60: Reduce visual complexity of events filter

### DIFF
--- a/components/ui/event-browser.tsx
+++ b/components/ui/event-browser.tsx
@@ -9,9 +9,7 @@ import { cn } from "@/utils/theme";
 import type { Event } from "@/app/events/actions";
 
 type CategoryFilter = "all" | "tech-talks" | "coffee-chats" | "socials" | "sports" | "other";
-type TimeFilter = "all" | "upcoming" | "past";
 type DisplayMode = "cards" | "grid" | "list";
-type SortBy = "date" | "title";
 
 const CATEGORY_TAGS: Record<Exclude<CategoryFilter, "all" | "other">, string[]> = {
   "tech-talks": ["Tech Talk", "Panel", "Workshop"],
@@ -40,33 +38,25 @@ const PAGE_SIZE = 20;
 
 export function EventBrowser({ events }: EventBrowserProps) {
   const [category, setCategory] = useState<CategoryFilter>("all");
-  const [timeFilter, setTimeFilter] = useState<TimeFilter>("all");
   const [displayMode, setDisplayMode] = useState<DisplayMode>("cards");
-  const [sortBy, setSortBy] = useState<SortBy>("date");
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   const filtered = useMemo(() => {
     let result = events.filter((e) => {
       if (!matchesCategory(e, category)) return false;
-      if (timeFilter === "upcoming") return e.status === "upcoming";
-      if (timeFilter === "past") return e.status === "past";
       return true;
     });
 
-    if (sortBy === "date") {
-      result = result.sort((a, b) => {
-        if (a.status !== b.status) return a.status === "upcoming" ? -1 : 1;
-        const diff = new Date(a.start_at).getTime() - new Date(b.start_at).getTime();
-        return a.status === "upcoming" ? diff : -diff;
-      });
-    } else {
-      result = result.sort((a, b) => a.title.localeCompare(b.title));
-    }
+    result = result.sort((a, b) => {
+      if (a.status !== b.status) return a.status === "upcoming" ? -1 : 1;
+      const diff = new Date(a.start_at).getTime() - new Date(b.start_at).getTime();
+      return a.status === "upcoming" ? diff : -diff;
+    });
 
     return result;
-  }, [events, category, timeFilter, sortBy]);
+  }, [events, category]);
 
-  useEffect(() => { setVisibleCount(PAGE_SIZE); }, [category, timeFilter, sortBy]);
+  useEffect(() => { setVisibleCount(PAGE_SIZE); }, [category]);
 
   const visible = filtered.slice(0, visibleCount);
   const hasMore = visibleCount < filtered.length;
@@ -81,18 +71,13 @@ export function EventBrowser({ events }: EventBrowserProps) {
     { id: "other", label: "Other" },
   ];
 
-  const timeFilters: { id: TimeFilter; label: string }[] = [
-    { id: "all", label: "All" },
-    { id: "upcoming", label: "Upcoming" },
-    { id: "past", label: "Past" },
-  ];
 
   return (
     <div>
       {/* Controls */}
-      <div className="rounded-xl bg-card border border-border p-4 flex flex-col gap-4 mb-8">
+      <div className="rounded-xl bg-card border border-border p-4 flex flex-col md:flex-row items-center justify-between gap-4 mb-8">
         {/* Category filters */}
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap items-center justify-center md:justify-start gap-2">
           {categories.map((c) => (
             <button
               key={c.id}
@@ -109,82 +94,38 @@ export function EventBrowser({ events }: EventBrowserProps) {
           ))}
         </div>
 
-        {/* Time filter + display mode + sort */}
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex gap-1.5">
-            {timeFilters.map((t) => (
-              <button
-                key={t.id}
-                onClick={() => setTimeFilter(t.id)}
-                className={cn(
-                  "px-3 py-1 rounded-md text-xs font-medium transition-colors",
-                  timeFilter === t.id
-                    ? "bg-secondary text-secondary-foreground"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
-              >
-                {t.label}
-              </button>
-            ))}
-          </div>
-
-          <div className="flex items-center gap-3">
-            {/* Sort */}
-            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <button
-                onClick={() => setSortBy("date")}
-                className={cn(
-                  "px-3 py-1 rounded-md text-xs font-medium transition-colors",
-                  sortBy === "date" ? "bg-secondary text-secondary-foreground" : "text-muted-foreground hover:text-foreground"
-                )}
-              >
-                Date
-              </button>
-              <button
-                onClick={() => setSortBy("title")}
-                className={cn(
-                  "px-3 py-1 rounded-md text-xs font-medium transition-colors",
-                  sortBy === "title" ? "bg-secondary text-secondary-foreground" : "text-muted-foreground hover:text-foreground"
-                )}
-              >
-                Title
-              </button>
-            </div>
-
-            {/* Display mode */}
-            <div className="flex items-center gap-0.5 rounded-lg bg-muted p-0.5">
-              <button
-                onClick={() => setDisplayMode("cards")}
-                className={cn(
-                  "p-1.5 rounded-md transition-colors",
-                  displayMode === "cards" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
-                )}
-                aria-label="Cards view"
-              >
-                <Columns2 className="h-3.5 w-3.5" />
-              </button>
-              <button
-                onClick={() => setDisplayMode("grid")}
-                className={cn(
-                  "p-1.5 rounded-md transition-colors",
-                  displayMode === "grid" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
-                )}
-                aria-label="Grid view"
-              >
-                <LayoutGrid className="h-3.5 w-3.5" />
-              </button>
-              <button
-                onClick={() => setDisplayMode("list")}
-                className={cn(
-                  "p-1.5 rounded-md transition-colors",
-                  displayMode === "list" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
-                )}
-                aria-label="List view"
-              >
-                <List className="h-3.5 w-3.5" />
-              </button>
-            </div>
-          </div>
+        {/* Display mode */}
+        <div className="flex items-center gap-0.5 rounded-lg bg-muted p-0.5 shrink-0">
+          <button
+            onClick={() => setDisplayMode("cards")}
+            className={cn(
+              "p-1.5 rounded-md transition-colors",
+              displayMode === "cards" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+            )}
+            aria-label="Cards view"
+          >
+            <Columns2 className="h-3.5 w-3.5" />
+          </button>
+          <button
+            onClick={() => setDisplayMode("grid")}
+            className={cn(
+              "p-1.5 rounded-md transition-colors",
+              displayMode === "grid" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+            )}
+            aria-label="Grid view"
+          >
+            <LayoutGrid className="h-3.5 w-3.5" />
+          </button>
+          <button
+            onClick={() => setDisplayMode("list")}
+            className={cn(
+              "p-1.5 rounded-md transition-colors",
+              displayMode === "list" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+            )}
+            aria-label="List view"
+          >
+            <List className="h-3.5 w-3.5" />
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
# Summary

Simplify the filters on events page as per #60.

## Screenshots

Before:
<img width="330" height="277" alt="image" src="https://github.com/user-attachments/assets/55c7abbb-5e5f-4517-b11b-e78090069e88" />
<img width="751" height="218" alt="image" src="https://github.com/user-attachments/assets/48540724-61af-4e7c-891e-7e116670d21f" />

After:
<img width="324" height="236" alt="image" src="https://github.com/user-attachments/assets/ea6ac0ea-4318-4b51-b78d-a5871d748fc8" />
<img width="757" height="198" alt="image" src="https://github.com/user-attachments/assets/d29a81de-8786-4e21-b756-4c40314249d2" />

## Checklist

- [x] No new TypeScript errors (`pnpm build` and `pnpm lint:fix` passes)
- [x] Visually tested in the browser (desktop + mobile)
- [ ] PRD updated if information architecture, routes or design system is changed (`prd/`)
- [x] No placeholder content (`#`, `TODO`, Lorem Ipsum) left in production paths
- [x] Close the issue on merge
