### PR TITLE
docs: add contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,28 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for contribution guidelines.
 3. Keep one dominant CTA per page. Role pages under `/get-involved/*` must end
    in an intake action (email us).
 
+## Contributors
+
+This redesign was built by TechTank TO volunteers who gave their time to a
+community they believe in. Thank you to everyone who shipped it 💙
+
+- [Batstone Christyanton](https://github.com/batstonechristyanton)
+- [Danny Kim](https://github.com/0916dhkim)
+- [Danyal Imran](https://github.com/imRanDan)
+- [Jacky](https://github.com/jackytea)
+- [John Malapit](https://github.com/johnmal-dev)
+- [Justin Bento](https://github.com/Justin-Bento)
+- [Jyle Vergara](https://github.com/jylevergara)
+- [Miller Gonzalez](https://github.com/Millertaker)
+- [Niki Fereidooni](https://github.com/nfereidooni)
+- [Rohan Villoth](https://github.com/RohanVilloth)
+- [Taehyeon Kim](https://github.com/1234tgk)
+- [Tony Ko](https://github.com/tkodev)
+
+And a heartfelt thank you to everyone who built and stewarded earlier versions
+of techtankto.com. This redesign stands on the foundation, inspiration, and
+lessons you left behind.
+
 ## License
 
 [MIT](./LICENSE.md) — see the file for details.

--- a/README.md
+++ b/README.md
@@ -104,18 +104,18 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for contribution guidelines.
 This redesign was built by TechTank TO volunteers who gave their time to a
 community they believe in. Thank you to everyone who shipped it 💙
 
-- [Batstone Christyanton](https://github.com/batstonechristyanton)
-- [Danny Kim](https://github.com/0916dhkim)
-- [Danyal Imran](https://github.com/imRanDan)
+- [Tony Ko](https://github.com/tkodev)
+- [Rohan Villoth](https://github.com/RohanVilloth)
+- [Justin Bento](https://github.com/Justin-Bento)
 - [Jacky](https://github.com/jackytea)
 - [John Malapit](https://github.com/johnmal-dev)
-- [Justin Bento](https://github.com/Justin-Bento)
-- [Jyle Vergara](https://github.com/jylevergara)
-- [Miller Gonzalez](https://github.com/Millertaker)
+- [Danyal Imran](https://github.com/imRanDan)
 - [Niki Fereidooni](https://github.com/nfereidooni)
-- [Rohan Villoth](https://github.com/RohanVilloth)
+- [Danny Kim](https://github.com/0916dhkim)
+- [Batstone Christyanton](https://github.com/batstonechristyanton)
+- [Miller Gonzalez](https://github.com/Millertaker)
 - [Taehyeon Kim](https://github.com/1234tgk)
-- [Tony Ko](https://github.com/tkodev)
+- [Jyle Vergara](https://github.com/jylevergara)
 
 And a heartfelt thank you to everyone who built and stewarded earlier versions
 of techtankto.com. This redesign stands on the foundation, inspiration, and


### PR DESCRIPTION
## What

Adds a **Contributors** section to the README, between *Contributing* and *License*.

- Credits the volunteers who built the techtankto.com redesign (linked to their GitHub profiles where available).
- Adds a closing thank-you to everyone who built and stewarded earlier versions of the site.

## Why

The redesign was a team effort across many volunteers. This gives them durable, public credit in the repo itself.

## Notes

- List is alphabetical by first name; no ranking implied.
- Verified against `git shortlog` across all branches. Folks who contributed bios/content only (no commits) were intentionally left off per maintainer direction.