### PR TITLE
feat(about): add FAQ page and shared resources layout

### DIFF
--- a/app/about/faq/page.tsx
+++ b/app/about/faq/page.tsx
@@ -1,0 +1,227 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Section, SectionHeader } from "@/components/ui/section";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+
+export const metadata: Metadata = {
+  title: "FAQ",
+  description:
+    "Answers to common questions about TechTank TO — events, membership, sponsorship, volunteering, and more.",
+};
+
+const faqs = [
+  {
+    category: "General",
+    items: [
+      {
+        q: "Is TechTank free?",
+        a: "Joining TechTank through our Slack community is free. Most events are free or low cost. When there is a cost, we say so upfront at registration. We try to keep things as accessible as possible, and sponsored events typically include food and drinks covered by the host.",
+      },
+      {
+        q: "Where are you based?",
+        a: "Toronto, primarily. Most events happen in the downtown core, but we're not locked to one neighbourhood or venue. As we grow, we'd love to bring programming to other parts of Ontario too.",
+      },
+      {
+        q: "Who are these events for?",
+        a: "Anyone working in or adjacent to tech — engineers, designers, product managers, data engineers, founders, and anyone else building things. We actively work to make TechTank welcoming to people at all experience levels. You don't need a senior title or a decade of experience to belong here.",
+      },
+      {
+        q: "How do I find out about events?",
+        a: "We list events on Luma and Meetup. We also announce events in our Slack community and post on LinkedIn and Instagram. Any of those will keep you in the loop.",
+      },
+      {
+        q: "Do I need to be a member to attend?",
+        a: "Nope. Most TechTank events are open to anyone. Just register on Luma or Meetup and show up.",
+      },
+    ],
+  },
+  {
+    category: "Sponsorship & Hosting",
+    items: [
+      {
+        q: "Can my company sponsor or host an event?",
+        a: (
+          <>
+            Yes. Companies can sponsor by providing a venue, covering food and drinks, or contributing financially. Hosting a TechTank event is a great way to get your space and team in front of Toronto's tech community.{" "}
+            <Link href="/get-involved/sponsor" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              Fill out the sponsor and host inquiry form
+            </Link>{" "}
+            and an organizer will follow up.
+          </>
+        ),
+      },
+      {
+        q: "Where does donation and sponsorship money go?",
+        a: (
+          <>
+            <p className="mb-3">TechTank is a nonprofit run almost entirely by volunteers. When you donate or when a company sponsors us, here is where that money goes:</p>
+            <ul className="list-disc list-inside space-y-1 text-muted-foreground mb-3">
+              <li>Platform fees for Luma and Meetup</li>
+              <li>Website hosting and domain costs</li>
+              <li>Event materials like nametags, printed materials, and supplies</li>
+              <li>Swag and community merchandise</li>
+              <li>Special event costs for socials and programming not covered by a venue sponsor</li>
+              <li>Operational costs including legal and bookkeeping services</li>
+              <li>Food and drinks for volunteers and organizers at events and team meetings</li>
+              <li>Eventually: speaker honorariums and travel costs, as we grow our ability to bring in speakers who require compensation</li>
+            </ul>
+            <p>We keep most events free specifically because we believe access to community shouldn't cost anything. Donations and sponsorships are what make that possible.</p>
+          </>
+        ),
+      },
+      {
+        q: "What does sponsoring an event include?",
+        a: "It depends on the type of sponsorship. Venue sponsors provide space and typically cover food and drinks for the event. Financial sponsors help cover platform fees, materials, and operational costs. We work with each sponsor to figure out what makes sense. All sponsors are credited at the event and in our communications.",
+      },
+      {
+        q: "Is TechTank a nonprofit?",
+        a: "Yes. TechTank is a registered nonprofit corporation in Ontario. We are volunteer-run and community-driven, and all funds go back into supporting programming and operations.",
+      },
+    ],
+  },
+  {
+    category: "Getting Involved",
+    items: [
+      {
+        q: "I have an idea for an event or initiative. Can I bring it to TechTank?",
+        a: (
+          <>
+            Please do. TechTank has been shaped by people who showed up with ideas and made them happen. If you want to organize something, facilitate a workshop, or launch a new initiative under the TechTank umbrella,{" "}
+            <a href="mailto:techtankto@gmail.com" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              reach out
+            </a>{" "}
+            or fill out the organizer interest form. We'd love to hear it.
+          </>
+        ),
+      },
+      {
+        q: "Can I volunteer?",
+        a: (
+          <>
+            Yes. We need help behind the scenes with social media, design, website, operations, fundraising, and sponsorship outreach. We also need people to help run events like socials and Tech Talks — though for event roles, we ask that you get involved in the community first so you know what TechTank is all about. Time commitment varies.{" "}
+            <Link href="/get-involved/volunteer" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              Fill out the volunteer form
+            </Link>{" "}
+            and we'll be in touch.
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    category: "Events & Policies",
+    items: [
+      {
+        q: "What is your RSVP and cancellation policy?",
+        a: "If you RSVP and can no longer attend, please update your registration at least 24 hours before the event. Repeated no-shows may affect your ability to register for future TechTank events. We keep waitlists for popular events, so cancelling early gives someone else a chance to attend. For paid events, cancellations before the cutoff date will be refunded. If you cancel after the cutoff, a refund is only possible if someone else takes your spot. Cutoff dates are posted on each event listing and vary based on the event.",
+      },
+      {
+        q: "Will photos or videos be taken at events?",
+        a: "Yes. TechTank may take photos and videos at events for use in promotional content, social media, and community communications. By attending, you acknowledge this. If you'd prefer not to be photographed or filmed, just let an organizer know when you arrive and we'll make sure to respect that.",
+      },
+      {
+        q: "I witnessed or experienced something that made me uncomfortable at a TechTank event. What do I do?",
+        a: (
+          <>
+            Please reach out to us at{" "}
+            <a href="mailto:techtankto@gmail.com" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              techtankto@gmail.com
+            </a>{" "}
+            or speak to any organizer at the event. We take every report seriously and handle them confidentially. You can also review our full{" "}
+            <Link href="/legal/code-of-conduct" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              Code of Conduct
+            </Link>{" "}
+            for more detail on how reports are handled.
+          </>
+        ),
+      },
+    ],
+  },
+];
+
+export default function FAQPage() {
+  return (
+    <>
+      {/* Hero */}
+      <section className="relative overflow-hidden gradient-hero texture-grain">
+        <div className="relative mx-auto max-w-7xl px-6 py-16 lg:px-8 lg:py-24">
+          <div className="max-w-3xl">
+            <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
+              FAQ
+            </span>
+            <h1 className="font-display text-4xl md:text-5xl font-semibold text-foreground lg:text-6xl text-balance mb-6">
+              Frequently asked questions
+            </h1>
+            <p className="text-xl text-muted-foreground leading-relaxed">
+              Everything you need to know about TechTank — events, membership,
+              sponsorship, and more. Can't find what you're looking for?{" "}
+              <a
+                href="mailto:techtankto@gmail.com"
+                className="underline underline-offset-2 hover:text-foreground transition-colors"
+              >
+                Email us
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ sections */}
+      {faqs.map((group, groupIndex) => (
+        <Section key={group.category} background={groupIndex % 2 === 0 ? undefined : "white"}>
+          <div>
+            <SectionHeader
+              overline={group.category}
+              title={group.category}
+              className="mb-8"
+            />
+            <Accordion type="single" collapsible className="space-y-2">
+              {group.items.map((item, index) => (
+                <AccordionItem
+                  key={index}
+                  value={`${group.category}-${index}`}
+                  className="bg-card rounded-xl border border-border px-6"
+                >
+                  <AccordionTrigger className="text-left font-semibold text-foreground hover:no-underline py-5">
+                    {item.q}
+                  </AccordionTrigger>
+                  <AccordionContent className="text-muted-foreground leading-relaxed pb-5">
+                    {item.a}
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </div>
+        </Section>
+      ))}
+
+      {/* Still have questions */}
+      <Section background="brand-soft">
+        <div className="max-w-2xl mx-auto text-center">
+          <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
+            Still have questions?
+          </span>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
+            We're happy to help
+          </h2>
+          <p className="text-muted-foreground mb-6">
+            If you didn't find what you were looking for, reach out directly and
+            an organizer will get back to you.
+          </p>
+          <a
+            href="mailto:techtankto@gmail.com"
+            className="inline-flex items-center gap-2 font-semibold text-foreground underline underline-offset-4 hover:text-ring transition-colors"
+          >
+            techtankto@gmail.com
+          </a>
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/app/get-involved/page.tsx
+++ b/app/get-involved/page.tsx
@@ -31,28 +31,6 @@ const whyGetInvolved = [
   },
 ];
 
-const faqs = [
-  {
-    question: "Do I need to be a senior engineer to speak?",
-    answer:
-      "No! We welcome speakers at all levels. Some of our best talks come from people sharing what they just learned. We also offer coaching for first-time speakers.",
-  },
-  {
-    question: "Is there a cost to host?",
-    answer:
-      "No fee to TechTank. Hosts provide venue and food (typically pizza and drinks). TechTank handles everything else: speakers, marketing, coordination, recording.",
-  },
-  {
-    question: "Can I volunteer without speaking or hosting?",
-    answer:
-      "Absolutely! We have event-day roles (check-in, setup), ongoing roles (social media, design), and organizing roles. No public speaking required.",
-  },
-  {
-    question: "How fast will you get back to me?",
-    answer:
-      "We aim to respond to all inquiries within one week. If you haven't heard back, please email us directly at techtankto@gmail.com.",
-  },
-];
 
 export default function GetInvolvedPage() {
   return (
@@ -110,28 +88,6 @@ export default function GetInvolvedPage() {
                 {item.title}
               </h3>
               <p className="text-muted-foreground leading-relaxed">{item.description}</p>
-            </div>
-          ))}
-        </div>
-      </Section>
-
-      {/* FAQ */}
-      <Section>
-        <SectionHeader
-          overline="FAQ"
-          title="Common questions"
-          className="mb-12"
-        />
-        <div className="grid gap-6 lg:grid-cols-2">
-          {faqs.map((faq, index) => (
-            <div
-              key={index}
-              className="bg-card rounded-xl border border-border p-6"
-            >
-              <h3 className="font-display text-lg font-semibold text-foreground mb-2">
-                {faq.question}
-              </h3>
-              <p className="text-muted-foreground">{faq.answer}</p>
             </div>
           ))}
         </div>

--- a/app/resources/layout.tsx
+++ b/app/resources/layout.tsx
@@ -4,29 +4,28 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Button } from "@/components/ui/button";
 
-const subNav = [
-  { name: "TechTank", href: "/about" },
-  { name: "Team", href: "/about/team" },
-  { name: "FAQ", href: "/about/faq" },
+const resourcesNav = [
+  { name: "Media Kit", href: "/resources/media-kit" },
 ];
 
-export default function AboutLayout({ children }: { children: React.ReactNode }) {
+export default function ResourcesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const pathname = usePathname();
 
   return (
     <div className="min-h-screen">
+      {/* Sticky Sub-Nav */}
       <nav className="sticky top-18 z-40 bg-background/80 backdrop-blur-xl border-b border-border">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
           <div className="flex items-center justify-center py-3">
             <div className="flex flex-wrap items-center justify-center gap-1">
-              {subNav.map((item) => {
-                const isActive =
-                  item.href === "/about"
-                    ? pathname === "/about"
-                    : pathname.startsWith(item.href);
-
+              {resourcesNav.map((item) => {
+                const isActive = pathname === item.href;
                 return (
-                  <Button key={item.name} variant="nav" size="sm" isActive={isActive} asChild>
+                  <Button key={item.href} variant="nav" size="sm" isActive={isActive} asChild>
                     <Link href={item.href}>{item.name}</Link>
                   </Button>
                 );
@@ -36,6 +35,7 @@ export default function AboutLayout({ children }: { children: React.ReactNode })
         </div>
       </nav>
 
+      {/* Page Content */}
       {children}
     </div>
   );

--- a/app/resources/layout.tsx
+++ b/app/resources/layout.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 
 const resourcesNav = [
   { name: "Media Kit", href: "/resources/media-kit" },
+  { name: "Design System", href: "/resources/design-system" },
 ];
 
 export default function ResourcesLayout({

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -20,6 +20,7 @@ const footerLinks = {
     links: [
       { name: "TechTank", href: "/about", external: false },
       { name: "Team", href: "/about/team", external: false },
+      { name: "FAQ", href: "/about/faq", external: false },
     ],
   },
   getInvolved: {

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -11,6 +11,7 @@ const navigation = [
   { name: "About", href: "/about" },
   { name: "Get Involved", href: "/get-involved" },
   { name: "Events", href: "/events" },
+  { name: "Resources", href: "/resources/media-kit" },
   { name: "Code of Conduct", href: "/legal/code-of-conduct" },
 ];
 

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import * as React from "react"
+import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import { ChevronDown } from "lucide-react"
+
+import { cn } from "@/utils/theme"
+
+const Accordion = AccordionPrimitive.Root
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn("border-b", className)}
+    {...props}
+  />
+))
+AccordionItem.displayName = "AccordionItem"
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+))
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    {...props}
+  >
+    <div className={cn("pb-4 pt-0", className)}>{children}</div>
+  </AccordionPrimitive.Content>
+))
+
+AccordionContent.displayName = AccordionPrimitive.Content.displayName
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "pnpm": ">=10"
   },
   "dependencies": {
+    "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-slot": "^1.2.4",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-accordion':
+        specifier: ^1.2.12
+        version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
@@ -308,6 +311,48 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-accordion@1.2.12':
+    resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.12':
+    resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -317,8 +362,97 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-slot@1.2.4':
     resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -875,8 +1009,100 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
@@ -884,6 +1110,27 @@ snapshots:
   '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14

--- a/prd/PRD.md
+++ b/prd/PRD.md
@@ -126,6 +126,7 @@ under Ontario/Canadian jurisdiction.
 | `/events` | Events | Upcoming events via Luma calendar |
 | `/resources/media-kit` | Media Kit | Brand assets, logos, and fast facts for press and partners |
 | `/resources/design-system` | Design System | Brand guidelines — colours, typography, and component reference |
+| `/about/faq` | FAQ | Frequently asked questions about membership, events, sponsorship, and policies |
 | `/legal/terms-of-service` | Terms of Service | — |
 | `/legal/privacy-policy` | Privacy Policy | — |
 | `/legal/code-of-conduct` | Code of Conduct | — |

--- a/prd/pages/resources/faq.md
+++ b/prd/pages/resources/faq.md
@@ -1,0 +1,65 @@
+# FAQ — `/resources/faq`
+
+## Purpose
+
+A single-page reference for the most common questions about TechTank TO.
+Reduces repetitive intake emails and gives new visitors quick answers
+about membership, events, sponsorship, volunteering, and policies.
+
+## Primary audience
+
+- Curious newcomers deciding whether to attend
+- Companies evaluating sponsorship or hosting
+- Potential volunteers and organizers
+- Anyone wondering about policies (RSVP, photos, conduct)
+
+## Key messages
+
+- TechTank is free to join and most events are free or low cost.
+- TechTank is a registered nonprofit — all funds go back into programming.
+- There are multiple ways to get involved: attend, volunteer, host, or sponsor.
+- Concerns and conduct reports are handled confidentially.
+
+## Content sections
+
+### Hero
+
+- Overline: `FAQ`
+- Headline: **Frequently asked questions**
+- Subtext: short intro pointing to email for unanswered questions
+
+### FAQ groups (accordion per group)
+
+| Group | Questions |
+|---|---|
+| General | Is TechTank free? / Where are you based? / Who are these events for? / How do I find out about events? / Do I need to be a member to attend? |
+| Sponsorship & Hosting | Can my company sponsor or host? / Where does donation and sponsorship money go? / What does sponsoring include? / Is TechTank a nonprofit? |
+| Getting Involved | I have an idea for an event — can I bring it? / Can I volunteer? |
+| Events & Policies | RSVP and cancellation policy / Photos and video at events / What to do if something made me uncomfortable |
+
+### Closing CTA
+
+- Overline: `Still have questions?`
+- Headline: **We're happy to help**
+- CTA: `techtankto@gmail.com` mailto link
+
+## CTAs
+
+- **Dominant:** Email `techtankto@gmail.com`
+- **Secondary:** Internal links to `/get-involved/sponsor`, `/get-involved/volunteer`, `/legal/code-of-conduct`
+
+## Functional requirements
+
+- Accordion UI — one question open at a time per group; all collapsed on load.
+- Inline links in answers point to relevant internal pages (no new tabs for internal links).
+- No form capture — all intake is via existing email and intake pages.
+
+## Acceptance criteria
+
+- [ ] All 15 questions and answers from the content brief are present.
+- [ ] Grouped into four categories matching the table above.
+- [ ] Accordion works — each item expands/collapses independently.
+- [ ] Links in answers resolve correctly (sponsor, volunteer, code-of-conduct, mailto).
+- [ ] Page metadata (`<title>`, `<meta description>`) is set.
+- [ ] Linked from footer resources column.
+- [ ] Route added to PRD route map.


### PR DESCRIPTION
## Summary

- Adds `/about/faq` with 15 questions grouped into four categories (General, Sponsorship & Hosting, Getting Involved, Events & Policies) using a shadcn accordion
- Adds FAQ to the About sub-nav and footer About column
- Adds a shared `/resources` layout with a sticky sub-nav (Media Kit, Design System)
- Adds a Resources link to the global header pointing to `/resources/media-kit`
- Removes the duplicate 4-question FAQ section from `/get-involved`
- Updates PRD route map and adds `prd/pages/resources/faq.md` spec

## Test plan

- [x] `/about/faq` loads and accordion expand/collapse works for all groups
- [x] About sub-nav shows FAQ pill and marks it active on `/about/faq`
- [x] Footer About column links to `/about/faq`
- [x] Resources sub-nav appears on `/resources/media-kit` and `/resources/design-system`
- [x] Header Resources link navigates to `/resources/media-kit`
- [x] `/get-involved` no longer shows the FAQ card grid
- [x] Mobile menu includes Resources link and navigates correctly