### PR TITLE
Fix #43: Allowlist Luma images CDN in NextJS image optimization config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -27,6 +27,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "images.squarespace-cdn.com",
       },
+      {
+        protocol: "https",
+        hostname: "images.lumacdn.com",
+      },
     ],
   },
 };


### PR DESCRIPTION
# Summary

- Add `images.lumacdn.com` to the `remotePatterns` in `next.config.ts`.
- Resolves the "unconfigured host" error thrown by the `next/image` component in the event browser, ensuring external Luma event covers are permitted and correctly optimized at runtime. Fixes regression from #87 .

## Screenshots

Before:
<img width="1937" height="1206" alt="image" src="https://github.com/user-attachments/assets/b807de9b-53c1-4a63-bdca-c4b96c2a7741" />

After:
<img width="1994" height="1313" alt="Screenshot 2026-05-22 190601" src="https://github.com/user-attachments/assets/0edc49c8-1ca2-4e1b-8fca-431784d75c8b" />


## Checklist

- [x] No new TypeScript errors (`pnpm build` and `pnpm lint:fix` passes)
- [x] Visually tested in the browser (desktop + mobile)
- [x] PRD updated if information architecture, routes or design system is changed (`prd/`)
- [x] No placeholder content (`#`, `TODO`, Lorem Ipsum) left in production paths
- [x] Close the issue on merge
