### PR TITLE
Enable Dynamic Open Graph Image

### DIFF
--- a/app/about/opengraph-image.tsx
+++ b/app/about/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { createOGImage, size } from "@/components/ui/og-image";
+
+export const alt = "TechTank TO About";
+export { size };
+
+export const contentType = "image/png";
+
+export default function OGImage() {
+  return createOGImage({
+    title: "ABOUT",
+    imageAlt: alt,
+  });
+}

--- a/app/events/opengraph-image.tsx
+++ b/app/events/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { createOGImage, size } from "@/components/ui/og-image";
+
+export const alt = "TechTank TO Events";
+export { size };
+
+export const contentType = "image/png";
+
+export default function OGImage() {
+  return createOGImage({
+    title: "EVENTS",
+    imageAlt: alt,
+  });
+}

--- a/app/get-involved/opengraph-image.tsx
+++ b/app/get-involved/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { createOGImage, size } from "@/components/ui/og-image";
+
+export const alt = "TechTank TO Get Involved";
+export { size };
+
+export const contentType = "image/png";
+
+export default function OGImage() {
+  return createOGImage({
+    title: "VOLUNTEERS",
+    imageAlt: alt,
+  });
+}

--- a/app/get-involved/opengraph-image.tsx
+++ b/app/get-involved/opengraph-image.tsx
@@ -7,7 +7,7 @@ export const contentType = "image/png";
 
 export default function OGImage() {
   return createOGImage({
-    title: "VOLUNTEERS",
+    title: "GET INVOLVED",
     imageAlt: alt,
   });
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,23 +31,23 @@ export async function generateMetadata(): Promise<Metadata> {
     },
     description:
       "Foster a supportive and inclusive environment where people of all skill levels can explore, create, and thrive in technology. Monthly in-person events in Toronto.",
-    openGraph: {
-      title: "TechTank TO — Toronto's Tech Community",
-      description:
-        "Foster a supportive and inclusive environment where people of all skill levels can explore, create, and thrive in technology.",
-      url: host,
-      siteName: "TechTank TO",
-      images: [
-        {
-          url: "/images/logos/light.png",
-          width: 1200,
-          height: 630,
-          alt: "TechTank TO",
-        },
-      ],
-      locale: "en_CA",
-      type: "website",
-    },
+    // openGraph: {
+    //   title: "TechTank TO — Toronto's Tech Community",
+    //   description:
+    //     "Foster a supportive and inclusive environment where people of all skill levels can explore, create, and thrive in technology.",
+    //   url: host,
+    //   siteName: "TechTank TO",
+    //   images: [
+    //     {
+    //       url: "/images/logos/light.png",
+    //       width: 1200,
+    //       height: 630,
+    //       alt: "TechTank TO",
+    //     },
+    //   ],
+    //   locale: "en_CA",
+    //   type: "website",
+    // },
     twitter: {
       card: "summary_large_image",
       title: "TechTank TO — Toronto's Tech Community",
@@ -83,7 +83,13 @@ export default async function RootLayout({
       className={`${inter.variable} ${spaceGrotesk.variable} bg-background`}
     >
       <body className="min-h-screen flex flex-col font-sans antialiased">
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange themes={["light", "dark"]}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+          themes={["light", "dark"]}
+        >
           <Header />
           <main className="flex-1">{children}</main>
           <Footer />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,23 +31,6 @@ export async function generateMetadata(): Promise<Metadata> {
     },
     description:
       "Foster a supportive and inclusive environment where people of all skill levels can explore, create, and thrive in technology. Monthly in-person events in Toronto.",
-    // openGraph: {
-    //   title: "TechTank TO — Toronto's Tech Community",
-    //   description:
-    //     "Foster a supportive and inclusive environment where people of all skill levels can explore, create, and thrive in technology.",
-    //   url: host,
-    //   siteName: "TechTank TO",
-    //   images: [
-    //     {
-    //       url: "/images/logos/light.png",
-    //       width: 1200,
-    //       height: 630,
-    //       alt: "TechTank TO",
-    //     },
-    //   ],
-    //   locale: "en_CA",
-    //   type: "website",
-    // },
     twitter: {
       card: "summary_large_image",
       title: "TechTank TO — Toronto's Tech Community",

--- a/app/legal/opengraph-image.tsx
+++ b/app/legal/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { createOGImage, size } from "@/components/ui/og-image";
+
+export const alt = "TechTank TO Legal";
+export { size };
+
+export const contentType = "image/png";
+
+export default function OGImage() {
+  return createOGImage({
+    title: "LEGAL",
+    imageAlt: alt,
+  });
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,40 @@
+import { ImageResponse } from "next/og";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+// Image metadata
+export const alt = "TechTank TO";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = "image/png";
+
+// Image generation
+export default async function OGImage() {
+  const imageData = await readFile(
+    join(process.cwd(), "public/images/logos/light.png"),
+  );
+  const base64Image = `data:image/png;base64,${imageData.toString("base64")}`;
+
+  return new ImageResponse(
+    <div
+      style={{
+        fontSize: 128,
+        background: "white",
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <img src={base64Image} alt="TechTank TO" />
+    </div>,
+    {
+      ...size,
+    },
+  );
+}

--- a/app/resources/design-system/opengraph-image.tsx
+++ b/app/resources/design-system/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { createOGImage, size } from "@/components/ui/og-image";
+
+export const alt = "TechTank TO Design System";
+export { size };
+
+export const contentType = "image/png";
+
+export default function OGImage() {
+  return createOGImage({
+    title: "DESIGN SYSTEM",
+    imageAlt: alt,
+  });
+}

--- a/app/resources/media-kit/opengraph-image.tsx
+++ b/app/resources/media-kit/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { createOGImage, size } from "@/components/ui/og-image";
+
+export const alt = "TechTank TO Media Kit";
+export { size };
+
+export const contentType = "image/png";
+
+export default function OGImage() {
+  return createOGImage({
+    title: "MEDIA KIT",
+    imageAlt: alt,
+  });
+}

--- a/components/ui/og-image.tsx
+++ b/components/ui/og-image.tsx
@@ -1,0 +1,100 @@
+import { ImageResponse } from "next/og";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+const logoPath = join(process.cwd(), "public/images/logos/light.png");
+
+async function loadGoogleFont(font: string, text: string) {
+  const url = `https://fonts.googleapis.com/css2?family=${font}&text=${encodeURIComponent(
+    text,
+  )}`;
+
+  const css = await fetch(url).then((res) => res.text());
+
+  const resource = css.match(
+    /src: url\((.+)\) format\('(opentype|truetype)'\)/,
+  );
+
+  if (!resource) {
+    throw new Error("Failed to load font");
+  }
+
+  return fetch(resource[1]).then((res) => res.arrayBuffer());
+}
+
+type CreateOGImageParams = {
+  title?: string;
+  imageAlt?: string;
+};
+
+export async function createOGImage({
+  title,
+  imageAlt = "TechTank TO",
+}: CreateOGImageParams) {
+  const hasTitle = Boolean(title?.trim());
+
+  const logo = await readFile(logoPath);
+  const logoSrc = `data:image/png;base64,${logo.toString("base64")}`;
+
+  const font =
+    hasTitle && title ? await loadGoogleFont("Inter:wght@700", title) : null;
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#ffffff",
+        color: "#224056",
+        padding: hasTitle ? "80px" : "0px",
+        fontFamily: "Space Grotesk",
+      }}
+    >
+      <img
+        src={logoSrc}
+        alt={imageAlt}
+        style={{
+          width: hasTitle ? "820px" : "1200px",
+          objectFit: "contain",
+        }}
+      />
+
+      {hasTitle && (
+        <div
+          style={{
+            marginTop: "56px",
+            fontSize: "88px",
+            fontWeight: 700,
+            letterSpacing: "0.08em",
+            lineHeight: 1,
+          }}
+        >
+          {title}
+        </div>
+      )}
+    </div>,
+    {
+      ...size,
+      fonts:
+        hasTitle && font
+          ? [
+              {
+                name: "Inter",
+                data: font,
+                weight: 700,
+                style: "normal",
+              },
+            ]
+          : [],
+    },
+  );
+}


### PR DESCRIPTION
# Summary

Enable Dynamic Open Graph images based on page params.

## Screenshots

for /
<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/00b1ecc1-68ea-4441-b0de-f209e906bfe7" />

<br />

for /events
<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/187832ee-a523-46da-9489-86fb3eaf6f9e" />


## Checklist

- [x] No new TypeScript errors (`pnpm build` and `pnpm lint:fix` passes)
- [x] Visually tested in the browser (desktop + mobile)
- [x] PRD updated if information architecture, routes or design system is changed (`prd/`)
- [x] No placeholder content (`#`, `TODO`, Lorem Ipsum) left in production paths
- [x] Close the issue on merge
