### PR TITLE
fix(marquee): items overlapped in reduced motion mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -323,34 +323,20 @@
 
 /* Marquee */
 @keyframes marquee {
-  /* 
-    Path length = gap * total items - item width 
-    Gap = max(container / visible count, item width + 32px)
-  */
-  from { 
-    transform: translateX(
-      calc(
-        max(100cqw / var(--visible-count, 4), calc(var(--item-width, 250px) + 32px)) * var(--total-items, 4) - var(--item-width, 250px)
-      )
-    ); 
-  }
-  to { 
-    transform: translateX(calc(-1 * var(--item-width, 250px))); 
-  }
+  from { transform: translateX(0); }
+  to   { transform: translateX(calc(-100% / var(--marquee-copies, 2))); }
 }
 
-.animate-marquee {
-  animation: marquee var(--marquee-duration, 25s) linear infinite;
-  animation-delay: calc(var(--marquee-duration, 25s) / var(--total-items, 4) * var(--item-index, 0) * -1);
-  will-change: transform;
-}
-
-.modern-marquee:hover .animate-marquee {
-  animation-play-state: paused !important;
+.marquee-track {
+  animation-name: marquee;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  animation-duration: var(--marquee-duration, 25s);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .animate-marquee {
+  .marquee-track {
     animation: none;
+    transform: none;
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -322,6 +322,14 @@
 }
 
 /* Marquee */
+.marquee-container {
+  container-type: inline-size;
+}
+
+.marquee-item {
+  width: max(100cqw / var(--visible-count, 4), var(--item-width, 250px));
+}
+
 @keyframes marquee {
   from { transform: translateX(0); }
   to   { transform: translateX(calc(-100% / var(--marquee-copies, 2))); }
@@ -332,6 +340,10 @@
   animation-timing-function: linear;
   animation-iteration-count: infinite;
   animation-duration: var(--marquee-duration, 25s);
+}
+
+.marquee-track:hover {
+  animation-play-state: paused !important;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/components/ui/marquee.tsx
+++ b/components/ui/marquee.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import { cn } from "@/utils/theme";
 
@@ -8,42 +6,47 @@ interface MarqueeProps {
   className?: string;
   itemWidth?: string;
   duration?: string;
-  visibleCount?: number;
+  copies?: number;
 }
 
-export function Marquee({ 
-  children, 
+export function Marquee({
+  children,
   className,
   itemWidth = "250px",
   duration = "25s",
-  visibleCount = 4
+  copies = 2,
 }: MarqueeProps) {
-  const count = React.Children.count(children);
+  const childArray = React.Children.toArray(children);
 
   return (
-    <div 
-      className={cn("@container modern-marquee relative w-full overflow-hidden", className)}
-    >
-      {/* Invisible placeholder dictates the natural height of the container */}
-      <div className="invisible pointer-events-none opacity-0" aria-hidden="true">
-        {React.Children.toArray(children)[0]}
-      </div>
-
-      {React.Children.map(children, (child, index) => (
-        <div 
-          className="absolute inset-y-0 left-0 flex items-center justify-center animate-marquee"
-          style={{
-            width: itemWidth,
-            "--item-width": itemWidth,
-            "--total-items": count,
-            "--item-index": index,
+    <div className={cn("relative w-full overflow-hidden", className)}>
+      <div
+        className="flex w-max marquee-track"
+        style={
+          {
             "--marquee-duration": duration,
-            "--visible-count": visibleCount,
-          } as React.CSSProperties}
-        >
-          {child}
-        </div>
-      ))}
+            "--marquee-copies": copies,
+          } as React.CSSProperties
+        }
+      >
+        {Array.from({ length: copies }).map((_, copyIndex) => (
+          <div
+            key={copyIndex}
+            className="flex flex-none"
+            aria-hidden={copyIndex > 0 || undefined}
+          >
+            {childArray.map((child, i) => (
+              <div
+                key={i}
+                className="flex-none flex items-center justify-center px-8"
+                style={{ width: itemWidth }}
+              >
+                {child}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/ui/marquee.tsx
+++ b/components/ui/marquee.tsx
@@ -7,6 +7,7 @@ interface MarqueeProps {
   itemWidth?: string;
   duration?: string;
   copies?: number;
+  visibleCount?: number;
 }
 
 export function Marquee({
@@ -15,17 +16,20 @@ export function Marquee({
   itemWidth = "250px",
   duration = "25s",
   copies = 2,
+  visibleCount = 4,
 }: MarqueeProps) {
   const childArray = React.Children.toArray(children);
 
   return (
-    <div className={cn("relative w-full overflow-hidden", className)}>
+    <div className={cn("marquee-container relative w-full overflow-hidden", className)}>
       <div
         className="flex w-max marquee-track"
         style={
           {
             "--marquee-duration": duration,
             "--marquee-copies": copies,
+            "--item-width": itemWidth,
+            "--visible-count": visibleCount,
           } as React.CSSProperties
         }
       >
@@ -38,8 +42,7 @@ export function Marquee({
             {childArray.map((child, i) => (
               <div
                 key={i}
-                className="flex-none flex items-center justify-center px-8"
-                style={{ width: itemWidth }}
+                className="marquee-item flex-none flex items-center justify-center px-8"
               >
                 {child}
               </div>

--- a/components/ui/sponsors-marquee.tsx
+++ b/components/ui/sponsors-marquee.tsx
@@ -8,7 +8,7 @@ const sponsors = getAllSponsors();
 
 export function SponsorsMarquee({ className }: { className?: string }) {
   return (
-    <Marquee duration="40s" itemWidth="180px" visibleCount={5} className={className}>
+    <Marquee duration="40s" itemWidth="200px" className={className}>
       {sponsors.map((sponsor) => (
         <a
           key={sponsor.id}

--- a/components/ui/stats-marquee.tsx
+++ b/components/ui/stats-marquee.tsx
@@ -10,7 +10,7 @@ const items = [
 
 export function StatsMarquee({ className }: { className?: string }) {
   return (
-    <Marquee duration="25s" itemWidth="160px" visibleCount={3} className={className}>
+    <Marquee duration="25s" itemWidth="300px" copies={5} className={className}>
       {items.map((item) => (
         <div key={item.label} className="flex flex-col items-center text-center">
           <span className="font-display text-xl lg:text-2xl font-bold text-foreground">


### PR DESCRIPTION
# Summary

- `components/ui/marquee.tsx` shows items overlapping when `prefers-reduced-motion: reduce` is `true`

## Screenshots

**Before:**
<img width="1232" height="270" alt="dark_mode_sponsors_OLD" src="https://github.com/user-attachments/assets/243c2c1a-31a8-468e-82cc-8e40c668a77e" />
<img width="1209" height="244" alt="dark_mode_stats_OLD" src="https://github.com/user-attachments/assets/26f5e4a6-d89a-4f91-adf3-a58fa22207ce" />
<img width="1243" height="279" alt="light_mode_sponsors_OLD" src="https://github.com/user-attachments/assets/5aa401b3-3a73-4fb6-a829-d19bee5a4f02" />
<img width="1226" height="233" alt="light_mode_stats_OLD" src="https://github.com/user-attachments/assets/2748a151-d3f6-48f7-b9d4-1b324ec62174" />

**After:**
<img width="1227" height="251" alt="Screenshot 2026-06-27 133614" src="https://github.com/user-attachments/assets/5dfde1e6-0a4c-4465-b811-29977de8f5fc" />
<img width="1261" height="249" alt="dark_mode_stats" src="https://github.com/user-attachments/assets/b0deddfe-9351-48b6-ac1c-9582b3426763" />
<img width="1224" height="264" alt="Screenshot 2026-06-27 133605" src="https://github.com/user-attachments/assets/cf0a6e50-aed1-4c85-9078-16f5427ec0a5" />
<img width="1239" height="261" alt="light_mode_stats" src="https://github.com/user-attachments/assets/58dda551-13c7-41e2-b1e2-ec6bbfa213cb" />


## Checklist

- [x] No new TypeScript errors (`pnpm build` and `pnpm lint:fix` passes)
- [x] Visually tested in the browser (desktop + mobile)
- [x] PRD updated if information architecture, routes or design system is changed (`prd/`)
- [x] No placeholder content (`#`, `TODO`, Lorem Ipsum) left in production paths
- [x] Close the issue on merge
