### PR TITLE
fix(not-found): resolve horizontal overflow and add touch support of 404 easter egg

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -5,21 +5,21 @@ import PreviousButton from "@/components/ui/PreviousButton"
 export default function NotFound() {
   return (
     <main
-      className={`relative min-h-dvh`}
+      className={`relative min-h-dvh overflow-x-hidden`}
     >
       {/* Canvas */}
       <FishCanvas />
 
       {/* UI overlay */}
       <div className="absolute inset-0 z-20 flex flex-col items-center justify-center">
-        <h1 className="text-[16rem] leading-[0.85] tracking-[-0.04em]">
+        <h1 className="text-[8rem] sm:text-[12rem] md:text-[16rem] leading-[0.85] tracking-[-0.04em]">
           404
         </h1>
         <p className="font-mono mt-6 uppercase tracking-[0.22em] text-[0.7rem]">
           Page not found
         </p>
         <p className="mt-3 uppercase tracking-[0.18em] text-[0.6rem] animate-pulse">
-          move your cursor to reveal
+          move cursor or touch to reveal
         </p>
         <PreviousButton />
       </div>

--- a/components/ui/fish-canvas.tsx
+++ b/components/ui/fish-canvas.tsx
@@ -108,12 +108,10 @@ export default function FishCanvas() {
     let lastTime = 0;
 
     function resize() {
-      W = window.innerWidth;
-      H = window.innerHeight;
+      W = canvas!.clientWidth;
+      H = canvas!.clientHeight;
       canvas!.width = W * dpr;
       canvas!.height = H * dpr;
-      canvas!.style.width = `${W}px`;
-      canvas!.style.height = `${H}px`;
       ctx!.scale(dpr, dpr);
       fishRef.current = Array.from({ length: FISH_COUNT }, (_, i) =>
         makeFish(i, W, H)
@@ -155,11 +153,26 @@ export default function FishCanvas() {
       mouseRef.current = { x: e.clientX, y: e.clientY };
       setCursorPos({ x: e.clientX, y: e.clientY });
     }
+    
+    function handleTouchMove(e: TouchEvent) {
+      if (e.touches.length > 0) {
+        mouseRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+        setCursorPos({ x: e.touches[0].clientX, y: e.touches[0].clientY });
+      }
+    }
+
     window.addEventListener('mousemove', handleMouseMove);
-    return () => window.removeEventListener('mousemove', handleMouseMove);
+    window.addEventListener('touchmove', handleTouchMove);
+    window.addEventListener('touchstart', handleTouchMove);
+    
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('touchmove', handleTouchMove);
+      window.removeEventListener('touchstart', handleTouchMove);
+    };
   }, []);
 
   return (
-      <canvas ref={canvasRef} className="absolute inset-0 z-0" />
+      <canvas ref={canvasRef} className="absolute inset-0 z-0 w-full h-full" />
   );
 }


### PR DESCRIPTION
# Summary
- Refactor `fish-canvas` to calculate internal drawing resolution using element `clientWidth`/`clientHeight` instead of `window.innerWidth`
- Replace JS-injected inline styles with Tailwind `w-full h-full` classes for reliable layout sizing
- Add `overflow-x-hidden` to 404 page container to prevent scrollbars from sub-pixel rounding
- Implement `touchmove` and `touchstart` event listeners for mobile interaction parity
- Update 404 page prompt text to explicitly mention touch interactions

## Screenshots

Before:
<img width="310" height="687" alt="image" src="https://github.com/user-attachments/assets/2a9731ce-7adc-4ef2-b179-f17e93e7ef88" />
<img width="2881" height="1618" alt="image" src="https://github.com/user-attachments/assets/3e67284b-1124-41f6-af19-5496b66382c7" />

After:
<img width="310" height="688" alt="image" src="https://github.com/user-attachments/assets/42aed759-26c8-4780-884f-bcb5ab2c11bb" />
<img width="2875" height="1623" alt="image" src="https://github.com/user-attachments/assets/ca0731f3-2ced-459b-a787-5cef489c8e57" />



## Checklist

- [x] No new TypeScript errors (`pnpm build` and `pnpm lint:fix` passes)
- [x] Visually tested in the browser (desktop + mobile)
- [x] PRD updated if information architecture, routes or design system is changed (`prd/`)
- [x] No placeholder content (`#`, `TODO`, Lorem Ipsum) left in production paths
- [x] Close the issue on merge
