### PR TITLE
feat: add monochromatic logos for dark mode

### DIFF
--- a/components/ui/sponsors-marquee.tsx
+++ b/components/ui/sponsors-marquee.tsx
@@ -21,7 +21,7 @@ export function SponsorsMarquee({ className }: { className?: string }) {
             alt={`${sponsor.name} logo`}
             width={120}
             height={40}
-            className="h-8 lg:h-10 w-auto object-contain opacity-70 hover:opacity-100 transition-all duration-300"
+            className="h-8 lg:h-10 w-auto object-contain opacity-70 hover:opacity-100 transition-all duration-300 dark:brightness-0 dark:invert"
             style={sponsor.scale ? { transform: `scale(${sponsor.scale})` } : undefined}
           />
         </a>


### PR DESCRIPTION
# Summary

<!-- What does this PR do? One to three bullet points. -->
This PR inverts all logos to a monochromatic white using Tailwind's dark: variant.

## Screenshots

<!-- Let's see the beautiful changes! Helps with reviews. -->
<img width="2572" height="322" alt="image" src="https://github.com/user-attachments/assets/3408c464-71ac-4b53-8e3c-8d36dad44c80" />


## Checklist

- [ ] No new TypeScript errors (`pnpm build` and `pnpm lint:fix` passes)
- [ ] Visually tested in the browser (desktop + mobile)
- [ ] PRD updated if information architecture, routes or design system is changed (`prd/`)
- [ ] No placeholder content (`#`, `TODO`, Lorem Ipsum) left in production paths
- [ ] Close the issue on merge
