### PR TITLE
chore: set up oxfmt + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  typecheck:
+  type-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,7 +16,7 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm typecheck
+      - run: pnpm type:check
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm format:check

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 120,
+  "ignorePatterns": []
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ Components follow [shadcn/ui](https://ui.shadcn.com/) patterns with
   `get-involved/sponsor`, `prd`, `legal`, etc.) when one is obvious;
   omit it when the change is global.
 - Keep the subject under ~72 characters, lowercase, no trailing
-  period; explain the *why* in the body if the diff alone doesn't.
+  period; explain the _why_ in the body if the diff alone doesn't.
 - Use `!` (e.g. `feat(get-involved)!: …`) and a `BREAKING CHANGE:`
   footer for changes that move URLs, rename routes, or alter
   documented behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,13 @@ Components follow [shadcn/ui](https://ui.shadcn.com/) patterns with
 - Pair every background token with its matching foreground: `bg-primary → text-primary-foreground`, `bg-secondary → text-secondary-foreground`, `bg-success → text-success-foreground`.
 - Gradients are defined as CSS utility classes (`.gradient-brand`, `.gradient-hero`, etc.) with `.dark` overrides in `globals.css`; use the class name in JSX, never inline `background:` values.
 
+### After making code changes
+
+- Run `pnpm typecheck` to catch type errors.
+- Run `pnpm format` to keep the codebase oxfmt-clean.
+
+Do both before reporting a task complete or opening a commit.
+
 ### Adding a new page
 
 1. Decide where it belongs in the IA. If it's a role, it goes under

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ Components follow [shadcn/ui](https://ui.shadcn.com/) patterns with
 
 ### After making code changes
 
-- Run `pnpm typecheck` to catch type errors.
+- Run `pnpm type:check` to catch type errors.
 - Run `pnpm format` to keep the codebase oxfmt-clean.
 
 Do both before reporting a task complete or opening a commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,20 @@ chore/upgrade-tailwind
 - Lowercase, hyphen-separated, ≤40 characters
 - Reference the affected area, not a ticket number
 
+## Editor setup
+
+This repo uses [oxfmt](https://www.npmjs.com/package/oxfmt) for formatting. In VS Code, install the [Oxc extension](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode), set it as the default formatter, and enable format-on-save:
+
+```jsonc
+// .vscode/settings.json
+{
+  "editor.defaultFormatter": "oxc.oxc-vscode",
+  "editor.formatOnSave": true,
+}
+```
+
+You can also run `pnpm format` from the CLI at any time.
+
 ## Pull requests
 
 - One focused concern per PR — avoid mixing features with refactors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ This repo uses [Conventional Commits](https://www.conventionalcommits.org/).
 
 **Scope:** match the affected page or area — `home`, `about`, `events`, `get-involved/sponsor`, `legal`, `design-system`, `prd`, etc. Omit when the change is global.
 
-**Subject:** lowercase, no trailing period, ≤72 characters. Put the *why* in the commit body if the diff alone doesn't explain it.
+**Subject:** lowercase, no trailing period, ≤72 characters. Put the _why_ in the commit body if the diff alone doesn't explain it.
 
 **Breaking changes:** append `!` to the type+scope and add a `BREAKING CHANGE:` footer for anything that moves a URL, renames a route, or alters documented behaviour.
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Then open <http://localhost:3000>.
 
 ### Scripts
 
-| Command | What it does |
-|---|---|
-| `pnpm dev` | Start the dev server with Turbopack |
-| `pnpm build` | Production build |
-| `pnpm start` | Serve the production build |
-| `pnpm lint` | Run Next.js' linter |
-| `pnpm format` | Format the repo with oxfmt |
-| `pnpm format:check` | Check formatting without writing |
+| Command             | What it does                        |
+| ------------------- | ----------------------------------- |
+| `pnpm dev`          | Start the dev server with Turbopack |
+| `pnpm build`        | Production build                    |
+| `pnpm start`        | Serve the production build          |
+| `pnpm lint`         | Run Next.js' linter                 |
+| `pnpm format`       | Format the repo with oxfmt          |
+| `pnpm format:check` | Check formatting without writing    |
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Then open <http://localhost:3000>.
 | `pnpm build` | Production build |
 | `pnpm start` | Serve the production build |
 | `pnpm lint` | Run Next.js' linter |
+| `pnpm format` | Format the repo with oxfmt |
+| `pnpm format:check` | Check formatting without writing |
 
 ## Project structure
 

--- a/app/about/faq/page.tsx
+++ b/app/about/faq/page.tsx
@@ -1,12 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Section, SectionHeader } from "@/components/ui/section";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 
 export const metadata: Metadata = {
   title: "FAQ",
@@ -47,8 +42,12 @@ const faqs = [
         q: "Can my company sponsor or host an event?",
         a: (
           <>
-            Yes. Companies can sponsor by providing a venue, covering food and drinks, or contributing financially. Hosting a TechTank event is a great way to get your space and team in front of Toronto's tech community.{" "}
-            <Link href="/get-involved/sponsor" className="underline underline-offset-2 hover:text-foreground transition-colors">
+            Yes. Companies can sponsor by providing a venue, covering food and drinks, or contributing financially.
+            Hosting a TechTank event is a great way to get your space and team in front of Toronto's tech community.{" "}
+            <Link
+              href="/get-involved/sponsor"
+              className="underline underline-offset-2 hover:text-foreground transition-colors"
+            >
               Fill out the sponsor and host inquiry form
             </Link>{" "}
             and an organizer will follow up.
@@ -59,7 +58,10 @@ const faqs = [
         q: "Where does donation and sponsorship money go?",
         a: (
           <>
-            <p className="mb-3">TechTank is a nonprofit run almost entirely by volunteers. When you donate or when a company sponsors us, here is where that money goes:</p>
+            <p className="mb-3">
+              TechTank is a nonprofit run almost entirely by volunteers. When you donate or when a company sponsors us,
+              here is where that money goes:
+            </p>
             <ul className="list-disc list-inside space-y-1 text-muted-foreground mb-3">
               <li>Platform fees for Luma and Meetup</li>
               <li>Website hosting and domain costs</li>
@@ -68,9 +70,15 @@ const faqs = [
               <li>Special event costs for socials and programming not covered by a venue sponsor</li>
               <li>Operational costs including legal and bookkeeping services</li>
               <li>Food and drinks for volunteers and organizers at events and team meetings</li>
-              <li>Eventually: speaker honorariums and travel costs, as we grow our ability to bring in speakers who require compensation</li>
+              <li>
+                Eventually: speaker honorariums and travel costs, as we grow our ability to bring in speakers who
+                require compensation
+              </li>
             </ul>
-            <p>We keep most events free specifically because we believe access to community shouldn't cost anything. Donations and sponsorships are what make that possible.</p>
+            <p>
+              We keep most events free specifically because we believe access to community shouldn't cost anything.
+              Donations and sponsorships are what make that possible.
+            </p>
           </>
         ),
       },
@@ -91,8 +99,12 @@ const faqs = [
         q: "I have an idea for an event or initiative. Can I bring it to TechTank?",
         a: (
           <>
-            Please do. TechTank has been shaped by people who showed up with ideas and made them happen. If you want to organize something, facilitate a workshop, or launch a new initiative under the TechTank umbrella,{" "}
-            <a href="mailto:techtankto@gmail.com" className="underline underline-offset-2 hover:text-foreground transition-colors">
+            Please do. TechTank has been shaped by people who showed up with ideas and made them happen. If you want to
+            organize something, facilitate a workshop, or launch a new initiative under the TechTank umbrella,{" "}
+            <a
+              href="mailto:techtankto@gmail.com"
+              className="underline underline-offset-2 hover:text-foreground transition-colors"
+            >
               reach out
             </a>{" "}
             or fill out the organizer interest form. We'd love to hear it.
@@ -103,8 +115,14 @@ const faqs = [
         q: "Can I volunteer?",
         a: (
           <>
-            Yes. We need help behind the scenes with social media, design, website, operations, fundraising, and sponsorship outreach. We also need people to help run events like socials and Tech Talks — though for event roles, we ask that you get involved in the community first so you know what TechTank is all about. Time commitment varies.{" "}
-            <Link href="/get-involved/volunteer" className="underline underline-offset-2 hover:text-foreground transition-colors">
+            Yes. We need help behind the scenes with social media, design, website, operations, fundraising, and
+            sponsorship outreach. We also need people to help run events like socials and Tech Talks — though for event
+            roles, we ask that you get involved in the community first so you know what TechTank is all about. Time
+            commitment varies.{" "}
+            <Link
+              href="/get-involved/volunteer"
+              className="underline underline-offset-2 hover:text-foreground transition-colors"
+            >
               Fill out the volunteer form
             </Link>{" "}
             and we'll be in touch.
@@ -129,11 +147,18 @@ const faqs = [
         a: (
           <>
             Please reach out to us at{" "}
-            <a href="mailto:techtankto@gmail.com" className="underline underline-offset-2 hover:text-foreground transition-colors">
+            <a
+              href="mailto:techtankto@gmail.com"
+              className="underline underline-offset-2 hover:text-foreground transition-colors"
+            >
               techtankto@gmail.com
             </a>{" "}
-            or speak to any organizer at the event. We take every report seriously and handle them confidentially. You can also review our full{" "}
-            <Link href="/legal/code-of-conduct" className="underline underline-offset-2 hover:text-foreground transition-colors">
+            or speak to any organizer at the event. We take every report seriously and handle them confidentially. You
+            can also review our full{" "}
+            <Link
+              href="/legal/code-of-conduct"
+              className="underline underline-offset-2 hover:text-foreground transition-colors"
+            >
               Code of Conduct
             </Link>{" "}
             for more detail on how reports are handled.
@@ -151,15 +176,13 @@ export default function FAQPage() {
       <section className="relative overflow-hidden gradient-hero texture-grain">
         <div className="relative mx-auto max-w-7xl px-6 py-16 lg:px-8 lg:py-24">
           <div className="max-w-3xl">
-            <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
-              FAQ
-            </span>
+            <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">FAQ</span>
             <h1 className="font-display text-4xl md:text-5xl font-semibold text-foreground lg:text-6xl text-balance mb-6">
               Frequently asked questions
             </h1>
             <p className="text-xl text-muted-foreground leading-relaxed">
-              Everything you need to know about TechTank — events, membership,
-              sponsorship, and more. Can't find what you're looking for?{" "}
+              Everything you need to know about TechTank — events, membership, sponsorship, and more. Can't find what
+              you're looking for?{" "}
               <a
                 href="mailto:techtankto@gmail.com"
                 className="underline underline-offset-2 hover:text-foreground transition-colors"
@@ -176,11 +199,7 @@ export default function FAQPage() {
       {faqs.map((group, groupIndex) => (
         <Section key={group.category} background={groupIndex % 2 === 0 ? undefined : "white"}>
           <div>
-            <SectionHeader
-              overline={group.category}
-              title={group.category}
-              className="mb-8"
-            />
+            <SectionHeader overline={group.category} title={group.category} className="mb-8" />
             <Accordion type="single" collapsible className="space-y-2">
               {group.items.map((item, index) => (
                 <AccordionItem
@@ -191,9 +210,7 @@ export default function FAQPage() {
                   <AccordionTrigger className="text-left font-semibold text-foreground hover:no-underline py-5">
                     {item.q}
                   </AccordionTrigger>
-                  <AccordionContent className="text-muted-foreground leading-relaxed pb-5">
-                    {item.a}
-                  </AccordionContent>
+                  <AccordionContent className="text-muted-foreground leading-relaxed pb-5">{item.a}</AccordionContent>
                 </AccordionItem>
               ))}
             </Accordion>
@@ -207,12 +224,9 @@ export default function FAQPage() {
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
             Still have questions?
           </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            We're happy to help
-          </h2>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">We're happy to help</h2>
           <p className="text-muted-foreground mb-6">
-            If you didn't find what you were looking for, reach out directly and
-            an organizer will get back to you.
+            If you didn't find what you were looking for, reach out directly and an organizer will get back to you.
           </p>
           <a
             href="mailto:techtankto@gmail.com"

--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -20,10 +20,7 @@ export default function AboutLayout({ children }: { children: React.ReactNode })
           <div className="flex items-center justify-center py-3">
             <div className="flex flex-wrap items-center justify-center gap-1">
               {subNav.map((item) => {
-                const isActive =
-                  item.href === "/about"
-                    ? pathname === "/about"
-                    : pathname.startsWith(item.href);
+                const isActive = item.href === "/about" ? pathname === "/about" : pathname.startsWith(item.href);
 
                 return (
                   <Button key={item.name} variant="nav" size="sm" isActive={isActive} asChild>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -17,17 +17,12 @@ import {
 import { Button } from "@/components/ui/button";
 import { Section, SectionHeader } from "@/components/ui/section";
 import { SponsorsMarquee } from "@/components/ui/sponsors-marquee";
-import {
-  getCoverImage,
-  getCoverVideo,
-  getInstagramPostsByIds,
-} from "@/constants/instagram-posts";
+import { getCoverImage, getCoverVideo, getInstagramPostsByIds } from "@/constants/instagram-posts";
 import { socialLinks } from "@/constants/social-links";
 
 export const metadata: Metadata = {
   title: "About",
-  description:
-    "Learn about TechTank's mission, values, story, and the programs we run in Toronto's tech community.",
+  description: "Learn about TechTank's mission, values, story, and the programs we run in Toronto's tech community.",
 };
 
 const values = [
@@ -41,8 +36,7 @@ const values = [
   {
     icon: Users,
     title: "Connection over networking",
-    description:
-      "We prioritize genuine relationships over transactional interactions or surface-level networking.",
+    description: "We prioritize genuine relationships over transactional interactions or surface-level networking.",
     color: "amber",
   },
   {
@@ -55,8 +49,7 @@ const values = [
   {
     icon: MapPin,
     title: "Local impact",
-    description:
-      "We are committed to strengthening Toronto's tech ecosystem by supporting the people within it.",
+    description: "We are committed to strengthening Toronto's tech ecosystem by supporting the people within it.",
     color: "teal",
   },
   {
@@ -97,8 +90,7 @@ const currentPrograms = [
   {
     icon: MessageSquare,
     title: "The Slack Channel",
-    description:
-      "Join the conversation between events. Where the community lives day-to-day.",
+    description: "Join the conversation between events. Where the community lives day-to-day.",
     cta: { label: "Join on Slack", href: socialLinks.slack.url },
   },
 ];
@@ -134,11 +126,9 @@ export default function AboutPage() {
               We build the community we wanted to find
             </h1>
             <p className="text-xl text-muted-foreground leading-relaxed mb-8">
-              TechTank TO is a volunteer-run, Toronto-based tech community
-              founded in 2023. We host year-round in-person events where
-              developers, designers, PMs, and tech-curious people gather to
-              learn, share, and connect. No gatekeeping—just people
-              helping people grow in tech.
+              TechTank TO is a volunteer-run, Toronto-based tech community founded in 2023. We host year-round in-person
+              events where developers, designers, PMs, and tech-curious people gather to learn, share, and connect. No
+              gatekeeping—just people helping people grow in tech.
             </p>
             <div className="flex flex-wrap gap-3">
               <Button variant="primary" size="lg" asChild>
@@ -171,26 +161,17 @@ export default function AboutPage() {
         />
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {values.map((value) => (
-            <div
-              key={value.title}
-              className="flex flex-col gap-4 bg-card rounded-2xl border border-border p-6"
-            >
+            <div key={value.title} className="flex flex-col gap-4 bg-card rounded-2xl border border-border p-6">
               <div
                 className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-xl ${
-                  value.color === "teal"
-                    ? "bg-ring/10 text-ring"
-                    : "bg-amber/10 text-amber"
+                  value.color === "teal" ? "bg-ring/10 text-ring" : "bg-amber/10 text-amber"
                 }`}
               >
                 <value.icon className="h-6 w-6" />
               </div>
               <div>
-                <h3 className="font-display text-lg font-semibold text-foreground mb-2">
-                  {value.title}
-                </h3>
-                <p className="text-muted-foreground leading-relaxed text-sm">
-                  {value.description}
-                </p>
+                <h3 className="font-display text-lg font-semibold text-foreground mb-2">{value.title}</h3>
+                <p className="text-muted-foreground leading-relaxed text-sm">{value.description}</p>
               </div>
             </div>
           ))}
@@ -204,47 +185,32 @@ export default function AboutPage() {
             <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
               From a simple idea to a registered nonprofit
             </span>
-            <h2 className="font-display text-3xl font-semibold text-foreground lg:text-4xl mb-6">
-              Our Story
-            </h2>
+            <h2 className="font-display text-3xl font-semibold text-foreground lg:text-4xl mb-6">Our Story</h2>
             <div className="space-y-4 text-muted-foreground leading-relaxed">
               <p>
-                TechTank TO was founded in January 2023 with a simple idea: build a
-                community for early-stage engineers in Toronto. Free (or low cost)
-                events, real connections, no pressure. A place where people just
-                starting out could learn, meet others, and feel like they belonged
-                somewhere in this industry.
+                TechTank TO was founded in January 2023 with a simple idea: build a community for early-stage engineers
+                in Toronto. Free (or low cost) events, real connections, no pressure. A place where people just starting
+                out could learn, meet others, and feel like they belonged somewhere in this industry.
               </p>
               <p>
-                Since then, TechTank has grown beyond that original vision. The
-                community expanded to include people at all stages of their careers,
-                the programming diversified, and a team of volunteer organizers
-                stepped up to help keep things running.
+                Since then, TechTank has grown beyond that original vision. The community expanded to include people at
+                all stages of their careers, the programming diversified, and a team of volunteer organizers stepped up
+                to help keep things running.
               </p>
               <p>
                 In April 2026, TechTank became a{" "}
-                <strong className="text-foreground">
-                  registered nonprofit corporation in Ontario
-                </strong>
-                .
+                <strong className="text-foreground">registered nonprofit corporation in Ontario</strong>.
               </p>
               <p>
-                At a time when the industry is shifting faster than most people can
-                keep up with, we believe having a community behind you matters more
-                than it used to.
+                At a time when the industry is shifting faster than most people can keep up with, we believe having a
+                community behind you matters more than it used to.
               </p>
             </div>
           </div>
           <div className="relative">
             <div className="relative aspect-4/3 rounded-2xl overflow-hidden bg-linear-to-br from-peach via-lavender to-aqua">
               {featuredVideo ? (
-                <video
-                  autoPlay
-                  loop
-                  muted
-                  playsInline
-                  className="absolute inset-0 h-full w-full object-cover"
-                >
+                <video autoPlay loop muted playsInline className="absolute inset-0 h-full w-full object-cover">
                   <source src={featuredVideo.replace(/\.mp4$/, ".webm")} type="video/webm" />
                   <source src={featuredVideo} type="video/mp4" />
                 </video>
@@ -258,9 +224,7 @@ export default function AboutPage() {
                 />
               ) : (
                 <div className="absolute inset-0 flex items-center justify-center">
-                  <p className="text-center text-foreground/60 px-8">
-                    Event photography placeholder
-                  </p>
+                  <p className="text-center text-foreground/60 px-8">Event photography placeholder</p>
                 </div>
               )}
             </div>
@@ -278,20 +242,13 @@ export default function AboutPage() {
         />
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {currentPrograms.map((program) => (
-            <div
-              key={program.title}
-              className="flex flex-col gap-4 bg-card rounded-2xl border border-border p-6"
-            >
+            <div key={program.title} className="flex flex-col gap-4 bg-card rounded-2xl border border-border p-6">
               <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-ring/10 text-ring">
                 <program.icon className="h-6 w-6" />
               </div>
               <div className="flex-1">
-                <h3 className="font-display text-lg font-semibold text-foreground mb-2">
-                  {program.title}
-                </h3>
-                <p className="text-muted-foreground leading-relaxed text-sm">
-                  {program.description}
-                </p>
+                <h3 className="font-display text-lg font-semibold text-foreground mb-2">{program.title}</h3>
+                <p className="text-muted-foreground leading-relaxed text-sm">{program.description}</p>
               </div>
               {program.cta && (
                 <Button variant="outline" size="sm" className="self-start" asChild>
@@ -301,7 +258,6 @@ export default function AboutPage() {
             </div>
           ))}
         </div>
-
       </Section>
 
       {/* What We've Run Before */}
@@ -314,22 +270,15 @@ export default function AboutPage() {
         />
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {pastPrograms.map((p) => (
-            <div
-              key={p.title}
-              className="flex flex-col gap-4 bg-card rounded-2xl border border-border p-6"
-            >
+            <div key={p.title} className="flex flex-col gap-4 bg-card rounded-2xl border border-border p-6">
               <div className="flex-1">
                 <div className="flex items-center gap-2 mb-2">
-                  <h3 className="font-display text-lg font-semibold text-foreground">
-                    {p.title}
-                  </h3>
+                  <h3 className="font-display text-lg font-semibold text-foreground">{p.title}</h3>
                   <span className="rounded-full bg-warning/40 dark:bg-warning/60 text-warning-foreground px-2 py-0.5 text-xs font-medium">
                     {p.label}
                   </span>
                 </div>
-                <p className="text-muted-foreground leading-relaxed text-sm">
-                  {p.description}
-                </p>
+                <p className="text-muted-foreground leading-relaxed text-sm">{p.description}</p>
               </div>
             </div>
           ))}
@@ -342,12 +291,9 @@ export default function AboutPage() {
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
             Help shape what TechTank becomes
           </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            Get Involved
-          </h2>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">Get Involved</h2>
           <p className="text-lg text-muted-foreground leading-relaxed mb-8">
-            Whether you want to pitch a new idea or get involved in an existing
-            initiative, we want to hear from you.
+            Whether you want to pitch a new idea or get involved in an existing initiative, we want to hear from you.
           </p>
           <div className="flex flex-wrap gap-4 justify-center">
             <Button variant="primary" size="lg" asChild>
@@ -372,29 +318,20 @@ export default function AboutPage() {
           className="mb-6"
         />
         <Button variant="outline" className="mb-10" asChild>
-          <a href="mailto:techtankto@gmail.com">
-            Interested in becoming a technology sponsor? Get in touch.
-          </a>
+          <a href="mailto:techtankto@gmail.com">Interested in becoming a technology sponsor? Get in touch.</a>
         </Button>
         <SponsorsMarquee />
       </Section>
 
       {/* Affiliations */}
       <Section background="white">
-        <SectionHeader
-          overline="Part of something bigger"
-          title="Affiliations"
-          className="mb-10"
-        />
+        <SectionHeader overline="Part of something bigger" title="Affiliations" className="mb-10" />
         <div className="max-w-2xl">
           <div className="rounded-2xl border border-border bg-card p-6 lg:p-8">
-            <h3 className="font-display text-xl font-semibold text-foreground mb-3">
-              Supercollider
-            </h3>
+            <h3 className="font-display text-xl font-semibold text-foreground mb-3">Supercollider</h3>
             <p className="text-muted-foreground leading-relaxed mb-6">
-              TechTank is a proud member of the Supercollider network, a community
-              of communities bringing together Toronto&apos;s tech scene. Our events
-              are listed on their Luma calendar so you can discover everything
+              TechTank is a proud member of the Supercollider network, a community of communities bringing together
+              Toronto&apos;s tech scene. Our events are listed on their Luma calendar so you can discover everything
               happening across the ecosystem.
             </p>
             <div className="flex flex-wrap gap-3">

--- a/app/about/team/page.tsx
+++ b/app/about/team/page.tsx
@@ -7,8 +7,7 @@ import { teamGroups } from "@/constants/team";
 
 export const metadata: Metadata = {
   title: "Team",
-  description:
-    "Meet the volunteers, organizers, and board members who make TechTank TO happen.",
+  description: "Meet the volunteers, organizers, and board members who make TechTank TO happen.",
 };
 
 export default function TeamPage() {
@@ -32,9 +31,8 @@ export default function TeamPage() {
               The people behind TechTank
             </h1>
             <p className="text-xl text-muted-foreground leading-relaxed mb-8">
-              TechTank TO is powered entirely by volunteers — organizers, designers,
-              developers, and community builders who give their time to make
-              Toronto&apos;s tech community more inclusive and welcoming.
+              TechTank TO is powered entirely by volunteers — organizers, designers, developers, and community builders
+              who give their time to make Toronto&apos;s tech community more inclusive and welcoming.
             </p>
             <Button variant="outline" size="lg" asChild>
               <Link href="/get-involved/organizer">Join the team</Link>
@@ -53,9 +51,7 @@ export default function TeamPage() {
         />
 
         <div className="mb-10">
-          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-5">
-            Co-Chairs
-          </p>
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-5">Co-Chairs</p>
           <div className="grid gap-5 sm:grid-cols-2">
             {boardCoChairs.members.map((m) => (
               <TeamCard key={m.name} variant="board" member={m} />
@@ -64,9 +60,7 @@ export default function TeamPage() {
         </div>
 
         <div>
-          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-5">
-            Treasurer
-          </p>
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-5">Treasurer</p>
           <div className="grid gap-5 sm:grid-cols-2">
             {boardTreasurer.members.map((m) => (
               <TeamCard key={m.name} variant="board" member={m} />
@@ -94,11 +88,7 @@ export default function TeamPage() {
       <Section background="brand-soft">
         <div className="grid gap-12 lg:grid-cols-2">
           <div>
-            <SectionHeader
-              overline="Website team"
-              title="Developers & designers"
-              className="mb-8"
-            />
+            <SectionHeader overline="Website team" title="Developers & designers" className="mb-8" />
             <div className="grid gap-3">
               {websiteTeam.members.map((m) => (
                 <TeamCard key={m.name} variant="compact" member={m} />
@@ -106,11 +96,7 @@ export default function TeamPage() {
             </div>
           </div>
           <div>
-            <SectionHeader
-              overline="Social media"
-              title="Content & community"
-              className="mb-8"
-            />
+            <SectionHeader overline="Social media" title="Content & community" className="mb-8" />
             <div className="grid gap-3">
               {socialMedia.members.map((m) => (
                 <TeamCard key={m.name} variant="compact" member={m} />
@@ -141,12 +127,10 @@ export default function TeamPage() {
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
             Get involved
           </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            Want to be part of the team?
-          </h2>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">Want to be part of the team?</h2>
           <p className="text-muted-foreground mb-8">
-            We&apos;re always looking for volunteers who want to help build
-            Toronto&apos;s most inclusive tech community.
+            We&apos;re always looking for volunteers who want to help build Toronto&apos;s most inclusive tech
+            community.
           </p>
           <Button variant="primary" size="lg" asChild>
             <Link href="/get-involved/organizer">Volunteer with us</Link>

--- a/app/events/actions.tsx
+++ b/app/events/actions.tsx
@@ -65,8 +65,7 @@ function lumaCalendarResponseToEvents(parsed: LumaEventResponse[]): Event[] {
     title: event.name,
     start_at: event.start_at,
     tags: [],
-    status:
-      Date.now() > new Date(event.start_at).valueOf() ? "past" : "upcoming",
+    status: Date.now() > new Date(event.start_at).valueOf() ? "past" : "upcoming",
     eventUrl: `https://luma.com/${event.url}`,
     imagePath: event.cover_url,
   }));

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -27,7 +27,7 @@ export default async function EventsPage() {
         const url = e.eventUrl!;
         const parts = url.split("/");
         return parts[parts.length - 1].split("?")[0];
-      })
+      }),
   );
 
   const mergedEvents = [...events];
@@ -42,9 +42,7 @@ export default async function EventsPage() {
   }
 
   // Sort descending by date
-  mergedEvents.sort(
-    (a, b) => new Date(b.start_at).getTime() - new Date(a.start_at).getTime()
-  );
+  mergedEvents.sort((a, b) => new Date(b.start_at).getTime() - new Date(a.start_at).getTime());
 
   return (
     <>
@@ -60,15 +58,12 @@ export default async function EventsPage() {
                 All Events
               </h1>
               <p className="text-xl text-muted-foreground">
-                RSVP to what&apos;s next — and scroll back through the
-                talks, photos, and recaps from every meetup we&apos;ve
-                hosted since 2023.
+                RSVP to what&apos;s next — and scroll back through the talks, photos, and recaps from every meetup
+                we&apos;ve hosted since 2023.
               </p>
             </div>
             <div className="shrink-0">
-              <p className="text-sm font-semibold text-foreground">
-                {mergedEvents.length} EVENTS · SINCE 2023
-              </p>
+              <p className="text-sm font-semibold text-foreground">{mergedEvents.length} EVENTS · SINCE 2023</p>
             </div>
           </div>
         </div>
@@ -76,12 +71,8 @@ export default async function EventsPage() {
 
       {/* Luma Calendar Embed Section */}
       <Section className="bg-[#f7f8f9] dark:bg-[#212325] text-center">
-        <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
-          Next Up
-        </span>
-        <h2 className="font-display text-3xl font-semibold text-foreground mb-6">
-          Subscribe on Luma
-        </h2>
+        <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">Next Up</span>
+        <h2 className="font-display text-3xl font-semibold text-foreground mb-6">Subscribe on Luma</h2>
         <p className="text-lg text-muted-foreground leading-relaxed mb-8">
           Subscribe on Luma to get notified when new events are announced.
         </p>
@@ -141,9 +132,7 @@ export default async function EventsPage() {
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
             Get in touch
           </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            Questions about events?
-          </h2>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">Questions about events?</h2>
         </div>
         <div className="max-w-xl mx-auto">
           <ContactCard context="For hosting, sponsorship, and media inquiries." />

--- a/app/get-involved/host/page.tsx
+++ b/app/get-involved/host/page.tsx
@@ -22,8 +22,7 @@ const whyHost = [
   {
     icon: Building,
     title: "Back to the office",
-    description:
-      "Give your team a reason to come in. Hosting an event creates energy and shows off your space.",
+    description: "Give your team a reason to come in. Hosting an event creates energy and shows off your space.",
   },
   {
     icon: Users,
@@ -88,13 +87,11 @@ export default function HostPage() {
               Host a TechTank event
             </h1>
             <p className="text-xl text-muted-foreground leading-relaxed mb-8">
-              Bring the Toronto tech community to your office. Great for
-              recruiting, brand visibility, and giving back to the community.
+              Bring the Toronto tech community to your office. Great for recruiting, brand visibility, and giving back
+              to the community.
             </p>
             <Button variant="primary" size="lg" asChild>
-              <a href="mailto:techtankto@gmail.com?subject=Host%20Inquiry%20-%20TechTank">
-                Contact us to host
-              </a>
+              <a href="mailto:techtankto@gmail.com?subject=Host%20Inquiry%20-%20TechTank">Contact us to host</a>
             </Button>
           </div>
         </div>
@@ -102,23 +99,14 @@ export default function HostPage() {
 
       {/* Why Host */}
       <Section>
-        <SectionHeader
-          overline="Why host"
-          title="What you get out of it"
-          className="mb-12"
-        />
+        <SectionHeader overline="Why host" title="What you get out of it" className="mb-12" />
         <div className="grid gap-8 lg:grid-cols-3">
           {whyHost.map((item) => (
-            <div
-              key={item.title}
-              className="bg-card rounded-2xl border border-border p-6 lg:p-8"
-            >
+            <div key={item.title} className="bg-card rounded-2xl border border-border p-6 lg:p-8">
               <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-ring/10 text-ring mb-4">
                 <item.icon className="h-6 w-6" />
               </div>
-              <h3 className="font-display text-xl font-semibold text-foreground mb-3">
-                {item.title}
-              </h3>
+              <h3 className="font-display text-xl font-semibold text-foreground mb-3">{item.title}</h3>
               <p className="text-muted-foreground leading-relaxed">{item.description}</p>
             </div>
           ))}
@@ -127,17 +115,10 @@ export default function HostPage() {
 
       {/* Event Logistics */}
       <Section background="white">
-        <SectionHeader
-          overline="Event logistics"
-          title="What we need from your space"
-          className="mb-12"
-        />
+        <SectionHeader overline="Event logistics" title="What we need from your space" className="mb-12" />
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {logistics.map((item) => (
-            <div
-              key={item.label}
-              className="flex items-start gap-4 bg-background rounded-xl p-5"
-            >
+            <div key={item.label} className="flex items-start gap-4 bg-background rounded-xl p-5">
               <item.icon className="h-5 w-5 text-ring shrink-0 mt-0.5" />
               <div>
                 <p className="font-semibold text-foreground">{item.label}</p>
@@ -152,9 +133,7 @@ export default function HostPage() {
       <Section>
         <div className="grid gap-8 lg:grid-cols-2">
           <div className="bg-ring/8 rounded-2xl border border-ring/30 p-6 lg:p-8">
-            <h3 className="font-display text-xl font-semibold text-foreground mb-6">
-              What TechTank handles
-            </h3>
+            <h3 className="font-display text-xl font-semibold text-foreground mb-6">What TechTank handles</h3>
             <ul className="space-y-3">
               {techTankHandles.map((item, index) => (
                 <li key={index} className="flex items-start gap-3">
@@ -166,9 +145,7 @@ export default function HostPage() {
           </div>
 
           <div className="bg-amber/8 rounded-2xl border border-amber/30 p-6 lg:p-8">
-            <h3 className="font-display text-xl font-semibold text-foreground mb-6">
-              What you provide
-            </h3>
+            <h3 className="font-display text-xl font-semibold text-foreground mb-6">What you provide</h3>
             <ul className="space-y-3">
               {youProvide.map((item, index) => (
                 <li key={index} className="flex items-start gap-3">
@@ -184,18 +161,10 @@ export default function HostPage() {
       {/* What You Get */}
       <Section background="brand-soft">
         <div className="max-w-3xl mx-auto">
-          <SectionHeader
-            overline="What you get"
-            title="Host perks"
-            align="center"
-            className="mb-12"
-          />
+          <SectionHeader overline="What you get" title="Host perks" align="center" className="mb-12" />
           <div className="grid gap-4 sm:grid-cols-2">
             {whatYouGet.map((item, index) => (
-              <div
-                key={index}
-                className="flex items-center gap-3 bg-card rounded-lg p-4"
-              >
+              <div key={index} className="flex items-center gap-3 bg-card rounded-lg p-4">
                 <Check className="h-5 w-5 text-ring shrink-0" />
                 <span className="text-foreground">{item}</span>
               </div>
@@ -206,11 +175,7 @@ export default function HostPage() {
 
       {/* Process */}
       <Section>
-        <SectionHeader
-          overline="The process"
-          title="How it works"
-          className="mb-12"
-        />
+        <SectionHeader overline="The process" title="How it works" className="mb-12" />
         <div className="grid gap-6 lg:grid-cols-5">
           {process.map((item) => (
             <div key={item.step} className="relative">
@@ -226,24 +191,15 @@ export default function HostPage() {
 
       {/* Past Hosts Logo Cloud */}
       <Section background="white">
-        <SectionHeader
-          overline="Past hosts"
-          title="Companies that have hosted"
-          align="center"
-          className="mb-8"
-        />
+        <SectionHeader overline="Past hosts" title="Companies that have hosted" align="center" className="mb-8" />
         <SponsorsMarquee className="py-4" />
       </Section>
 
       {/* Host Resources */}
       <Section>
         <div className="max-w-3xl mx-auto text-center">
-          <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
-            Resources
-          </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            Host toolkit in the Media Kit
-          </h2>
+          <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">Resources</span>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">Host toolkit in the Media Kit</h2>
           <p className="text-muted-foreground mb-8">
             Run-of-show guides, host checklists, brand assets, and event templates all live in our Media Kit.
           </p>
@@ -266,13 +222,10 @@ export default function HostPage() {
             Let&apos;s bring TechTank to your space
           </h2>
           <p className="text-muted-foreground mb-8">
-            Tell us about your venue and when you&apos;d like to host. We&apos;ll
-            get back to you within a week.
+            Tell us about your venue and when you&apos;d like to host. We&apos;ll get back to you within a week.
           </p>
           <Button variant="primary" size="lg" asChild>
-            <a href="mailto:techtankto@gmail.com?subject=Host%20Inquiry%20-%20TechTank">
-              Contact us to host
-            </a>
+            <a href="mailto:techtankto@gmail.com?subject=Host%20Inquiry%20-%20TechTank">Contact us to host</a>
           </Button>
         </div>
       </Section>

--- a/app/get-involved/layout.tsx
+++ b/app/get-involved/layout.tsx
@@ -12,11 +12,7 @@ const subNav = [
   { name: "Organizer Team", href: "/get-involved/organizer" },
 ];
 
-export default function GetInvolvedLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function GetInvolvedLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
 
   return (
@@ -29,9 +25,7 @@ export default function GetInvolvedLayout({
             <div className="flex flex-wrap items-center justify-center gap-1">
               {subNav.map((item) => {
                 const isActive =
-                  item.href === "/get-involved"
-                    ? pathname === "/get-involved"
-                    : pathname.startsWith(item.href);
+                  item.href === "/get-involved" ? pathname === "/get-involved" : pathname.startsWith(item.href);
 
                 return (
                   <Button key={item.name} variant="nav" size="sm" isActive={isActive} asChild>

--- a/app/get-involved/organizer/page.tsx
+++ b/app/get-involved/organizer/page.tsx
@@ -55,14 +55,11 @@ export default function OrganizerPage() {
               Join the Organizer Team
             </h1>
             <p className="text-xl text-muted-foreground leading-relaxed mb-8">
-              We&apos;re building out a more structured volunteer leadership
-              team with defined roles and a 6-month commitment. If you want to
-              help shape what TechTank becomes, this is the path.
+              We&apos;re building out a more structured volunteer leadership team with defined roles and a 6-month
+              commitment. If you want to help shape what TechTank becomes, this is the path.
             </p>
             <Button variant="primary" size="lg" asChild>
-              <a href="mailto:techtankto@gmail.com?subject=Organizer%20Team%20Inquiry%20-%20TechTank">
-                Get in touch
-              </a>
+              <a href="mailto:techtankto@gmail.com?subject=Organizer%20Team%20Inquiry%20-%20TechTank">Get in touch</a>
             </Button>
           </div>
         </div>
@@ -70,23 +67,14 @@ export default function OrganizerPage() {
 
       {/* Why Organize */}
       <Section>
-        <SectionHeader
-          overline="Why organize"
-          title="What this role is about"
-          className="mb-12"
-        />
+        <SectionHeader overline="Why organize" title="What this role is about" className="mb-12" />
         <div className="grid gap-8 lg:grid-cols-3">
           {whyOrganize.map((item) => (
-            <div
-              key={item.title}
-              className="bg-card rounded-2xl border border-border p-6 lg:p-8"
-            >
+            <div key={item.title} className="bg-card rounded-2xl border border-border p-6 lg:p-8">
               <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-ring/10 text-ring mb-4">
                 <item.icon className="h-6 w-6" />
               </div>
-              <h3 className="font-display text-xl font-semibold text-foreground mb-3">
-                {item.title}
-              </h3>
+              <h3 className="font-display text-xl font-semibold text-foreground mb-3">{item.title}</h3>
               <p className="text-muted-foreground leading-relaxed">{item.description}</p>
             </div>
           ))}
@@ -96,18 +84,10 @@ export default function OrganizerPage() {
       {/* What You Get */}
       <Section background="brand-soft">
         <div className="max-w-3xl mx-auto">
-          <SectionHeader
-            overline="What you get"
-            title="Organizer perks"
-            align="center"
-            className="mb-12"
-          />
+          <SectionHeader overline="What you get" title="Organizer perks" align="center" className="mb-12" />
           <div className="grid gap-4 sm:grid-cols-2">
             {whatYouGet.map((item, index) => (
-              <div
-                key={index}
-                className="flex items-center gap-3 bg-card rounded-lg p-4"
-              >
+              <div key={index} className="flex items-center gap-3 bg-card rounded-lg p-4">
                 <Check className="h-5 w-5 text-ring shrink-0" />
                 <span className="text-foreground">{item}</span>
               </div>
@@ -122,18 +102,13 @@ export default function OrganizerPage() {
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
             Get started
           </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            Ready to get involved?
-          </h2>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">Ready to get involved?</h2>
           <p className="text-muted-foreground mb-8">
-            Send us a note introducing yourself. Tell us what you&apos;d want
-            to own and why TechTank matters to you.
+            Send us a note introducing yourself. Tell us what you&apos;d want to own and why TechTank matters to you.
           </p>
           <div className="flex flex-wrap items-center justify-center gap-3">
             <Button variant="primary" size="sm" asChild>
-              <a href="mailto:techtankto@gmail.com?subject=Organizer%20Team%20Inquiry%20-%20TechTank">
-                Get in touch
-              </a>
+              <a href="mailto:techtankto@gmail.com?subject=Organizer%20Team%20Inquiry%20-%20TechTank">Get in touch</a>
             </Button>
             <Button variant="outline" size="sm" asChild>
               <Link href="/events">Attend an event first</Link>

--- a/app/get-involved/page.tsx
+++ b/app/get-involved/page.tsx
@@ -31,7 +31,6 @@ const whyGetInvolved = [
   },
 ];
 
-
 export default function GetInvolvedPage() {
   return (
     <>
@@ -46,9 +45,8 @@ export default function GetInvolvedPage() {
               Let&apos;s build TechTank together
             </h1>
             <p className="text-xl text-muted-foreground leading-relaxed">
-              TechTank runs because of people who show up and help make things
-              happen. There are a few ways to get involved depending on where
-              you&apos;re at and what you want to put in.
+              TechTank runs because of people who show up and help make things happen. There are a few ways to get
+              involved depending on where you&apos;re at and what you want to put in.
             </p>
           </div>
         </div>
@@ -56,11 +54,7 @@ export default function GetInvolvedPage() {
 
       {/* Role Cards */}
       <Section>
-        <SectionHeader
-          overline="Ways to get involved"
-          title="Choose your path"
-          className="mb-12"
-        />
+        <SectionHeader overline="Ways to get involved" title="Choose your path" className="mb-12" />
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {roleCardsData.map((role) => (
             <RoleCard key={role.role} {...role} />
@@ -70,23 +64,14 @@ export default function GetInvolvedPage() {
 
       {/* Why Get Involved */}
       <Section background="brand-soft">
-        <SectionHeader
-          overline="Why get involved"
-          title="What you get out of it"
-          className="mb-12"
-        />
+        <SectionHeader overline="Why get involved" title="What you get out of it" className="mb-12" />
         <div className="grid gap-8 lg:grid-cols-3">
           {whyGetInvolved.map((item) => (
-            <div
-              key={item.title}
-              className="bg-card rounded-2xl border border-border p-6 lg:p-8"
-            >
+            <div key={item.title} className="bg-card rounded-2xl border border-border p-6 lg:p-8">
               <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-ring/10 text-ring mb-4">
                 <item.icon className="h-6 w-6" />
               </div>
-              <h3 className="font-display text-xl font-semibold text-foreground mb-3">
-                {item.title}
-              </h3>
+              <h3 className="font-display text-xl font-semibold text-foreground mb-3">{item.title}</h3>
               <p className="text-muted-foreground leading-relaxed">{item.description}</p>
             </div>
           ))}
@@ -99,12 +84,10 @@ export default function GetInvolvedPage() {
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
             Ready to connect?
           </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            Drop us a line
-          </h2>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">Drop us a line</h2>
           <p className="text-muted-foreground">
-            We respond to every message — hosts, sponsors, speakers, and
-            volunteers. Whichever role fits, we&apos;d love to hear from you.
+            We respond to every message — hosts, sponsors, speakers, and volunteers. Whichever role fits, we&apos;d love
+            to hear from you.
           </p>
         </div>
         <div className="max-w-xl mx-auto">

--- a/app/get-involved/speak-or-facilitate/page.tsx
+++ b/app/get-involved/speak-or-facilitate/page.tsx
@@ -78,10 +78,9 @@ export default function SpeakOrFacilitatePage() {
               Speak or Facilitate
             </h1>
             <p className="text-xl text-muted-foreground leading-relaxed mb-8">
-              Got something to share? We&apos;re always looking for speakers,
-              panelists, and workshop facilitators. You don&apos;t need to be a
-              senior engineer or a public figure. If you have a perspective
-              worth hearing, we want to hear it.
+              Got something to share? We&apos;re always looking for speakers, panelists, and workshop facilitators. You
+              don&apos;t need to be a senior engineer or a public figure. If you have a perspective worth hearing, we
+              want to hear it.
             </p>
             <Button variant="primary" size="lg" asChild>
               <a
@@ -98,23 +97,14 @@ export default function SpeakOrFacilitatePage() {
 
       {/* Why Participate */}
       <Section>
-        <SectionHeader
-          overline="Why speak or facilitate"
-          title="What you get out of it"
-          className="mb-12"
-        />
+        <SectionHeader overline="Why speak or facilitate" title="What you get out of it" className="mb-12" />
         <div className="grid gap-8 lg:grid-cols-3">
           {whyParticipate.map((item) => (
-            <div
-              key={item.title}
-              className="bg-card rounded-2xl border border-border p-6 lg:p-8"
-            >
+            <div key={item.title} className="bg-card rounded-2xl border border-border p-6 lg:p-8">
               <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-ring/10 text-ring mb-4">
                 <item.icon className="h-6 w-6" />
               </div>
-              <h3 className="font-display text-xl font-semibold text-foreground mb-3">
-                {item.title}
-              </h3>
+              <h3 className="font-display text-xl font-semibold text-foreground mb-3">{item.title}</h3>
               <p className="text-muted-foreground leading-relaxed">{item.description}</p>
             </div>
           ))}
@@ -123,17 +113,10 @@ export default function SpeakOrFacilitatePage() {
 
       {/* Logistics */}
       <Section background="white">
-        <SectionHeader
-          overline="Logistics"
-          title="What to expect"
-          className="mb-12"
-        />
+        <SectionHeader overline="Logistics" title="What to expect" className="mb-12" />
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {logistics.map((item) => (
-            <div
-              key={item.label}
-              className="flex items-start gap-4 bg-background rounded-xl p-5"
-            >
+            <div key={item.label} className="flex items-start gap-4 bg-background rounded-xl p-5">
               <Clock className="h-5 w-5 text-ring shrink-0 mt-0.5" />
               <div>
                 <p className="font-semibold text-foreground">{item.label}</p>
@@ -148,9 +131,7 @@ export default function SpeakOrFacilitatePage() {
       <Section>
         <div className="grid gap-8 lg:grid-cols-2">
           <div className="bg-ring/8 rounded-2xl border border-ring/30 p-6 lg:p-8">
-            <h3 className="font-display text-xl font-semibold text-foreground mb-6">
-              What TechTank handles
-            </h3>
+            <h3 className="font-display text-xl font-semibold text-foreground mb-6">What TechTank handles</h3>
             <ul className="space-y-3">
               {techTankHandles.map((item, index) => (
                 <li key={index} className="flex items-start gap-3">
@@ -162,9 +143,7 @@ export default function SpeakOrFacilitatePage() {
           </div>
 
           <div className="bg-amber/8 rounded-2xl border border-amber/30 p-6 lg:p-8">
-            <h3 className="font-display text-xl font-semibold text-foreground mb-6">
-              What you provide
-            </h3>
+            <h3 className="font-display text-xl font-semibold text-foreground mb-6">What you provide</h3>
             <ul className="space-y-3">
               {youProvide.map((item, index) => (
                 <li key={index} className="flex items-start gap-3">
@@ -180,18 +159,10 @@ export default function SpeakOrFacilitatePage() {
       {/* What You Get */}
       <Section background="brand-soft">
         <div className="max-w-3xl mx-auto">
-          <SectionHeader
-            overline="What you get"
-            title="What you get"
-            align="center"
-            className="mb-12"
-          />
+          <SectionHeader overline="What you get" title="What you get" align="center" className="mb-12" />
           <div className="grid gap-4 sm:grid-cols-2">
             {whatYouGet.map((item, index) => (
-              <div
-                key={index}
-                className="flex items-center gap-3 bg-card rounded-lg p-4"
-              >
+              <div key={index} className="flex items-center gap-3 bg-card rounded-lg p-4">
                 <Check className="h-5 w-5 text-ring shrink-0" />
                 <span className="text-foreground">{item}</span>
               </div>
@@ -203,15 +174,11 @@ export default function SpeakOrFacilitatePage() {
       {/* Speaker Resources */}
       <Section>
         <div className="max-w-3xl mx-auto text-center">
-          <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
-            Resources
-          </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            Speaker and facilitator toolkit
-          </h2>
+          <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">Resources</span>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">Speaker and facilitator toolkit</h2>
           <p className="text-muted-foreground mb-8">
-            Brand assets, slide templates, run-of-show guidance, and tips for
-            first-time speakers and facilitators all live in our Media Kit.
+            Brand assets, slide templates, run-of-show guidance, and tips for first-time speakers and facilitators all
+            live in our Media Kit.
           </p>
           <Button variant="outline" asChild>
             <Link href="/resources/media-kit">
@@ -228,12 +195,9 @@ export default function SpeakOrFacilitatePage() {
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
             Ready to participate?
           </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            Submit your proposal
-          </h2>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">Submit your proposal</h2>
           <p className="text-muted-foreground mb-8">
-            Tell us about yourself and your idea — talk, panel, or workshop.
-            We&apos;ll get back to you within a week.
+            Tell us about yourself and your idea — talk, panel, or workshop. We&apos;ll get back to you within a week.
           </p>
           <Button variant="primary" size="lg" asChild>
             <a

--- a/app/get-involved/sponsor/page.tsx
+++ b/app/get-involved/sponsor/page.tsx
@@ -6,11 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Section, SectionHeader } from "@/components/ui/section";
 import { SponsorsMarquee } from "@/components/ui/sponsors-marquee";
 import { ContactCard } from "@/components/ui/contact-card";
-import {
-  getCoverImage,
-  getCoverVideo,
-  getInstagramPostsByIds,
-} from "@/constants/instagram-posts";
+import { getCoverImage, getCoverVideo, getInstagramPostsByIds } from "@/constants/instagram-posts";
 
 export const metadata: Metadata = {
   title: "Sponsor TechTank",
@@ -89,8 +85,8 @@ export default function SponsorPage() {
               Sponsor the Toronto tech community
             </h1>
             <p className="text-xl text-muted-foreground leading-relaxed mb-8">
-              Support the year-round events, speakers, and programs that bring the
-              community together. Tasteful brand visibility, real impact.
+              Support the year-round events, speakers, and programs that bring the community together. Tasteful brand
+              visibility, real impact.
             </p>
             <Button variant="primary" size="lg" asChild>
               <a href="mailto:techtankto@gmail.com?subject=Sponsorship%20Inquiry%20-%20TechTank">
@@ -103,23 +99,14 @@ export default function SponsorPage() {
 
       {/* Why Sponsor */}
       <Section>
-        <SectionHeader
-          overline="Why sponsor"
-          title="What you get out of it"
-          className="mb-12"
-        />
+        <SectionHeader overline="Why sponsor" title="What you get out of it" className="mb-12" />
         <div className="grid gap-8 lg:grid-cols-3">
           {whySponsor.map((item) => (
-            <div
-              key={item.title}
-              className="bg-card rounded-2xl border border-border p-6 lg:p-8"
-            >
+            <div key={item.title} className="bg-card rounded-2xl border border-border p-6 lg:p-8">
               <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-ring/10 text-ring mb-4">
                 <item.icon className="h-6 w-6" />
               </div>
-              <h3 className="font-display text-xl font-semibold text-foreground mb-3">
-                {item.title}
-              </h3>
+              <h3 className="font-display text-xl font-semibold text-foreground mb-3">{item.title}</h3>
               <p className="text-muted-foreground leading-relaxed">{item.description}</p>
             </div>
           ))}
@@ -133,9 +120,7 @@ export default function SponsorPage() {
             <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
               Your impact
             </span>
-            <h2 className="font-display text-3xl font-semibold text-foreground mb-6">
-              What sponsorship supports
-            </h2>
+            <h2 className="font-display text-3xl font-semibold text-foreground mb-6">What sponsorship supports</h2>
             <ul className="space-y-4">
               {whatSponsorshipSupports.map((item, index) => (
                 <li key={index} className="flex items-start gap-3">
@@ -148,14 +133,8 @@ export default function SponsorPage() {
           <div className="relative">
             <div className="relative aspect-[4/3] rounded-2xl overflow-hidden bg-gradient-to-br from-peach via-lavender to-aqua">
               {featuredVideo ? (
-                <video
-                  autoPlay
-                  loop
-                  muted
-                  playsInline
-                  className="absolute inset-0 h-full w-full object-cover"
-                >
-                  <source src={featuredVideo.replace(/\.mp4$/, '.webm')} type="video/webm" />
+                <video autoPlay loop muted playsInline className="absolute inset-0 h-full w-full object-cover">
+                  <source src={featuredVideo.replace(/\.mp4$/, ".webm")} type="video/webm" />
                   <source src={featuredVideo} type="video/mp4" />
                 </video>
               ) : featuredImage ? (
@@ -168,9 +147,7 @@ export default function SponsorPage() {
                 />
               ) : (
                 <div className="absolute inset-0 flex items-center justify-center">
-                  <p className="text-center text-foreground/60 px-8">
-                    Community event photography
-                  </p>
+                  <p className="text-center text-foreground/60 px-8">Community event photography</p>
                 </div>
               )}
             </div>
@@ -191,9 +168,7 @@ export default function SponsorPage() {
             <div
               key={tier.name}
               className={`rounded-2xl border p-6 lg:p-8 ${
-                tier.highlight
-                  ? "border-ring bg-ring/5"
-                  : "border-border bg-card"
+                tier.highlight ? "border-ring bg-ring/5" : "border-border bg-card"
               }`}
             >
               {tier.highlight && (
@@ -201,34 +176,23 @@ export default function SponsorPage() {
                   Most popular
                 </span>
               )}
-              <h3 className="font-display text-xl font-semibold text-foreground mb-2">
-                {tier.name}
-              </h3>
+              <h3 className="font-display text-xl font-semibold text-foreground mb-2">{tier.name}</h3>
               <p className="text-muted-foreground">{tier.description}</p>
             </div>
           ))}
         </div>
         <p className="text-center text-sm text-muted-foreground mt-8">
-          Exact pricing and benefits in our sponsorship info. Tiers are
-          illustrative — we&apos;ll work with your budget.
+          Exact pricing and benefits in our sponsorship info. Tiers are illustrative — we&apos;ll work with your budget.
         </p>
       </Section>
 
       {/* Base Package */}
       <Section background="brand-soft">
         <div className="max-w-3xl mx-auto">
-          <SectionHeader
-            overline="All sponsors get"
-            title="Base sponsor package"
-            align="center"
-            className="mb-12"
-          />
+          <SectionHeader overline="All sponsors get" title="Base sponsor package" align="center" className="mb-12" />
           <div className="grid gap-4 sm:grid-cols-2">
             {basePackage.map((item, index) => (
-              <div
-                key={index}
-                className="flex items-center gap-3 bg-card rounded-lg p-4"
-              >
+              <div key={index} className="flex items-center gap-3 bg-card rounded-lg p-4">
                 <Check className="h-5 w-5 text-ring shrink-0" />
                 <span className="text-foreground">{item}</span>
               </div>
@@ -251,17 +215,12 @@ export default function SponsorPage() {
       {/* Hosting vs Sponsoring */}
       <Section>
         <div className="max-w-3xl mx-auto text-center">
-          <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
-            Not sure?
-          </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            Hosting vs. sponsoring
-          </h2>
+          <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">Not sure?</span>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">Hosting vs. sponsoring</h2>
           <p className="text-muted-foreground mb-6">
-            <strong className="text-foreground">Hosting</strong> means providing
-            your venue and food for one event. <strong className="text-foreground">Sponsoring</strong>{" "}
-            means supporting TechTank with funding for ongoing operations,
-            programs, or multiple events.
+            <strong className="text-foreground">Hosting</strong> means providing your venue and food for one event.{" "}
+            <strong className="text-foreground">Sponsoring</strong> means supporting TechTank with funding for ongoing
+            operations, programs, or multiple events.
           </p>
           <Button variant="outline" asChild>
             <Link href="/get-involved/host">Learn about hosting</Link>
@@ -275,12 +234,9 @@ export default function SponsorPage() {
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
             Ready to sponsor?
           </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            Get the sponsorship info
-          </h2>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">Get the sponsorship info</h2>
           <p className="text-muted-foreground mb-8">
-            Tell us about your company and goals. We&apos;ll send our full
-            sponsorship details within a week.
+            Tell us about your company and goals. We&apos;ll send our full sponsorship details within a week.
           </p>
           <Button variant="primary" size="lg" asChild>
             <a href="mailto:techtankto@gmail.com?subject=Sponsorship%20Inquiry%20-%20TechTank">

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,51 +6,51 @@
 
 @theme {
   /* Brand palette — fixed across themes */
-  --color-teal: #2A6B7C;
-  --color-teal-dark: #1B4B5A;
-  --color-seafoam: #A8D5D8;
-  --color-mint: #5B9A8B;
-  --color-amber: #FFBC55;
-  --color-amber-dark: #EFA020;
-  --color-peach: #F5D4C1;
-  --color-coral: #E87C4E;
-  --color-blush: #EABFBF;
-  --color-sand: #F7EDE2;
+  --color-teal: #2a6b7c;
+  --color-teal-dark: #1b4b5a;
+  --color-seafoam: #a8d5d8;
+  --color-mint: #5b9a8b;
+  --color-amber: #ffbc55;
+  --color-amber-dark: #efa020;
+  --color-peach: #f5d4c1;
+  --color-coral: #e87c4e;
+  --color-blush: #eabfbf;
+  --color-sand: #f7ede2;
 
   /* Semantic tokens — light defaults (overridden per theme below) */
-  --color-background: #F9F6F2;
-  --color-foreground: #1B4B5A;
+  --color-background: #f9f6f2;
+  --color-foreground: #1b4b5a;
 
-  --color-muted: #EBF3F4;
-  --color-muted-foreground: #4A6670;
+  --color-muted: #ebf3f4;
+  --color-muted-foreground: #4a6670;
 
   --color-border: rgba(27, 75, 90, 0.12);
   --color-input: rgba(27, 75, 90, 0.18);
-  --color-ring: #2A6B7C;
+  --color-ring: #2a6b7c;
 
-  --color-primary: #1B4B5A;
-  --color-primary-foreground: #FFFFFF;
+  --color-primary: #1b4b5a;
+  --color-primary-foreground: #ffffff;
 
-  --color-secondary: #A8D5D8;
-  --color-secondary-foreground: #1B4B5A;
+  --color-secondary: #a8d5d8;
+  --color-secondary-foreground: #1b4b5a;
 
-  --color-accent: #D4ECEE;
-  --color-accent-foreground: #1B4B5A;
+  --color-accent: #d4ecee;
+  --color-accent-foreground: #1b4b5a;
 
-  --color-destructive: #E87C4E;
-  --color-destructive-foreground: #FFFFFF;
+  --color-destructive: #e87c4e;
+  --color-destructive-foreground: #ffffff;
 
-  --color-warning: #FFBC55;
-  --color-warning-foreground: #1B4B5A;
+  --color-warning: #ffbc55;
+  --color-warning-foreground: #1b4b5a;
 
-  --color-success: #5B9A8B;
-  --color-success-foreground: #FFFFFF;
+  --color-success: #5b9a8b;
+  --color-success-foreground: #ffffff;
 
   --color-card: rgba(255, 255, 255, 0.7);
-  --color-card-foreground: #1B4B5A;
+  --color-card-foreground: #1b4b5a;
 
-  --color-popover: #FFFFFF;
-  --color-popover-foreground: #1B4B5A;
+  --color-popover: #ffffff;
+  --color-popover-foreground: #1b4b5a;
 
   /* Typography */
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
@@ -62,103 +62,105 @@
   --radius-xl: 1.75rem;
   --radius-2xl: 2rem;
   --radius-full: 9999px;
-
 }
 
 /* ─── Light Tokens & Gradients ─────────────────────────────────────────────── */
 
 /* Gradient defaults (light) — :root ensures var() resolves during SSR and before theme hydration */
 :root {
-  --gradient-brand: linear-gradient(135deg, #A8D5D8 0%, #C9E4E5 22%, #F7EDE2 45%, #F4DFA8 82%, #F2D870 100%);
-  --gradient-brand-vertical: linear-gradient(180deg, #A8D5D8 0%, #F7EDE2 40%, #F2DCA8 100%);
-  --gradient-hero: linear-gradient(160deg, #B5DFE0 0%, #D4E8E5 20%, #F0E6DC 45%, #F5D4C1 80%, #F5C9B0 100%);
-  --gradient-hero-soft: linear-gradient(135deg, #BEE0E2 0%, #F0E9E0 40%, #F5D4C1 100%);
+  --gradient-brand: linear-gradient(135deg, #a8d5d8 0%, #c9e4e5 22%, #f7ede2 45%, #f4dfa8 82%, #f2d870 100%);
+  --gradient-brand-vertical: linear-gradient(180deg, #a8d5d8 0%, #f7ede2 40%, #f2dca8 100%);
+  --gradient-hero: linear-gradient(160deg, #b5dfe0 0%, #d4e8e5 20%, #f0e6dc 45%, #f5d4c1 80%, #f5c9b0 100%);
+  --gradient-hero-soft: linear-gradient(135deg, #bee0e2 0%, #f0e9e0 40%, #f5d4c1 100%);
 }
 
 .light {
-  --color-background: #F9F6F2;
-  --color-foreground: #1B4B5A;
+  --color-background: #f9f6f2;
+  --color-foreground: #1b4b5a;
 
-  --color-muted: #EBF3F4;
-  --color-muted-foreground: #4A6670;
+  --color-muted: #ebf3f4;
+  --color-muted-foreground: #4a6670;
 
   --color-border: rgba(27, 75, 90, 0.12);
   --color-input: rgba(27, 75, 90, 0.18);
-  --color-ring: #2A6B7C;
+  --color-ring: #2a6b7c;
 
-  --color-primary: #1B4B5A;
-  --color-primary-foreground: #FFFFFF;
+  --color-primary: #1b4b5a;
+  --color-primary-foreground: #ffffff;
 
-  --color-secondary: #A8D5D8;
-  --color-secondary-foreground: #1B4B5A;
+  --color-secondary: #a8d5d8;
+  --color-secondary-foreground: #1b4b5a;
 
-  --color-accent: #D4ECEE;
-  --color-accent-foreground: #1B4B5A;
+  --color-accent: #d4ecee;
+  --color-accent-foreground: #1b4b5a;
 
-  --color-success: #5B9A8B;
-  --color-success-foreground: #FFFFFF;
+  --color-success: #5b9a8b;
+  --color-success-foreground: #ffffff;
 
   --color-card: rgba(255, 255, 255, 0.7);
-  --color-card-foreground: #1B4B5A;
+  --color-card-foreground: #1b4b5a;
 
-  --color-popover: #FFFFFF;
-  --color-popover-foreground: #1B4B5A;
+  --color-popover: #ffffff;
+  --color-popover-foreground: #1b4b5a;
 
-  --gradient-brand: linear-gradient(135deg, #A8D5D8 0%, #C9E4E5 22%, #F7EDE2 45%, #F4DFA8 82%, #F2D870 100%);
-  --gradient-brand-vertical: linear-gradient(180deg, #A8D5D8 0%, #F7EDE2 40%, #F2DCA8 100%);
-  --gradient-hero: linear-gradient(160deg, #B5DFE0 0%, #D4E8E5 20%, #F0E6DC 45%, #F5D4C1 80%, #F5C9B0 100%);
-  --gradient-hero-soft: linear-gradient(135deg, #BEE0E2 0%, #F0E9E0 40%, #F5D4C1 100%);
+  --gradient-brand: linear-gradient(135deg, #a8d5d8 0%, #c9e4e5 22%, #f7ede2 45%, #f4dfa8 82%, #f2d870 100%);
+  --gradient-brand-vertical: linear-gradient(180deg, #a8d5d8 0%, #f7ede2 40%, #f2dca8 100%);
+  --gradient-hero: linear-gradient(160deg, #b5dfe0 0%, #d4e8e5 20%, #f0e6dc 45%, #f5d4c1 80%, #f5c9b0 100%);
+  --gradient-hero-soft: linear-gradient(135deg, #bee0e2 0%, #f0e9e0 40%, #f5d4c1 100%);
 }
 
-.gradient-brand          { background: var(--gradient-brand); }
-.gradient-brand-vertical { background: var(--gradient-brand-vertical); }
-.gradient-hero           { background: var(--gradient-hero); }
-.gradient-hero-soft      { background: var(--gradient-hero-soft); }
+.gradient-brand {
+  background: var(--gradient-brand);
+}
+.gradient-brand-vertical {
+  background: var(--gradient-brand-vertical);
+}
+.gradient-hero {
+  background: var(--gradient-hero);
+}
+.gradient-hero-soft {
+  background: var(--gradient-hero-soft);
+}
 
 .gradient-overlay-brand {
-  background: linear-gradient(
-    to top,
-    rgba(27, 75, 90, 0.92) 0%,
-    rgba(232, 124, 78, 0.55) 42%,
-    transparent 60%
-  );
+  background: linear-gradient(to top, rgba(27, 75, 90, 0.92) 0%, rgba(232, 124, 78, 0.55) 42%, transparent 60%);
 }
 
 /* ─── Dark Tokens & Gradients ──────────────────────────────────────────────── */
 
 .dark {
-  --color-background: #0D2B35;
-  --color-foreground: #E8F4F5;
+  --color-background: #0d2b35;
+  --color-foreground: #e8f4f5;
 
-  --color-muted: #1A3D4A;
-  --color-muted-foreground: #8BBEC6;
+  --color-muted: #1a3d4a;
+  --color-muted-foreground: #8bbec6;
 
   --color-border: rgba(168, 213, 216, 0.15);
   --color-input: rgba(168, 213, 216, 0.2);
-  --color-ring: #A8D5D8;
+  --color-ring: #a8d5d8;
 
-  --color-primary: #A8D5D8;
-  --color-primary-foreground: #0D2B35;
+  --color-primary: #a8d5d8;
+  --color-primary-foreground: #0d2b35;
 
-  --color-secondary: #1B4B5A;
-  --color-secondary-foreground: #A8D5D8;
+  --color-secondary: #1b4b5a;
+  --color-secondary-foreground: #a8d5d8;
 
-  --color-accent: #1E4A58;
-  --color-accent-foreground: #A8D5D8;
+  --color-accent: #1e4a58;
+  --color-accent-foreground: #a8d5d8;
 
-  --color-success: #4A8A7A;
-  --color-success-foreground: #FFFFFF;
+  --color-success: #4a8a7a;
+  --color-success-foreground: #ffffff;
 
   --color-card: rgba(27, 75, 90, 0.5);
-  --color-card-foreground: #E8F4F5;
+  --color-card-foreground: #e8f4f5;
 
-  --color-popover: #1A3D4A;
-  --color-popover-foreground: #E8F4F5;
+  --color-popover: #1a3d4a;
+  --color-popover-foreground: #e8f4f5;
 
-  --gradient-brand: linear-gradient(135deg, #1A3D4A 0%, #1B4B5A 25%, #3A2E20 50%, #352E18 100%);
-  --gradient-brand-vertical: linear-gradient(180deg, #1A3D4A 0%, #2A3830 38%, #352E18 100%);
-  --gradient-hero: linear-gradient(160deg, #0B2E38 0%, #1A3D4A 22%, #2E3028 48%, #4A2E1A 82%, #3A1E0E 100%);
-  --gradient-hero-soft: linear-gradient(135deg, #1A3D4A 0%, #2A3028 38%, #3A2818 100%);
+  --gradient-brand: linear-gradient(135deg, #1a3d4a 0%, #1b4b5a 25%, #3a2e20 50%, #352e18 100%);
+  --gradient-brand-vertical: linear-gradient(180deg, #1a3d4a 0%, #2a3830 38%, #352e18 100%);
+  --gradient-hero: linear-gradient(160deg, #0b2e38 0%, #1a3d4a 22%, #2e3028 48%, #4a2e1a 82%, #3a1e0e 100%);
+  --gradient-hero-soft: linear-gradient(135deg, #1a3d4a 0%, #2a3028 38%, #3a2818 100%);
 }
 
 /* ─── Helper Classes ───────────────────────────────────────────────────────── */
@@ -178,7 +180,12 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     font-family: var(--font-display);
     font-weight: 700;
     letter-spacing: -0.025em;
@@ -192,7 +199,9 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
+  *,
+  *::before,
+  *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
@@ -331,8 +340,12 @@
 }
 
 @keyframes marquee {
-  from { transform: translateX(0); }
-  to   { transform: translateX(calc(-100% / var(--marquee-copies, 2))); }
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(calc(-100% / var(--marquee-copies, 2)));
+  }
 }
 
 .marquee-track {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -62,17 +62,9 @@ export const viewport: Viewport = {
   initialScale: 1,
 };
 
-export default async function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html
-      lang="en"
-      suppressHydrationWarning
-      className={`${inter.variable} ${spaceGrotesk.variable} bg-background`}
-    >
+    <html lang="en" suppressHydrationWarning className={`${inter.variable} ${spaceGrotesk.variable} bg-background`}>
       <body className="min-h-screen flex flex-col font-sans antialiased" suppressHydrationWarning>
         <ThemeProvider
           attribute="class"

--- a/app/legal/code-of-conduct/page.tsx
+++ b/app/legal/code-of-conduct/page.tsx
@@ -3,8 +3,7 @@ import { Mail } from "lucide-react";
 
 export const metadata: Metadata = {
   title: "Code of Conduct",
-  description:
-    "TechTank TO Code of Conduct — our commitment to a safe, inclusive community.",
+  description: "TechTank TO Code of Conduct — our commitment to a safe, inclusive community.",
 };
 
 export default function CodeOfConductPage() {
@@ -13,9 +12,7 @@ export default function CodeOfConductPage() {
       {/* Header */}
       <div className="mb-8 pb-8 border-b border-border">
         <p className="text-sm text-muted-foreground mb-2">Last updated: June 5, 2026</p>
-        <h1 className="font-display text-3xl lg:text-4xl font-semibold text-foreground">
-          Code of Conduct
-        </h1>
+        <h1 className="font-display text-3xl lg:text-4xl font-semibold text-foreground">Code of Conduct</h1>
       </div>
 
       {/* Quick Report */}
@@ -23,16 +20,11 @@ export default function CodeOfConductPage() {
         <div className="flex flex-col sm:flex-row items-start gap-4">
           <Mail className="h-6 w-6 text-ring shrink-0 sm:mt-0.5" />
           <div>
-            <h2 className="font-semibold text-foreground mb-1">
-              Need to report something?
-            </h2>
+            <h2 className="font-semibold text-foreground mb-1">Need to report something?</h2>
             <p className="text-muted-foreground text-sm mb-2">
               At events: speak to any TechTank organizer. Any time: email us.
             </p>
-            <a
-              href="mailto:techtankto@gmail.com"
-              className="text-ring font-medium hover:underline"
-            >
+            <a href="mailto:techtankto@gmail.com" className="text-ring font-medium hover:underline">
               techtankto@gmail.com
             </a>
           </div>
@@ -41,55 +33,46 @@ export default function CodeOfConductPage() {
 
       {/* Content */}
       <div className="space-y-10 text-foreground leading-relaxed">
-
         {/* Scope */}
         <section>
           <h2 className="font-display text-xl font-semibold text-foreground mb-4">Scope</h2>
           <div className="space-y-4 text-muted-foreground">
             <p>
-              This code of conduct applies to everyone in the TechTank community: attendees,
-              volunteers, speakers, sponsors, organizers, and board members in all TechTank
-              spaces. This includes our Slack workspace, in-person and virtual events, social
-              gatherings, direct messages, and any other community channel.
+              This code of conduct applies to everyone in the TechTank community: attendees, volunteers, speakers,
+              sponsors, organizers, and board members in all TechTank spaces. This includes our Slack workspace,
+              in-person and virtual events, social gatherings, direct messages, and any other community channel.
             </p>
             <p>
-              TechTank is committed to providing a safe, inclusive, and welcoming experience
-              for everyone, regardless of age, race, ethnicity, gender identity or expression,
-              sexual orientation, disability, physical appearance, religion, nationality, or
-              level of experience. These standards are not optional.
+              TechTank is committed to providing a safe, inclusive, and welcoming experience for everyone, regardless of
+              age, race, ethnicity, gender identity or expression, sexual orientation, disability, physical appearance,
+              religion, nationality, or level of experience. These standards are not optional.
             </p>
           </div>
         </section>
 
         {/* Our Commitment to a Safe Space */}
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            Our Commitment to a Safe Space
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">Our Commitment to a Safe Space</h2>
           <div className="space-y-4 text-muted-foreground">
             <p>
-              TechTank is committed to being a safe and affirming space for 2SLGBTQ+ people.
-              We use and respect people&apos;s correct pronouns and chosen names. If you aren&apos;t
-              sure what pronouns someone uses, ask. If you make a mistake, apologize, correct
-              yourself, and move on.
+              TechTank is committed to being a safe and affirming space for 2SLGBTQ+ people. We use and respect
+              people&apos;s correct pronouns and chosen names. If you aren&apos;t sure what pronouns someone uses, ask.
+              If you make a mistake, apologize, correct yourself, and move on.
             </p>
             <p>
-              We acknowledge that racism, sexism, homophobia, transphobia, ableism, and other
-              forms of discrimination are real and present. TechTank is not a neutral space.
-              We actively work to create an environment where marginalized people feel safe,
-              and belonging is not something anyone has to earn.
+              We acknowledge that racism, sexism, homophobia, transphobia, ableism, and other forms of discrimination
+              are real and present. TechTank is not a neutral space. We actively work to create an environment where
+              marginalized people feel safe, and belonging is not something anyone has to earn.
             </p>
           </div>
         </section>
 
         {/* A. Members and Attendees */}
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            A. Members and Attendees
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">A. Members and Attendees</h2>
           <p className="text-muted-foreground mb-6">
-            Everyone who attends a TechTank event, joins our Slack, or participates in any
-            community space agrees to the following.
+            Everyone who attends a TechTank event, joins our Slack, or participates in any community space agrees to the
+            following.
           </p>
 
           <div className="space-y-6">
@@ -99,8 +82,8 @@ export default function CodeOfConductPage() {
                 <li>Be friendly, patient, and kind</li>
                 <li>Be welcoming to people of all backgrounds and identities</li>
                 <li>
-                  Take responsibility for your impact — if someone tells you they&apos;ve been
-                  harmed by your words or actions, listen, apologize, and correct the behaviour
+                  Take responsibility for your impact — if someone tells you they&apos;ve been harmed by your words or
+                  actions, listen, apologize, and correct the behaviour
                 </li>
                 <li>Respect physical and digital boundaries</li>
                 <li>Ask before recording or photographing anyone</li>
@@ -116,13 +99,13 @@ export default function CodeOfConductPage() {
                   <h4 className="font-medium text-foreground mb-2">Harassment and Discrimination</h4>
                   <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
                     <li>
-                      Hate speech or discriminatory language of any kind, including racist, sexist,
-                      homophobic, transphobic, or ableist remarks
+                      Hate speech or discriminatory language of any kind, including racist, sexist, homophobic,
+                      transphobic, or ableist remarks
                     </li>
                     <li>Unwelcome sexual attention, advances, or comments</li>
                     <li>
-                      Harassment in any form — verbal, written, physical, or visual — including
-                      offensive jokes, derogatory comments, or persistent unwelcome communication
+                      Harassment in any form — verbal, written, physical, or visual — including offensive jokes,
+                      derogatory comments, or persistent unwelcome communication
                     </li>
                     <li>Deliberate misgendering or deadnaming</li>
                     <li>Bullying, intimidation, or behaviour intended to belittle or demean others</li>
@@ -132,16 +115,13 @@ export default function CodeOfConductPage() {
                   <h4 className="font-medium text-foreground mb-2">Respect and Boundaries</h4>
                   <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
                     <li>
-                      Don&apos;t talk over people or shut down questions — everyone is at a different
-                      stage and that&apos;s the point
+                      Don&apos;t talk over people or shut down questions — everyone is at a different stage and
+                      that&apos;s the point
                     </li>
-                    <li>
-                      Don&apos;t solicit referrals from people you haven&apos;t built a real relationship with
-                    </li>
+                    <li>Don&apos;t solicit referrals from people you haven&apos;t built a real relationship with</li>
                     <li>Don&apos;t share private information about other members without their consent</li>
                     <li>
-                      Don&apos;t record, photograph, or share content featuring others without their
-                      explicit permission
+                      Don&apos;t record, photograph, or share content featuring others without their explicit permission
                     </li>
                     <li>No spamming, unsolicited self-promotion, or solicitation without organizer approval</li>
                   </ul>
@@ -152,10 +132,9 @@ export default function CodeOfConductPage() {
             <div>
               <h3 className="font-semibold text-foreground mb-3">Referral Policy</h3>
               <p className="text-muted-foreground">
-                Referrals carry real professional weight for the person giving them. Members
-                should not request referrals from someone they have not built a genuine
-                relationship with. A single interaction is not enough. Be thoughtful about
-                what you&apos;re asking someone to put their reputation behind.
+                Referrals carry real professional weight for the person giving them. Members should not request
+                referrals from someone they have not built a genuine relationship with. A single interaction is not
+                enough. Be thoughtful about what you&apos;re asking someone to put their reputation behind.
               </p>
             </div>
           </div>
@@ -163,12 +142,10 @@ export default function CodeOfConductPage() {
 
         {/* B. Organizers and Volunteers */}
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            B. Organizers and Volunteers
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">B. Organizers and Volunteers</h2>
           <p className="text-muted-foreground mb-6">
-            Organizers and volunteers are held to the same standards as all community members,
-            and carry additional responsibilities as representatives of TechTank.
+            Organizers and volunteers are held to the same standards as all community members, and carry additional
+            responsibilities as representatives of TechTank.
           </p>
 
           <div className="space-y-6">
@@ -177,47 +154,34 @@ export default function CodeOfConductPage() {
               <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
                 <li>Model the behaviour and values in this code of conduct at all times</li>
                 <li>
-                  Create a welcoming environment at every event — greet newcomers, make
-                  introductions, and make sure no one is left on the sidelines
+                  Create a welcoming environment at every event — greet newcomers, make introductions, and make sure no
+                  one is left on the sidelines
                 </li>
-                <li>
-                  If you witness a potential code of conduct violation, report it to the board
-                  promptly
-                </li>
+                <li>If you witness a potential code of conduct violation, report it to the board promptly</li>
                 <li>Handle attendee information and internal communications with confidentiality</li>
+                <li>Disclose any conflicts of interest that could affect your ability to act impartially</li>
                 <li>
-                  Disclose any conflicts of interest that could affect your ability to act
-                  impartially
+                  Don&apos;t use your organizer role to give yourself or your business unfair advantages, like access to
+                  member data or using TechTank&apos;s platforms to solicit clients or customers
                 </li>
+                <li>If you disagree with a board decision, bring it to the team directly rather than publicly</li>
                 <li>
-                  Don&apos;t use your organizer role to give yourself or your business unfair
-                  advantages, like access to member data or using TechTank&apos;s platforms to
-                  solicit clients or customers
-                </li>
-                <li>
-                  If you disagree with a board decision, bring it to the team directly rather
-                  than publicly
-                </li>
-                <li>
-                  Do not make commitments on behalf of TechTank — financial, partnership, or
-                  otherwise — without board approval
+                  Do not make commitments on behalf of TechTank — financial, partnership, or otherwise — without board
+                  approval
                 </li>
               </ul>
             </div>
 
             <div>
-              <h3 className="font-semibold text-foreground mb-3">
-                If an Organizer or Volunteer Violates This Code
-              </h3>
+              <h3 className="font-semibold text-foreground mb-3">If an Organizer or Volunteer Violates This Code</h3>
               <p className="text-muted-foreground">
                 Reports involving an organizer or volunteer should be sent to the board at{" "}
                 <a href="mailto:techtankto@gmail.com" className="text-ring hover:underline">
                   techtankto@gmail.com
                 </a>
-                . The implicated person will be recused from any discussion or decision
-                related to the report. Depending on the severity, consequences may include
-                removal from their role, temporary suspension, or permanent removal from the
-                community.
+                . The implicated person will be recused from any discussion or decision related to the report. Depending
+                on the severity, consequences may include removal from their role, temporary suspension, or permanent
+                removal from the community.
               </p>
             </div>
           </div>
@@ -225,12 +189,10 @@ export default function CodeOfConductPage() {
 
         {/* C. Sponsors and Hosts */}
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            C. Sponsors and Hosts
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">C. Sponsors and Hosts</h2>
           <p className="text-muted-foreground mb-6">
-            TechTank welcomes sponsors and venue hosts as partners in building community. By
-            sponsoring or hosting a TechTank event, you agree to the following.
+            TechTank welcomes sponsors and venue hosts as partners in building community. By sponsoring or hosting a
+            TechTank event, you agree to the following.
           </p>
 
           <div className="space-y-6">
@@ -239,48 +201,38 @@ export default function CodeOfConductPage() {
               <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
                 <li>Treat all TechTank community members with respect and dignity</li>
                 <li>
-                  Abide by TechTank&apos;s code of conduct in all interactions with attendees,
-                  organizers, and volunteers
+                  Abide by TechTank&apos;s code of conduct in all interactions with attendees, organizers, and
+                  volunteers
+                </li>
+                <li>Use TechTank&apos;s name, logo, and branding only as agreed upon and within brand guidelines</li>
+                <li>
+                  Coordinate all event communications, announcements, and promotional content with the TechTank team
+                  before publishing
                 </li>
                 <li>
-                  Use TechTank&apos;s name, logo, and branding only as agreed upon and within brand
-                  guidelines
-                </li>
-                <li>
-                  Coordinate all event communications, announcements, and promotional content
-                  with the TechTank team before publishing
-                </li>
-                <li>
-                  All TechTank events must be listed and managed through TechTank&apos;s official
-                  Luma or Meetup page. TechTank manages RSVPs and check-in for all events to
-                  ensure attendee safety and a consistent experience. Sponsors and hosts are
-                  welcome to promote and advertise the event through their own channels, but
-                  may not host a separate registration page or manage RSVPs independently.
+                  All TechTank events must be listed and managed through TechTank&apos;s official Luma or Meetup page.
+                  TechTank manages RSVPs and check-in for all events to ensure attendee safety and a consistent
+                  experience. Sponsors and hosts are welcome to promote and advertise the event through their own
+                  channels, but may not host a separate registration page or manage RSVPs independently.
                 </li>
               </ul>
             </div>
 
             <div>
-              <h3 className="font-semibold text-foreground mb-3">
-                What Sponsors and Hosts Should Not Do
-              </h3>
+              <h3 className="font-semibold text-foreground mb-3">What Sponsors and Hosts Should Not Do</h3>
               <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
                 <li>
-                  Recruiting and hiring outreach is welcome with prior agreement from TechTank
-                  organizers. Collecting attendee contact information or pitching attendees
-                  without their explicit consent is not permitted.
+                  Recruiting and hiring outreach is welcome with prior agreement from TechTank organizers. Collecting
+                  attendee contact information or pitching attendees without their explicit consent is not permitted.
                 </li>
                 <li>
-                  Use TechTank events as a primary sales or recruitment channel — attendees are
-                  community members, not leads
+                  Use TechTank events as a primary sales or recruitment channel — attendees are community members, not
+                  leads
                 </li>
+                <li>Make public statements on behalf of TechTank or imply endorsement beyond the agreed partnership</li>
                 <li>
-                  Make public statements on behalf of TechTank or imply endorsement beyond the
-                  agreed partnership
-                </li>
-                <li>
-                  Engage in discriminatory hiring practices or hold values that conflict with
-                  TechTank&apos;s commitment to inclusion
+                  Engage in discriminatory hiring practices or hold values that conflict with TechTank&apos;s commitment
+                  to inclusion
                 </li>
               </ul>
             </div>
@@ -289,15 +241,13 @@ export default function CodeOfConductPage() {
               <h3 className="font-semibold text-foreground mb-3">Attendee Data</h3>
               <div className="space-y-4 text-muted-foreground">
                 <p>
-                  TechTank does not share attendee contact information or registration data
-                  with sponsors for marketing or recruitment purposes. Attendees can opt in to
-                  sponsor communications when registering through Luma, and opt-in methods at
-                  events are welcome, like a QR code linking to a giveaway or sign-up form.
+                  TechTank does not share attendee contact information or registration data with sponsors for marketing
+                  or recruitment purposes. Attendees can opt in to sponsor communications when registering through Luma,
+                  and opt-in methods at events are welcome, like a QR code linking to a giveaway or sign-up form.
                 </p>
                 <p>
-                  For venue partners, we are happy to provide attendee information where
-                  required for legal, safety, or operational purposes, such as building access,
-                  capacity management, or emergency protocols.
+                  For venue partners, we are happy to provide attendee information where required for legal, safety, or
+                  operational purposes, such as building access, capacity management, or emergency protocols.
                 </p>
               </div>
             </div>
@@ -305,10 +255,9 @@ export default function CodeOfConductPage() {
             <div>
               <h3 className="font-semibold text-foreground mb-3">Sponsor Violations</h3>
               <p className="text-muted-foreground">
-                TechTank reserves the right to end a sponsorship or hosting relationship at
-                any time if a sponsor or host violates this code of conduct, acts in a way
-                that conflicts with TechTank&apos;s values, or creates an unsafe environment for
-                community members. This applies during and outside of events.
+                TechTank reserves the right to end a sponsorship or hosting relationship at any time if a sponsor or
+                host violates this code of conduct, acts in a way that conflicts with TechTank&apos;s values, or creates
+                an unsafe environment for community members. This applies during and outside of events.
               </p>
             </div>
           </div>
@@ -316,16 +265,13 @@ export default function CodeOfConductPage() {
 
         {/* Report a Concern */}
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            Report a Concern
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">Report a Concern</h2>
 
           <div className="space-y-6">
             <div>
               <h3 className="font-semibold text-foreground mb-3">General Reports</h3>
               <p className="text-muted-foreground mb-3">
-                If you experience or witness behaviour that violates this code of conduct,
-                please reach out at:
+                If you experience or witness behaviour that violates this code of conduct, please reach out at:
               </p>
               <p className="text-muted-foreground mb-3">
                 <a href="mailto:techtankto@gmail.com" className="text-ring hover:underline">
@@ -333,29 +279,25 @@ export default function CodeOfConductPage() {
                 </a>
               </p>
               <p className="text-muted-foreground">
-                You can also report directly to any organizer or board member you feel
-                comfortable approaching. All reports are handled confidentially. We will not
-                share your identity without your consent.
+                You can also report directly to any organizer or board member you feel comfortable approaching. All
+                reports are handled confidentially. We will not share your identity without your consent.
               </p>
             </div>
 
             <div>
-              <h3 className="font-semibold text-foreground mb-3">
-                Reports Involving an Organizer or Board Member
-              </h3>
+              <h3 className="font-semibold text-foreground mb-3">Reports Involving an Organizer or Board Member</h3>
               <div className="space-y-4 text-muted-foreground">
                 <p>
-                  If your report involves an organizer or board member, please contact the
-                  board directly at{" "}
+                  If your report involves an organizer or board member, please contact the board directly at{" "}
                   <a href="mailto:techtankto@gmail.com" className="text-ring hover:underline">
                     techtankto@gmail.com
                   </a>
-                  . The implicated person will be recused from any discussion or decision
-                  related to the report. The remaining board members will handle the matter.
+                  . The implicated person will be recused from any discussion or decision related to the report. The
+                  remaining board members will handle the matter.
                 </p>
                 <p>
-                  We recognize this process is imperfect for a small team. As TechTank grows,
-                  we are committed to building more independent reporting infrastructure.
+                  We recognize this process is imperfect for a small team. As TechTank grows, we are committed to
+                  building more independent reporting infrastructure.
                 </p>
               </div>
             </div>
@@ -364,48 +306,44 @@ export default function CodeOfConductPage() {
 
         {/* Enforcement */}
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            Enforcement
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">Enforcement</h2>
           <p className="text-muted-foreground mb-6">
-            TechTank reserves the right to take corrective action in response to any behaviour
-            deemed inappropriate, threatening, offensive, or harmful. This applies to all
-            community members, including organizers and board members.
+            TechTank reserves the right to take corrective action in response to any behaviour deemed inappropriate,
+            threatening, offensive, or harmful. This applies to all community members, including organizers and board
+            members.
           </p>
 
           <div className="space-y-6">
             <div>
               <h3 className="font-semibold text-foreground mb-2">1. Notice of Correction</h3>
               <p className="text-muted-foreground">
-                You will be contacted directly regarding the behaviour in question and asked
-                to correct it. This may happen via Slack, email, or in person depending on
-                the situation.
+                You will be contacted directly regarding the behaviour in question and asked to correct it. This may
+                happen via Slack, email, or in person depending on the situation.
               </p>
             </div>
 
             <div>
               <h3 className="font-semibold text-foreground mb-2">2. Temporary Ban</h3>
               <p className="text-muted-foreground">
-                A temporary ban from TechTank community spaces for up to two weeks. This
-                includes all in-person and virtual events, Slack, and direct messages.
+                A temporary ban from TechTank community spaces for up to two weeks. This includes all in-person and
+                virtual events, Slack, and direct messages.
               </p>
             </div>
 
             <div>
               <h3 className="font-semibold text-foreground mb-2">3. Permanent Ban</h3>
               <p className="text-muted-foreground">
-                Permanent removal from all TechTank spaces and events. Reserved for severe
-                violations or repeated behaviour after prior enforcement.
+                Permanent removal from all TechTank spaces and events. Reserved for severe violations or repeated
+                behaviour after prior enforcement.
               </p>
             </div>
 
             <p className="text-muted-foreground text-sm">
-              Note: some behaviours may warrant skipping directly to a temporary or permanent
-              ban without a prior notice of correction, at the board&apos;s discretion.
+              Note: some behaviours may warrant skipping directly to a temporary or permanent ban without a prior notice
+              of correction, at the board&apos;s discretion.
             </p>
           </div>
         </section>
-
       </div>
     </div>
   );

--- a/app/legal/layout.tsx
+++ b/app/legal/layout.tsx
@@ -10,11 +10,7 @@ const legalDocs = [
   { name: "Privacy Policy", href: "/legal/privacy-policy" },
 ];
 
-export default function LegalLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function LegalLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
 
   return (
@@ -40,9 +36,7 @@ export default function LegalLayout({
 
       {/* Main Content */}
       <main className="mx-auto max-w-7xl px-6 py-12 lg:px-8 lg:pb-16">
-        <article className="prose prose-slate max-w-none">
-          {children}
-        </article>
+        <article className="prose prose-slate max-w-none">{children}</article>
       </main>
     </div>
   );

--- a/app/legal/privacy-policy/page.tsx
+++ b/app/legal/privacy-policy/page.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
-  description:
-    "Privacy Policy for TechTank TO — what data we collect and how we use it.",
+  description: "Privacy Policy for TechTank TO — what data we collect and how we use it.",
 };
 
 export default function PrivacyPolicyPage() {
@@ -12,44 +11,33 @@ export default function PrivacyPolicyPage() {
       {/* Header */}
       <div className="mb-8 pb-8 border-b border-border">
         <p className="text-sm text-muted-foreground mb-2">Last updated: June 5, 2026</p>
-        <h1 className="font-display text-3xl lg:text-4xl font-semibold text-foreground">
-          Privacy Policy
-        </h1>
+        <h1 className="font-display text-3xl lg:text-4xl font-semibold text-foreground">Privacy Policy</h1>
       </div>
 
       {/* Content */}
       <div className="space-y-8 text-foreground leading-relaxed">
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            1. Overview
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">1. Overview</h2>
           <p className="text-muted-foreground">
-            This Privacy Policy explains what personal information TechTank TO
-            collects, how it&apos;s used, and who it&apos;s shared with. This policy
-            applies to techtankto.com and TechTank-operated community channels.
+            This Privacy Policy explains what personal information TechTank TO collects, how it&apos;s used, and who
+            it&apos;s shared with. This policy applies to techtankto.com and TechTank-operated community channels.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            2. Data We Collect Directly
-          </h2>
-          <p className="text-muted-foreground mb-4">
-            TechTank collects minimal personal information directly:
-          </p>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">2. Data We Collect Directly</h2>
+          <p className="text-muted-foreground mb-4">TechTank collects minimal personal information directly:</p>
           <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
             <li>
-              <strong>Intake form submissions</strong> (via Google Forms): name,
-              email, optional profile links, and role-specific information (talk
-              abstract, company, venue details, etc.)
+              <strong>Intake form submissions</strong> (via Google Forms): name, email, optional profile links, and
+              role-specific information (talk abstract, company, venue details, etc.)
             </li>
             <li>
-              <strong>Event registration and attendance data</strong> collected
-              via Luma and Meetup
+              <strong>Event registration and attendance data</strong> collected via Luma and Meetup
             </li>
             <li>
-              <strong>Optional demographic or background information</strong> you
-              choose to share when registering or filling out a form
+              <strong>Optional demographic or background information</strong> you choose to share when registering or
+              filling out a form
             </li>
             <li>
               <strong>Contact emails</strong> you send to techtankto@gmail.com
@@ -61,9 +49,7 @@ export default function PrivacyPolicyPage() {
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            3. Data We Don&apos;t Collect
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">3. Data We Don&apos;t Collect</h2>
           <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
             <li>No user accounts or passwords on this website</li>
             <li>No payment or financial data</li>
@@ -73,167 +59,118 @@ export default function PrivacyPolicyPage() {
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            4. Third-Party Platforms
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">4. Third-Party Platforms</h2>
           <p className="text-muted-foreground mb-4">
-            TechTank uses third-party platforms that have their own privacy
-            policies:
+            TechTank uses third-party platforms that have their own privacy policies:
           </p>
           <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
             <li>
               <strong>Luma, Meetup:</strong> Event RSVPs and attendee lists
             </li>
             <li>
-              <strong>Google Forms:</strong> Intake submissions (speaker, host,
-              sponsor, volunteer)
+              <strong>Google Forms:</strong> Intake submissions (speaker, host, sponsor, volunteer)
             </li>
             <li>
               <strong>Slack:</strong> Community messages and discussions
             </li>
             <li>
-              <strong>YouTube, Instagram, LinkedIn, GitHub:</strong> Embedded
-              content and community channels
+              <strong>YouTube, Instagram, LinkedIn, GitHub:</strong> Embedded content and community channels
             </li>
           </ul>
           <p className="text-muted-foreground mt-4">
-            Each platform has its own privacy policy. Please review them for
-            details on how they handle your data.
+            Each platform has its own privacy policy. Please review them for details on how they handle your data.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            5. Analytics
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">5. Analytics</h2>
           <p className="text-muted-foreground">
-            TechTank uses privacy-respecting analytics to understand how
-            visitors use the website. We collect aggregate data only (page
-            views, referrers, general geographic region). We do not track
-            individual users across sites or collect personal identifiers
-            through analytics.
+            TechTank uses privacy-respecting analytics to understand how visitors use the website. We collect aggregate
+            data only (page views, referrers, general geographic region). We do not track individual users across sites
+            or collect personal identifiers through analytics.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            6. How We Use Your Data
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">6. How We Use Your Data</h2>
           <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
             <li>Confirm your registration and send event updates</li>
             <li>Respond to intake form submissions and inquiries</li>
             <li>Coordinate events with speakers, hosts, and sponsors</li>
+            <li>Improve future programming based on who&apos;s attending and what&apos;s working</li>
+            <li>Contact you about TechTank news, only if you&apos;ve opted in</li>
             <li>
-              Improve future programming based on who&apos;s attending and what&apos;s
-              working
-            </li>
-            <li>
-              Contact you about TechTank news, only if you&apos;ve opted in
-            </li>
-            <li>
-              Share with venue partners where required for building access,
-              capacity management, or emergency protocols
+              Share with venue partners where required for building access, capacity management, or emergency protocols
             </li>
           </ul>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            7. Data Sharing
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">7. Data Sharing</h2>
           <p className="text-muted-foreground mb-4">
-            TechTank does not sell personal data. We do not share attendee
-            contact information or registration data with sponsors for marketing
-            or recruitment purposes. Limited sharing may occur:
+            TechTank does not sell personal data. We do not share attendee contact information or registration data with
+            sponsors for marketing or recruitment purposes. Limited sharing may occur:
           </p>
           <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
             <li>
-              <strong>Venue partners:</strong> Attendee information may be
-              shared where required for building access, capacity management, or
-              emergency protocols
+              <strong>Venue partners:</strong> Attendee information may be shared where required for building access,
+              capacity management, or emergency protocols
             </li>
             <li>
-              <strong>Speaker/sponsor coordination:</strong> Your contact
-              information may be shared with event partners to coordinate
-              logistics
+              <strong>Speaker/sponsor coordination:</strong> Your contact information may be shared with event partners
+              to coordinate logistics
             </li>
           </ul>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            8. Data Retention
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">8. Data Retention</h2>
           <p className="text-muted-foreground">
-            Registration data is stored through Google Forms and associated
-            Google Workspace tools. Event data is managed through Luma and
-            Meetup. We retain data as long as it&apos;s relevant to community
-            operations. Analytics data is aggregated and retained per our
-            analytics provider&apos;s policy.
+            Registration data is stored through Google Forms and associated Google Workspace tools. Event data is
+            managed through Luma and Meetup. We retain data as long as it&apos;s relevant to community operations.
+            Analytics data is aggregated and retained per our analytics provider&apos;s policy.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            9. Your Rights
-          </h2>
-          <p className="text-muted-foreground mb-4">
-            You have the right to:
-          </p>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">9. Your Rights</h2>
+          <p className="text-muted-foreground mb-4">You have the right to:</p>
           <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
             <li>Request access to your personal data</li>
             <li>Request correction of inaccurate data</li>
-            <li>
-              Request removal of your data from TechTank-managed records, where
-              technically feasible
-            </li>
+            <li>Request removal of your data from TechTank-managed records, where technically feasible</li>
           </ul>
           <p className="text-muted-foreground mt-4">
             To exercise these rights, email{" "}
-            <a
-              href="mailto:techtankto@gmail.com"
-              className="text-ring hover:underline"
-            >
+            <a href="mailto:techtankto@gmail.com" className="text-ring hover:underline">
               techtankto@gmail.com
             </a>
-            . These rights are available under PIPEDA (Canada) and, where
-            applicable, GDPR. For data held by third-party platforms like Luma
-            and Meetup, please refer to their respective privacy policies.
+            . These rights are available under PIPEDA (Canada) and, where applicable, GDPR. For data held by third-party
+            platforms like Luma and Meetup, please refer to their respective privacy policies.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            10. Cookies
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">10. Cookies</h2>
           <p className="text-muted-foreground">
-            This website uses minimal cookies for essential functionality and
-            analytics. No advertising or cross-site tracking cookies are used.
+            This website uses minimal cookies for essential functionality and analytics. No advertising or cross-site
+            tracking cookies are used.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            11. Changes to This Policy
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">11. Changes to This Policy</h2>
           <p className="text-muted-foreground">
-            TechTank may update this Privacy Policy from time to time. Material
-            changes will be announced via the website. The &quot;Last updated&quot; date
-            at the top indicates when the policy was last revised.
+            TechTank may update this Privacy Policy from time to time. Material changes will be announced via the
+            website. The &quot;Last updated&quot; date at the top indicates when the policy was last revised.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            12. Contact
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">12. Contact</h2>
           <p className="text-muted-foreground">
-            For privacy-related questions or to exercise your data rights,
-            contact us at{" "}
-            <a
-              href="mailto:techtankto@gmail.com"
-              className="text-ring hover:underline"
-            >
+            For privacy-related questions or to exercise your data rights, contact us at{" "}
+            <a href="mailto:techtankto@gmail.com" className="text-ring hover:underline">
               techtankto@gmail.com
             </a>
             .

--- a/app/legal/terms-of-service/page.tsx
+++ b/app/legal/terms-of-service/page.tsx
@@ -3,8 +3,7 @@ import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Terms of Service",
-  description:
-    "Terms of Service for TechTank TO website and community events.",
+  description: "Terms of Service for TechTank TO website and community events.",
 };
 
 export default function TermsOfServicePage() {
@@ -13,43 +12,38 @@ export default function TermsOfServicePage() {
       {/* Header */}
       <div className="mb-8 pb-8 border-b border-border">
         <p className="text-sm text-muted-foreground mb-2">Last updated: June 5, 2026</p>
-        <h1 className="font-display text-3xl lg:text-4xl font-semibold text-foreground">
-          Terms of Service
-        </h1>
+        <h1 className="font-display text-3xl lg:text-4xl font-semibold text-foreground">Terms of Service</h1>
       </div>
 
       {/* Content */}
       <div className="space-y-8 text-foreground leading-relaxed">
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            1. Acceptance of Terms
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">1. Acceptance of Terms</h2>
           <p className="text-muted-foreground">
-            These terms apply to anyone who uses the TechTank TO website
-            (techtankto.com), registers for or attends TechTank events, or
-            participates in TechTank community spaces (including Slack or
-            similar). By doing any of the above, you agree to be bound by
-            these Terms of Service. &quot;TechTank TO&quot; refers to the
+            These terms apply to anyone who uses the TechTank TO website (techtankto.com), registers for or attends
+            TechTank events, or participates in TechTank community spaces (including Slack or similar). By doing any of
+            the above, you agree to be bound by these Terms of Service. &quot;TechTank TO&quot; refers to the
             volunteer-run community operating the website and organizing events.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            2. What We Ask of You
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">2. What We Ask of You</h2>
           <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
-            <li>Respect the <Link href="/legal/code-of-conduct" className="text-ring hover:underline">Code of Conduct</Link> in all community spaces</li>
+            <li>
+              Respect the{" "}
+              <Link href="/legal/code-of-conduct" className="text-ring hover:underline">
+                Code of Conduct
+              </Link>{" "}
+              in all community spaces
+            </li>
           </ul>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            3. Website Use
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">3. Website Use</h2>
           <p className="text-muted-foreground mb-4">
-            The TechTank TO website is provided for informational and community
-            purposes. You may use the site to:
+            The TechTank TO website is provided for informational and community purposes. You may use the site to:
           </p>
           <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
             <li>Learn about TechTank events and programs</li>
@@ -58,155 +52,109 @@ export default function TermsOfServicePage() {
             <li>Download brand assets from the Media Kit</li>
           </ul>
           <p className="text-muted-foreground mt-4">
-            You may not use the site for harmful purposes, including scraping at
-            harmful volume, re-posting content without attribution, or
-            impersonation.
+            You may not use the site for harmful purposes, including scraping at harmful volume, re-posting content
+            without attribution, or impersonation.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            4. External Platforms
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">4. External Platforms</h2>
           <p className="text-muted-foreground">
-            TechTank uses third-party platforms for event registration (Luma, Meetup),
-            community discussion (Slack), and content hosting (YouTube,
-            GitHub). Use of these platforms is subject to their
-            respective terms of service. TechTank is not responsible for the
-            policies or practices of these third parties.
+            TechTank uses third-party platforms for event registration (Luma, Meetup), community discussion (Slack), and
+            content hosting (YouTube, GitHub). Use of these platforms is subject to their respective terms of service.
+            TechTank is not responsible for the policies or practices of these third parties.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            5. Events
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">5. Events</h2>
           <p className="text-muted-foreground mb-4">
-            Participation at TechTank events (virtual or in-person) implies agreement with
-            our{" "}
-            <Link
-              href="/legal/code-of-conduct"
-              className="text-ring hover:underline"
-            >
+            Participation at TechTank events (virtual or in-person) implies agreement with our{" "}
+            <Link href="/legal/code-of-conduct" className="text-ring hover:underline">
               Code of Conduct
             </Link>
-            . All attendees, speakers, hosts, sponsors, and volunteers are
-            expected to follow these guidelines.
+            . All attendees, speakers, hosts, sponsors, and volunteers are expected to follow these guidelines.
           </p>
           <p className="text-muted-foreground mb-4">
-            Registration for events does not guarantee attendance if capacity
-            is exceeded. TechTank reserves the right to cancel or reschedule
-            events. Refund policies for paid events will be stated at the time
-            of registration.
+            Registration for events does not guarantee attendance if capacity is exceeded. TechTank reserves the right
+            to cancel or reschedule events. Refund policies for paid events will be stated at the time of registration.
           </p>
           <p className="text-muted-foreground">
-            <strong>Photography and Recording:</strong> By participating in or
-            attending a TechTank event, you grant TechTank and its
-            representatives the right to take photographs, videos, and other
-            media of you, and to use and publish them in print and/or
-            electronically for any lawful purpose, including publicity,
-            illustration, advertising, social media, and web content. You
-            release TechTank, its volunteers, and all persons acting under its
-            permission or authority from any liability related to such use, and
-            acknowledge that you will not receive compensation and waive any
-            right to inspect or approve the finished product. If you prefer not
-            to be photographed, please inform an organizer at the event.
-            Attendees may not record, photograph, or distribute event content
-            without permission from the relevant parties.
+            <strong>Photography and Recording:</strong> By participating in or attending a TechTank event, you grant
+            TechTank and its representatives the right to take photographs, videos, and other media of you, and to use
+            and publish them in print and/or electronically for any lawful purpose, including publicity, illustration,
+            advertising, social media, and web content. You release TechTank, its volunteers, and all persons acting
+            under its permission or authority from any liability related to such use, and acknowledge that you will not
+            receive compensation and waive any right to inspect or approve the finished product. If you prefer not to be
+            photographed, please inform an organizer at the event. Attendees may not record, photograph, or distribute
+            event content without permission from the relevant parties.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            6. Intellectual Property
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">6. Intellectual Property</h2>
           <p className="text-muted-foreground mb-4">
-            TechTank branding, logos, and website content are property of
-            TechTank TO.
+            TechTank branding, logos, and website content are property of TechTank TO.
           </p>
           <p className="text-muted-foreground mb-4">
-            Content shared at TechTank events — including talks, presentations,
-            and workshop materials — belongs to its creators. Do not record,
-            reproduce, or distribute such content without permission from the
-            creator.
+            Content shared at TechTank events — including talks, presentations, and workshop materials — belongs to its
+            creators. Do not record, reproduce, or distribute such content without permission from the creator.
           </p>
           <p className="text-muted-foreground">
-            User-submitted content (talk proposals, intake form submissions)
-            remains the property of the submitter. By submitting content, you
-            grant TechTank a limited license to use it for promotion of your
-            talk or event participation.
+            User-submitted content (talk proposals, intake form submissions) remains the property of the submitter. By
+            submitting content, you grant TechTank a limited license to use it for promotion of your talk or event
+            participation.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            7. Disclaimers
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">7. Disclaimers</h2>
           <p className="text-muted-foreground">
-            Information on this website is provided &quot;as is&quot; without warranty.
-            TechTank makes no guarantees regarding event availability, venue,
-            speaker lineup, or timing. Events may be cancelled, postponed, or
+            Information on this website is provided &quot;as is&quot; without warranty. TechTank makes no guarantees
+            regarding event availability, venue, speaker lineup, or timing. Events may be cancelled, postponed, or
             modified at any time.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            8. Limitation of Liability
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">8. Limitation of Liability</h2>
           <p className="text-muted-foreground">
-            TechTank TO and its organizers shall not be liable for any direct,
-            indirect, incidental, special, or consequential damages arising
-            from your use of this website or participation in TechTank events,
-            to the fullest extent permitted by the laws of Ontario, Canada.
+            TechTank TO and its organizers shall not be liable for any direct, indirect, incidental, special, or
+            consequential damages arising from your use of this website or participation in TechTank events, to the
+            fullest extent permitted by the laws of Ontario, Canada.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            9. Indemnification
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">9. Indemnification</h2>
           <p className="text-muted-foreground">
-            You agree to indemnify and hold harmless TechTank TO and its
-            organizers from any claims, damages, or expenses arising from your
-            use of the website or participation in events, or your violation
-            of these terms.
+            You agree to indemnify and hold harmless TechTank TO and its organizers from any claims, damages, or
+            expenses arising from your use of the website or participation in events, or your violation of these terms.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            10. Changes to Terms
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">10. Changes to Terms</h2>
           <p className="text-muted-foreground">
-            TechTank may update these Terms of Service at any time. Material
-            changes will be announced via the website and Slack community. Your
-            continued use of the website after changes constitutes acceptance of
-            the new terms.
+            TechTank may update these Terms of Service at any time. Material changes will be announced via the website
+            and Slack community. Your continued use of the website after changes constitutes acceptance of the new
+            terms.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            11. Governing Law
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">11. Governing Law</h2>
           <p className="text-muted-foreground">
-            These Terms of Service are governed by the laws of the Province of
-            Ontario, Canada, and are subject to the exclusive jurisdiction of
-            courts within Toronto, Ontario, Canada.
+            These Terms of Service are governed by the laws of the Province of Ontario, Canada, and are subject to the
+            exclusive jurisdiction of courts within Toronto, Ontario, Canada.
           </p>
         </section>
 
         <section>
-          <h2 className="font-display text-xl font-semibold text-foreground mb-4">
-            12. Contact
-          </h2>
+          <h2 className="font-display text-xl font-semibold text-foreground mb-4">12. Contact</h2>
           <p className="text-muted-foreground">
             For questions about these Terms of Service, please contact us at{" "}
-            <a
-              href="mailto:techtankto@gmail.com"
-              className="text-ring hover:underline"
-            >
+            <a href="mailto:techtankto@gmail.com" className="text-ring hover:underline">
               techtankto@gmail.com
             </a>
             .

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -4,7 +4,8 @@ export default function manifest(): MetadataRoute.Manifest {
   return {
     name: "TechTank TO - Toronto's Tech Community",
     short_name: "TechTank TO",
-    description: "Foster a supportive and inclusive environment where people of all skill levels can explore, create, and thrive in technology. Year-round in-person events in Toronto.",
+    description:
+      "Foster a supportive and inclusive environment where people of all skill levels can explore, create, and thrive in technology. Year-round in-person events in Toronto.",
     start_url: "/",
     display: "standalone",
     background_color: "#ffffff",
@@ -14,14 +15,14 @@ export default function manifest(): MetadataRoute.Manifest {
         src: "/web-app-manifest-192x192.png",
         sizes: "192x192",
         type: "image/png",
-        purpose: "maskable"
+        purpose: "maskable",
       },
       {
         src: "/web-app-manifest-512x512.png",
         sizes: "512x512",
         type: "image/png",
-        purpose: "maskable"
-      }
+        purpose: "maskable",
+      },
     ],
   };
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,29 +1,19 @@
-import FishCanvas from "@/components/ui/fish-canvas"
-import PreviousButton from "@/components/ui/PreviousButton"
+import FishCanvas from "@/components/ui/fish-canvas";
+import PreviousButton from "@/components/ui/PreviousButton";
 
 export default function NotFound() {
   return (
-    <main
-      className={`relative min-h-dvh overflow-x-hidden`}
-    >
+    <main className={`relative min-h-dvh overflow-x-hidden`}>
       {/* Canvas */}
       <FishCanvas />
 
       {/* UI overlay */}
       <div className="absolute inset-0 z-20 flex flex-col items-center justify-center">
-        <h1 className="text-[8rem] sm:text-[12rem] md:text-[16rem] leading-[0.85] tracking-[-0.04em]">
-          404
-        </h1>
-        <p className="font-mono mt-6 uppercase tracking-[0.22em] text-[0.7rem]">
-          Page not found
-        </p>
-        <p className="mt-3 uppercase tracking-[0.18em] text-[0.6rem] animate-pulse">
-          move cursor or touch to reveal
-        </p>
+        <h1 className="text-[8rem] sm:text-[12rem] md:text-[16rem] leading-[0.85] tracking-[-0.04em]">404</h1>
+        <p className="font-mono mt-6 uppercase tracking-[0.22em] text-[0.7rem]">Page not found</p>
+        <p className="mt-3 uppercase tracking-[0.18em] text-[0.6rem] animate-pulse">move cursor or touch to reveal</p>
         <PreviousButton />
       </div>
-
-
     </main>
-  )
+  );
 }

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -13,9 +13,7 @@ export const contentType = "image/png";
 
 // Image generation
 export default async function OGImage() {
-  const imageData = await readFile(
-    join(process.cwd(), "public/images/logos/light.png"),
-  );
+  const imageData = await readFile(join(process.cwd(), "public/images/logos/light.png"));
   const base64Image = `data:image/png;base64,${imageData.toString("base64")}`;
 
   return new ImageResponse(

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,11 +8,7 @@ import { SponsorsMarquee } from "@/components/ui/sponsors-marquee";
 import { RoleCard, roleCardsData } from "@/components/ui/role-card";
 import { EventCard } from "@/components/ui/event-card";
 import { SocialFeed } from "@/components/ui/social-feed";
-import {
-  getCoverImage,
-  getCoverVideo,
-  getInstagramPostsByIds,
-} from "@/constants/instagram-posts";
+import { getCoverImage, getCoverVideo, getInstagramPostsByIds } from "@/constants/instagram-posts";
 import { getLumaEvents, getPastLumaEvents } from "./events/actions";
 
 function captionToAlt(caption: string): string {
@@ -43,15 +39,12 @@ export default async function HomePage() {
           <div className="grid lg:grid-cols-2 gap-8 lg:gap-6 items-center">
             {/* Left: Text content */}
             <div className="lg:max-w-xl py-8 lg:py-12">
-              <span className="tag mb-4">
-                Toronto &middot; Year-round &middot; Inclusive
-              </span>
+              <span className="tag mb-4">Toronto &middot; Year-round &middot; Inclusive</span>
               <h1 className="font-display text-4xl md:text-5xl font-semibold text-foreground lg:text-6xl text-balance mb-6">
                 Toronto&apos;s home for tech community
               </h1>
               <p className="text-lg text-muted-foreground leading-relaxed mb-6 lg:max-w-md">
-                Tech talks, panels, socials, sports, and more—hosted at
-                companies across the city.
+                Tech talks, panels, socials, sports, and more—hosted at companies across the city.
               </p>
               <div className="flex flex-wrap gap-3">
                 <Button variant="primary" size="md" asChild>
@@ -76,7 +69,7 @@ export default async function HomePage() {
                       playsInline
                       className="absolute inset-0 h-full w-full object-cover object-top"
                     >
-                      <source src={heroPosts[0].videoSrc.replace(/\.mp4$/, '.webm')} type="video/webm" />
+                      <source src={heroPosts[0].videoSrc.replace(/\.mp4$/, ".webm")} type="video/webm" />
                       <source src={heroPosts[0].videoSrc} type="video/mp4" />
                     </video>
                   ) : heroPosts[0].imageSrc ? (
@@ -101,7 +94,7 @@ export default async function HomePage() {
                       playsInline
                       className="absolute inset-0 h-full w-full object-cover object-top"
                     >
-                      <source src={heroPosts[1].videoSrc.replace(/\.mp4$/, '.webm')} type="video/webm" />
+                      <source src={heroPosts[1].videoSrc.replace(/\.mp4$/, ".webm")} type="video/webm" />
                       <source src={heroPosts[1].videoSrc} type="video/mp4" />
                     </video>
                   ) : heroPosts[1].imageSrc ? (
@@ -125,21 +118,13 @@ export default async function HomePage() {
 
       {/* Social Feed */}
       <Section id="community" background="muted">
-        <SectionHeader
-          overline="From the community"
-          title="Real people, real moments"
-          className="mb-8"
-        />
+        <SectionHeader overline="From the community" title="Real people, real moments" className="mb-8" />
         <SocialFeed />
       </Section>
 
       {/* Events Section - Upcoming (large) + Past (small) */}
       <Section>
-        <SectionHeader
-          overline="Events"
-          title="Recent happenings"
-          className="mb-6"
-        />
+        <SectionHeader overline="Events" title="Recent happenings" className="mb-6" />
 
         {/* Recent Events - Large featured + smaller cards */}
         <div className="grid gap-4 lg:grid-cols-2 mb-4">
@@ -164,21 +149,13 @@ export default async function HomePage() {
         {/* CTAs */}
         <div className="flex flex-wrap items-center justify-center gap-3">
           <Button variant="primary" size="md" asChild>
-            <a
-              href="https://luma.com/techtank"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <a href="https://luma.com/techtank" target="_blank" rel="noopener noreferrer">
               Luma
               <ExternalLink className="ml-2 h-4 w-4" />
             </a>
           </Button>
           <Button variant="outline" size="md" asChild>
-            <a
-              href="https://meetup.com/techtank-to"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <a href="https://meetup.com/techtank-to" target="_blank" rel="noopener noreferrer">
               Meetup
               <ExternalLink className="ml-2 h-4 w-4" />
             </a>
@@ -210,15 +187,10 @@ export default async function HomePage() {
       {/* Values Teaser */}
       <Section>
         <div className="glass rounded-2xl p-6 lg:p-10 text-center max-w-2xl mx-auto">
-          <span className="tag-outline mb-4 inline-block text-sm">
-            What we&apos;re about
-          </span>
-          <h2 className="font-display text-2xl lg:text-3xl font-bold text-foreground mb-4">
-            Community first. Always.
-          </h2>
+          <span className="tag-outline mb-4 inline-block text-sm">What we&apos;re about</span>
+          <h2 className="font-display text-2xl lg:text-3xl font-bold text-foreground mb-4">Community first. Always.</h2>
           <p className="text-muted-foreground mb-6">
-            No gatekeeping—just people who genuinely want to learn, share, and
-            lift each other up.
+            No gatekeeping—just people who genuinely want to learn, share, and lift each other up.
           </p>
           <Button variant="primary" asChild>
             <Link href="/about">More about us</Link>
@@ -227,11 +199,7 @@ export default async function HomePage() {
       </Section>
 
       {/* Two-flow CTA */}
-      <Section
-        id="join-us"
-        background="brand-vertical"
-        className="py-8 lg:py-12"
-      >
+      <Section id="join-us" background="brand-vertical" className="py-8 lg:py-12">
         <SectionHeader
           overline="Take the next step"
           title="Where to next?"
@@ -248,9 +216,7 @@ export default async function HomePage() {
               <span className="inline-block text-xs font-semibold uppercase tracking-widest text-amber-dark mb-2">
                 Show up
               </span>
-              <h3 className="font-display text-lg lg:text-xl font-bold text-foreground mb-2">
-                Upcoming events
-              </h3>
+              <h3 className="font-display text-lg lg:text-xl font-bold text-foreground mb-2">Upcoming events</h3>
               <p className="text-sm text-muted-foreground mb-4">
                 See what&apos;s coming up and RSVP to the next meetup.
               </p>
@@ -270,12 +236,8 @@ export default async function HomePage() {
               <span className="inline-block text-xs font-semibold uppercase tracking-widest text-amber-dark mb-2">
                 Contribute
               </span>
-              <h3 className="font-display text-lg lg:text-xl font-bold text-foreground mb-2">
-                Get involved
-              </h3>
-              <p className="text-sm text-muted-foreground mb-4">
-                Speak, host, sponsor, or volunteer with the crew.
-              </p>
+              <h3 className="font-display text-lg lg:text-xl font-bold text-foreground mb-2">Get involved</h3>
+              <p className="text-sm text-muted-foreground mb-4">Speak, host, sponsor, or volunteer with the crew.</p>
               <span className="inline-flex items-center text-sm font-semibold text-foreground group-hover:text-amber-dark transition-colors">
                 Pick your path
                 <ArrowRight className="ml-2 h-4 w-4" />

--- a/app/resources/design-system/page.tsx
+++ b/app/resources/design-system/page.tsx
@@ -2,16 +2,7 @@ import type { Metadata } from "next";
 import { Section, SectionHeader } from "@/components/ui/section";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import {
-  Check,
-  Mail,
-  ArrowRight,
-  Download,
-  ExternalLink,
-  Users,
-  Star,
-  Zap,
-} from "lucide-react";
+import { Check, Mail, ArrowRight, Download, ExternalLink, Users, Star, Zap } from "lucide-react";
 
 export const metadata: Metadata = {
   title: "Design System",
@@ -20,51 +11,119 @@ export const metadata: Metadata = {
 };
 
 const brandColors = [
-  { name: "teal",       cls: "bg-teal",       label: "Teal",       hex: "#2A6B7C", usage: "Ring / focus, kicker labels" },
-  { name: "teal-dark",  cls: "bg-teal-dark",  label: "Teal Dark",  hex: "#1B4B5A", usage: "Primary (light mode)" },
-  { name: "amber",      cls: "bg-amber",      label: "Amber",      hex: "#FFBC55", usage: "Warning / secondary CTA" },
+  { name: "teal", cls: "bg-teal", label: "Teal", hex: "#2A6B7C", usage: "Ring / focus, kicker labels" },
+  { name: "teal-dark", cls: "bg-teal-dark", label: "Teal Dark", hex: "#1B4B5A", usage: "Primary (light mode)" },
+  { name: "amber", cls: "bg-amber", label: "Amber", hex: "#FFBC55", usage: "Warning / secondary CTA" },
   { name: "amber-dark", cls: "bg-amber-dark", label: "Amber Dark", hex: "#EFA020", usage: "Overlines, hover links" },
 ];
 
 const accentTokens = [
-  { name: "coral",   cls: "bg-coral",   label: "Coral",   hex: "#E87C4E", usage: "Destructive / orange accent" },
-  { name: "mint",    cls: "bg-mint",    label: "Mint",    hex: "#5B9A8B", usage: "Check icons, accent green" },
+  { name: "coral", cls: "bg-coral", label: "Coral", hex: "#E87C4E", usage: "Destructive / orange accent" },
+  { name: "mint", cls: "bg-mint", label: "Mint", hex: "#5B9A8B", usage: "Check icons, accent green" },
   { name: "seafoam", cls: "bg-seafoam", label: "Seafoam", hex: "#A8D5D8", usage: "Secondary (light mode)" },
-  { name: "sand",    cls: "bg-sand",    label: "Sand",    hex: "#F7EDE2", usage: "Warm off-white, gradients" },
-  { name: "peach",   cls: "bg-peach",   label: "Peach",   hex: "#F5D4C1", usage: "Warm gradient base" },
-  { name: "blush",   cls: "bg-blush",   label: "Blush",   hex: "#EABFBF", usage: "Pink accent" },
+  { name: "sand", cls: "bg-sand", label: "Sand", hex: "#F7EDE2", usage: "Warm off-white, gradients" },
+  { name: "peach", cls: "bg-peach", label: "Peach", hex: "#F5D4C1", usage: "Warm gradient base" },
+  { name: "blush", cls: "bg-blush", label: "Blush", hex: "#EABFBF", usage: "Pink accent" },
 ];
 
 const semanticPairs = [
-  { bg: "background",  bgCls: "bg-background",  bgAlias: "#F9F6F2",       darkBgAlias: "#0D2B35",
-    fg: "foreground",  fgCls: "bg-[var(--color-foreground)]",  fgAlias: "teal-dark",    darkFgAlias: "#E8F4F5" },
-  { bg: "muted",       bgCls: "bg-muted",        bgAlias: "#EBF3F4",       darkBgAlias: "#1A3D4A",
-    fg: "muted-foreground",  fgCls: "bg-[var(--color-muted-foreground)]",  fgAlias: "#4A6670",     darkFgAlias: "#8BBEC6" },
-  { bg: "card",        bgCls: "bg-card",         bgAlias: "white / 70%",   darkBgAlias: "teal-dark / 50%",
-    fg: "card-foreground",   fgCls: "bg-[var(--color-card-foreground)]",   fgAlias: "teal-dark",    darkFgAlias: "#E8F4F5" },
-  { bg: "primary",     bgCls: "bg-primary",      bgAlias: "teal-dark",     darkBgAlias: "seafoam",
-    fg: "primary-foreground",  fgCls: "bg-[var(--color-primary-foreground)]",  fgAlias: "white",   darkFgAlias: "#0D2B35" },
-  { bg: "secondary",   bgCls: "bg-secondary",    bgAlias: "seafoam",       darkBgAlias: "teal-dark",
-    fg: "secondary-foreground",  fgCls: "bg-[var(--color-secondary-foreground)]",  fgAlias: "teal-dark",  darkFgAlias: "seafoam" },
-  { bg: "accent",      bgCls: "bg-accent",       bgAlias: "seafoam / 20%", darkBgAlias: "#1E4A58",
-    fg: "accent-foreground",   fgCls: "bg-[var(--color-accent-foreground)]",   fgAlias: "teal-dark",   darkFgAlias: "seafoam" },
-  { bg: "destructive", bgCls: "bg-destructive",  bgAlias: "coral",         darkBgAlias: "coral",
-    fg: "destructive-foreground",  fgCls: "bg-[var(--color-destructive-foreground)]",  fgAlias: "white",  darkFgAlias: "white" },
-  { bg: "warning",     bgCls: "bg-warning",      bgAlias: "amber",         darkBgAlias: "amber",
-    fg: "warning-foreground",  fgCls: "bg-[var(--color-warning-foreground)]",  fgAlias: "teal-dark",   darkFgAlias: "teal-dark" },
+  {
+    bg: "background",
+    bgCls: "bg-background",
+    bgAlias: "#F9F6F2",
+    darkBgAlias: "#0D2B35",
+    fg: "foreground",
+    fgCls: "bg-[var(--color-foreground)]",
+    fgAlias: "teal-dark",
+    darkFgAlias: "#E8F4F5",
+  },
+  {
+    bg: "muted",
+    bgCls: "bg-muted",
+    bgAlias: "#EBF3F4",
+    darkBgAlias: "#1A3D4A",
+    fg: "muted-foreground",
+    fgCls: "bg-[var(--color-muted-foreground)]",
+    fgAlias: "#4A6670",
+    darkFgAlias: "#8BBEC6",
+  },
+  {
+    bg: "card",
+    bgCls: "bg-card",
+    bgAlias: "white / 70%",
+    darkBgAlias: "teal-dark / 50%",
+    fg: "card-foreground",
+    fgCls: "bg-[var(--color-card-foreground)]",
+    fgAlias: "teal-dark",
+    darkFgAlias: "#E8F4F5",
+  },
+  {
+    bg: "primary",
+    bgCls: "bg-primary",
+    bgAlias: "teal-dark",
+    darkBgAlias: "seafoam",
+    fg: "primary-foreground",
+    fgCls: "bg-[var(--color-primary-foreground)]",
+    fgAlias: "white",
+    darkFgAlias: "#0D2B35",
+  },
+  {
+    bg: "secondary",
+    bgCls: "bg-secondary",
+    bgAlias: "seafoam",
+    darkBgAlias: "teal-dark",
+    fg: "secondary-foreground",
+    fgCls: "bg-[var(--color-secondary-foreground)]",
+    fgAlias: "teal-dark",
+    darkFgAlias: "seafoam",
+  },
+  {
+    bg: "accent",
+    bgCls: "bg-accent",
+    bgAlias: "seafoam / 20%",
+    darkBgAlias: "#1E4A58",
+    fg: "accent-foreground",
+    fgCls: "bg-[var(--color-accent-foreground)]",
+    fgAlias: "teal-dark",
+    darkFgAlias: "seafoam",
+  },
+  {
+    bg: "destructive",
+    bgCls: "bg-destructive",
+    bgAlias: "coral",
+    darkBgAlias: "coral",
+    fg: "destructive-foreground",
+    fgCls: "bg-[var(--color-destructive-foreground)]",
+    fgAlias: "white",
+    darkFgAlias: "white",
+  },
+  {
+    bg: "warning",
+    bgCls: "bg-warning",
+    bgAlias: "amber",
+    darkBgAlias: "amber",
+    fg: "warning-foreground",
+    fgCls: "bg-[var(--color-warning-foreground)]",
+    fgAlias: "teal-dark",
+    darkFgAlias: "teal-dark",
+  },
 ];
 
 const semanticUtilities = [
   { token: "border", bgCls: "bg-border", lightAlias: "teal-dark / 12%", darkAlias: "seafoam / 15%" },
-  { token: "ring",   bgCls: "bg-ring",   lightAlias: "teal",            darkAlias: "seafoam" },
-  { token: "input",  bgCls: "bg-input",  lightAlias: "teal-dark / 18%", darkAlias: "seafoam / 20%" },
+  { token: "ring", bgCls: "bg-ring", lightAlias: "teal", darkAlias: "seafoam" },
+  { token: "input", bgCls: "bg-input", lightAlias: "teal-dark / 18%", darkAlias: "seafoam / 20%" },
 ];
 
 const gradients = [
-  { cls: "gradient-brand texture-grain",          label: ".gradient-brand",          desc: "135° — seafoam → sand → peach" },
-  { cls: "gradient-brand-vertical texture-grain", label: ".gradient-brand-vertical", desc: "180° vertical — seafoam → sand → peach" },
-  { cls: "gradient-hero texture-grain",           label: ".gradient-hero",           desc: "160° — aqua → warm off-white → peach" },
-  { cls: "gradient-hero-soft",                    label: ".gradient-hero-soft",      desc: "Soft brand gradient for CTA sections" },
+  { cls: "gradient-brand texture-grain", label: ".gradient-brand", desc: "135° — seafoam → sand → peach" },
+  {
+    cls: "gradient-brand-vertical texture-grain",
+    label: ".gradient-brand-vertical",
+    desc: "180° vertical — seafoam → sand → peach",
+  },
+  { cls: "gradient-hero texture-grain", label: ".gradient-hero", desc: "160° — aqua → warm off-white → peach" },
+  { cls: "gradient-hero-soft", label: ".gradient-hero-soft", desc: "Soft brand gradient for CTA sections" },
 ];
 
 export default function DesignSystemPage() {
@@ -132,7 +191,8 @@ export default function DesignSystemPage() {
       <Section background="muted">
         <SectionHeader overline="Theming" title="Semantic tokens" className="mb-4" />
         <p className="text-sm text-muted-foreground mb-8 max-w-2xl">
-          Every token resolves differently in light and dark mode. Never use raw brand hex values for text, surfaces, or borders in components — always use the semantic name.
+          Every token resolves differently in light and dark mode. Never use raw brand hex values for text, surfaces, or
+          borders in components — always use the semantic name.
         </p>
 
         <div className="grid lg:grid-cols-2 gap-5">
@@ -140,7 +200,9 @@ export default function DesignSystemPage() {
           <div className="light rounded-xl overflow-hidden border border-border bg-background">
             <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
               <div className="h-2.5 w-2.5 rounded-full bg-background border border-foreground/30" />
-              <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Light mode</span>
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                Light mode
+              </span>
             </div>
             {semanticPairs.map((pair) => (
               <div key={pair.bg} className="px-4 py-2.5 border-b border-border/60">
@@ -157,10 +219,15 @@ export default function DesignSystemPage() {
               </div>
             ))}
             <div className="px-4 pt-3 pb-1 border-t border-border">
-              <p className="text-[10px] font-semibold uppercase tracking-widest mb-2 text-muted-foreground">Utilities</p>
+              <p className="text-[10px] font-semibold uppercase tracking-widest mb-2 text-muted-foreground">
+                Utilities
+              </p>
             </div>
             {semanticUtilities.map((u, i) => (
-              <div key={u.token} className={`flex items-center gap-2.5 px-4 py-2${i === semanticUtilities.length - 1 ? " pb-4" : ""}`}>
+              <div
+                key={u.token}
+                className={`flex items-center gap-2.5 px-4 py-2${i === semanticUtilities.length - 1 ? " pb-4" : ""}`}
+              >
                 <div className={`h-4 w-4 rounded-[3px] border border-foreground/20 shrink-0 ${u.bgCls}`} />
                 <code className="text-[11px] font-semibold flex-1 text-foreground">{u.token}</code>
                 <span className="text-[10px] font-mono text-muted-foreground">{u.lightAlias}</span>
@@ -172,7 +239,9 @@ export default function DesignSystemPage() {
           <div className="dark rounded-xl overflow-hidden border border-border bg-background">
             <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
               <div className="h-2.5 w-2.5 rounded-full bg-background border border-foreground/30" />
-              <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Dark mode</span>
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                Dark mode
+              </span>
             </div>
             {semanticPairs.map((pair) => (
               <div key={pair.bg} className="px-4 py-2.5 border-b border-border/60">
@@ -189,10 +258,15 @@ export default function DesignSystemPage() {
               </div>
             ))}
             <div className="px-4 pt-3 pb-1 border-t border-border">
-              <p className="text-[10px] font-semibold uppercase tracking-widest mb-2 text-muted-foreground">Utilities</p>
+              <p className="text-[10px] font-semibold uppercase tracking-widest mb-2 text-muted-foreground">
+                Utilities
+              </p>
             </div>
             {semanticUtilities.map((u, i) => (
-              <div key={u.token} className={`flex items-center gap-2.5 px-4 py-2${i === semanticUtilities.length - 1 ? " pb-4" : ""}`}>
+              <div
+                key={u.token}
+                className={`flex items-center gap-2.5 px-4 py-2${i === semanticUtilities.length - 1 ? " pb-4" : ""}`}
+              >
                 <div className={`h-4 w-4 rounded-[3px] border border-foreground/20 shrink-0 ${u.bgCls}`} />
                 <code className="text-[11px] font-semibold flex-1 text-foreground">{u.token}</code>
                 <span className="text-[10px] font-mono text-muted-foreground">{u.darkAlias}</span>
@@ -214,11 +288,16 @@ export default function DesignSystemPage() {
           <div className="light rounded-xl overflow-hidden border border-border">
             <div className="flex items-center gap-2 px-4 py-3 border-b border-border bg-background">
               <div className="h-2.5 w-2.5 rounded-full bg-background border border-foreground/30" />
-              <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Light mode</span>
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                Light mode
+              </span>
             </div>
             <div className="grid grid-cols-2">
               {gradients.map((g, i) => (
-                <div key={g.label} className={`bg-background${i % 2 === 0 ? " border-r border-border" : ""}${i < 2 ? " border-b border-border" : ""}`}>
+                <div
+                  key={g.label}
+                  className={`bg-background${i % 2 === 0 ? " border-r border-border" : ""}${i < 2 ? " border-b border-border" : ""}`}
+                >
                   <div className={`h-28 w-full ${g.cls}`} />
                   <div className="px-3 py-2.5">
                     <code className="text-[11px] font-semibold block text-foreground">{g.label}</code>
@@ -233,11 +312,16 @@ export default function DesignSystemPage() {
           <div className="dark rounded-xl overflow-hidden border border-border">
             <div className="flex items-center gap-2 px-4 py-3 border-b border-border bg-background">
               <div className="h-2.5 w-2.5 rounded-full bg-background border border-foreground/30" />
-              <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">Dark mode</span>
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                Dark mode
+              </span>
             </div>
             <div className="grid grid-cols-2">
               {gradients.map((g, i) => (
-                <div key={g.label} className={`bg-background${i % 2 === 0 ? " border-r border-border" : ""}${i < 2 ? " border-b border-border" : ""}`}>
+                <div
+                  key={g.label}
+                  className={`bg-background${i % 2 === 0 ? " border-r border-border" : ""}${i < 2 ? " border-b border-border" : ""}`}
+                >
                   <div className={`h-28 w-full ${g.cls}`} />
                   <div className="px-3 py-2.5">
                     <code className="text-[11px] font-semibold block text-foreground">{g.label}</code>
@@ -255,7 +339,9 @@ export default function DesignSystemPage() {
         <SectionHeader overline="Typography" title="Type scale" className="mb-12" />
         <div className="space-y-8 max-w-3xl">
           <div className="pb-6 border-b border-border">
-            <p className="text-xs text-muted-foreground uppercase tracking-wider mb-3">Display — Space Grotesk (.font-display)</p>
+            <p className="text-xs text-muted-foreground uppercase tracking-wider mb-3">
+              Display — Space Grotesk (.font-display)
+            </p>
             <p className="font-display text-6xl font-semibold text-foreground leading-tight">Aa Display 6xl</p>
             <p className="font-display text-5xl font-semibold text-foreground leading-tight mt-2">Aa Display 5xl</p>
             <p className="font-display text-4xl font-semibold text-foreground leading-tight mt-2">Aa Display 4xl</p>
@@ -295,10 +381,18 @@ export default function DesignSystemPage() {
           <div>
             <p className="text-sm text-muted-foreground mb-4 uppercase tracking-wider">Sizes</p>
             <div className="flex flex-wrap gap-4 items-center">
-              <Button variant="primary" size="lg">Large</Button>
-              <Button variant="primary" size="md">Medium (default)</Button>
-              <Button variant="primary" size="sm">Small</Button>
-              <Button variant="primary" size="icon"><Star className="h-4 w-4" /></Button>
+              <Button variant="primary" size="lg">
+                Large
+              </Button>
+              <Button variant="primary" size="md">
+                Medium (default)
+              </Button>
+              <Button variant="primary" size="sm">
+                Small
+              </Button>
+              <Button variant="primary" size="icon">
+                <Star className="h-4 w-4" />
+              </Button>
             </div>
           </div>
           <div>
@@ -325,8 +419,12 @@ export default function DesignSystemPage() {
           <div>
             <p className="text-sm text-muted-foreground mb-4 uppercase tracking-wider">States</p>
             <div className="flex flex-wrap gap-4 items-center">
-              <Button variant="primary" disabled>Disabled primary</Button>
-              <Button variant="outline" disabled>Disabled outline</Button>
+              <Button variant="primary" disabled>
+                Disabled primary
+              </Button>
+              <Button variant="outline" disabled>
+                Disabled outline
+              </Button>
             </div>
           </div>
         </div>
@@ -349,8 +447,12 @@ export default function DesignSystemPage() {
           <div>
             <p className="text-sm text-muted-foreground mb-3 uppercase tracking-wider">Sizes</p>
             <div className="flex flex-wrap gap-3 items-center">
-              <Badge variant="default" size="md">Medium (default)</Badge>
-              <Badge variant="default" size="sm">Small</Badge>
+              <Badge variant="default" size="md">
+                Medium (default)
+              </Badge>
+              <Badge variant="default" size="sm">
+                Small
+              </Badge>
             </div>
           </div>
           <div>
@@ -373,7 +475,9 @@ export default function DesignSystemPage() {
               <Users className="h-6 w-6" />
             </div>
             <h3 className="font-display text-xl font-semibold text-foreground mb-3">Icon card</h3>
-            <p className="text-muted-foreground leading-relaxed">Used for feature lists and benefit sections throughout the site.</p>
+            <p className="text-muted-foreground leading-relaxed">
+              Used for feature lists and benefit sections throughout the site.
+            </p>
           </div>
 
           {/* Checklist card — ring tint */}
@@ -412,7 +516,10 @@ export default function DesignSystemPage() {
           </div>
 
           {/* Hover-link card */}
-          <a href="#" className="group flex items-center gap-4 bg-card rounded-xl border border-border p-5 hover:border-ring/50 transition-all">
+          <a
+            href="#"
+            className="group flex items-center gap-4 bg-card rounded-xl border border-border p-5 hover:border-ring/50 transition-all"
+          >
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-ring/10">
               <Star className="h-6 w-6 text-ring" />
             </div>
@@ -462,17 +569,15 @@ export default function DesignSystemPage() {
       <Section>
         <SectionHeader overline="Components" title="Process stepper" className="mb-12" />
         <div className="grid gap-6 lg:grid-cols-5">
-          {["Initial contact", "Scoping call", "Confirm details", "Marketing kickoff", "Event day"].map(
-            (title, i) => (
-              <div key={title} className="relative">
-                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-ring text-primary-foreground font-semibold mb-4">
-                  {i + 1}
-                </div>
-                <h4 className="font-semibold text-foreground mb-1">{title}</h4>
-                <p className="text-sm text-muted-foreground">Step description goes here.</p>
+          {["Initial contact", "Scoping call", "Confirm details", "Marketing kickoff", "Event day"].map((title, i) => (
+            <div key={title} className="relative">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-ring text-primary-foreground font-semibold mb-4">
+                {i + 1}
               </div>
-            )
-          )}
+              <h4 className="font-semibold text-foreground mb-1">{title}</h4>
+              <p className="text-sm text-muted-foreground">Step description goes here.</p>
+            </div>
+          ))}
         </div>
       </Section>
 
@@ -482,9 +587,7 @@ export default function DesignSystemPage() {
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
             CTA section pattern
           </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            Gradient CTA section
-          </h2>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">Gradient CTA section</h2>
           <p className="text-muted-foreground mb-8">
             Used at the bottom of every get-involved sub-page. Always ends with a primary action.
           </p>

--- a/app/resources/layout.tsx
+++ b/app/resources/layout.tsx
@@ -9,11 +9,7 @@ const resourcesNav = [
   { name: "Design System", href: "/resources/design-system" },
 ];
 
-export default function ResourcesLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function ResourcesLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
 
   return (

--- a/app/resources/media-kit/page.tsx
+++ b/app/resources/media-kit/page.tsx
@@ -9,8 +9,7 @@ import { CopyButton } from "@/components/ui/copy-button";
 
 export const metadata: Metadata = {
   title: "Media Kit",
-  description:
-    "TechTank TO media kit — logos, brand guidelines, and fast facts for press, sponsors, and partners.",
+  description: "TechTank TO media kit — logos, brand guidelines, and fast facts for press, sponsors, and partners.",
 };
 
 const fastFacts = [
@@ -42,10 +41,30 @@ const logoDownload = {
 };
 
 const resources = [
-  { name: "Brand Guidelines", href: "/resources/design-system", description: "Colors, typography, usage rules", internal: true },
-  { name: "Speaker Slide Template", href: "/downloads/coming-soon.txt", description: "Google Slides / PPTX template", internal: false },
-  { name: "Speaker Checklist", href: "/downloads/coming-soon.txt", description: "Preparation guide for first-time speakers", internal: false },
-  { name: "Host Checklist", href: "/downloads/coming-soon.txt", description: "Event-day preparation guide", internal: false },
+  {
+    name: "Brand Guidelines",
+    href: "/resources/design-system",
+    description: "Colors, typography, usage rules",
+    internal: true,
+  },
+  {
+    name: "Speaker Slide Template",
+    href: "/downloads/coming-soon.txt",
+    description: "Google Slides / PPTX template",
+    internal: false,
+  },
+  {
+    name: "Speaker Checklist",
+    href: "/downloads/coming-soon.txt",
+    description: "Preparation guide for first-time speakers",
+    internal: false,
+  },
+  {
+    name: "Host Checklist",
+    href: "/downloads/coming-soon.txt",
+    description: "Event-day preparation guide",
+    internal: false,
+  },
 ];
 
 export default function PressKitPage() {
@@ -62,8 +81,8 @@ export default function PressKitPage() {
               TechTank Media Kit
             </h1>
             <p className="text-xl text-muted-foreground leading-relaxed mb-8">
-              Logos, guidelines, and fast facts for press, sponsors, and
-              partners. All assets are free to use with attribution.
+              Logos, guidelines, and fast facts for press, sponsors, and partners. All assets are free to use with
+              attribution.
             </p>
             <Button variant="primary" size="lg" asChild>
               <a href="/downloads/techtank-media-kit.zip" download>
@@ -77,17 +96,10 @@ export default function PressKitPage() {
 
       {/* Fast Facts */}
       <Section>
-        <SectionHeader
-          overline="Fast facts"
-          title="About TechTank TO"
-          className="mb-12"
-        />
+        <SectionHeader overline="Fast facts" title="About TechTank TO" className="mb-12" />
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {fastFacts.map((fact) => (
-            <div
-              key={fact.label}
-              className="bg-card rounded-xl border border-border p-5"
-            >
+            <div key={fact.label} className="bg-card rounded-xl border border-border p-5">
               <p className="text-sm text-muted-foreground mb-1">{fact.label}</p>
               <p className="font-semibold text-foreground">{fact.value}</p>
             </div>
@@ -97,39 +109,30 @@ export default function PressKitPage() {
 
       {/* Boilerplate */}
       <Section background="white">
-        <SectionHeader
-          overline="Boilerplate"
-          title="About TechTank (for press)"
-          className="mb-8"
-        />
+        <SectionHeader overline="Boilerplate" title="About TechTank (for press)" className="mb-8" />
         <div className="max-w-3xl space-y-6">
           <div className="bg-background rounded-xl border border-border p-6">
             <p className="text-foreground leading-relaxed mb-4">
-              <strong>Full paragraph: </strong>TechTank TO is Toronto&apos;s
-              volunteer-run tech community, hosting year-round in-person events
-              since 2023. Each event brings together 40-120 attendees,
-              including developers, designers, and tech professionals for
-              technical talks and networking. TechTank is committed to
-              fostering a supportive and inclusive environment where people of
-              all skill levels can explore, create, and thrive in technology.
+              <strong>Full paragraph: </strong>TechTank TO is Toronto&apos;s volunteer-run tech community, hosting
+              year-round in-person events since 2023. Each event brings together 40-120 attendees, including developers,
+              designers, and tech professionals for technical talks and networking. TechTank is committed to fostering a
+              supportive and inclusive environment where people of all skill levels can explore, create, and thrive in
+              technology.
             </p>
             <CopyButton text="TechTank TO is Toronto's volunteer-run tech community, hosting year-round in-person events since 2023. Each event brings together 40-120 attendees, including developers, designers, and tech professionals for technical talks and networking. TechTank is committed to fostering a supportive and inclusive environment where people of all skill levels can explore, create, and thrive in technology." />
           </div>
           <div className="bg-background rounded-xl border border-border p-6">
             <p className="text-foreground leading-relaxed mb-4">
-              <strong>One-liner: </strong>TechTank TO is Toronto&apos;s
-              volunteer-run tech community, hosting year-round events for
-              developers, designers, and tech professionals since 2023.
+              <strong>One-liner: </strong>TechTank TO is Toronto&apos;s volunteer-run tech community, hosting year-round
+              events for developers, designers, and tech professionals since 2023.
             </p>
             <CopyButton text="TechTank TO is Toronto's volunteer-run tech community, hosting year-round events for developers, designers, and tech professionals since 2023." />
           </div>
           <div className="bg-background rounded-xl border border-border p-6">
             <p className="text-foreground leading-relaxed mb-4">
-              <strong>Mission statement: </strong>TechTank strengthens
-              Toronto&apos;s tech ecosystem by creating engaging,
-              community-driven spaces that bring people together through social
-              events and career-focused programming, helping them build
-              meaningful connections and grow in their careers.
+              <strong>Mission statement: </strong>TechTank strengthens Toronto&apos;s tech ecosystem by creating
+              engaging, community-driven spaces that bring people together through social events and career-focused
+              programming, helping them build meaningful connections and grow in their careers.
             </p>
             <CopyButton text="TechTank strengthens Toronto's tech ecosystem by creating engaging, community-driven spaces that bring people together through social events and career-focused programming, helping them build meaningful connections and grow in their careers." />
           </div>
@@ -179,9 +182,7 @@ export default function PressKitPage() {
             <FileText className="h-6 w-6 text-ring" />
           </div>
           <div className="flex-1 min-w-0">
-            <p className="font-semibold text-foreground group-hover:text-ring transition-colors">
-              {logoDownload.name}
-            </p>
+            <p className="font-semibold text-foreground group-hover:text-ring transition-colors">{logoDownload.name}</p>
             <p className="text-sm text-muted-foreground">{logoDownload.description}</p>
           </div>
           <Download className="h-5 w-5 text-muted-foreground group-hover:text-ring transition-colors shrink-0" />
@@ -190,21 +191,11 @@ export default function PressKitPage() {
 
       {/* Brand Colors */}
       <Section background="white">
-        <SectionHeader
-          overline="Brand colors"
-          title="Color palette"
-          className="mb-12"
-        />
+        <SectionHeader overline="Brand colors" title="Color palette" className="mb-12" />
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {brandColors.map((color) => (
-            <div
-              key={color.name}
-              className="bg-background rounded-xl border border-border overflow-hidden"
-            >
-              <div
-                className="h-20"
-                style={{ backgroundColor: color.hex }}
-              />
+            <div key={color.name} className="bg-background rounded-xl border border-border overflow-hidden">
+              <div className="h-20" style={{ backgroundColor: color.hex }} />
               <div className="p-4">
                 <div className="flex items-center justify-between mb-1">
                   <p className="font-semibold text-foreground">{color.name}</p>
@@ -219,30 +210,20 @@ export default function PressKitPage() {
 
       {/* Typography */}
       <Section>
-        <SectionHeader
-          overline="Typography"
-          title="Font pairing"
-          className="mb-12"
-        />
+        <SectionHeader overline="Typography" title="Font pairing" className="mb-12" />
         <div className="grid gap-8 lg:grid-cols-2">
           <div className="bg-card rounded-xl border border-border p-6">
             <p className="text-sm text-muted-foreground mb-2">Display / Headlines</p>
-            <p className="font-display text-4xl font-semibold text-foreground mb-4">
-              Space Grotesk
-            </p>
+            <p className="font-display text-4xl font-semibold text-foreground mb-4">Space Grotesk</p>
             <p className="text-muted-foreground">
-              Used for headings, titles, and display text. Geometric sans-serif
-              with a modern, technical feel.
+              Used for headings, titles, and display text. Geometric sans-serif with a modern, technical feel.
             </p>
           </div>
           <div className="bg-card rounded-xl border border-border p-6">
             <p className="text-sm text-muted-foreground mb-2">Body / UI</p>
-            <p className="font-sans text-4xl font-semibold text-foreground mb-4">
-              Inter
-            </p>
+            <p className="font-sans text-4xl font-semibold text-foreground mb-4">Inter</p>
             <p className="text-muted-foreground">
-              Used for body text, UI elements, and long-form content. Humanist
-              sans-serif optimized for screens.
+              Used for body text, UI elements, and long-form content. Humanist sans-serif optimized for screens.
             </p>
           </div>
         </div>
@@ -250,17 +231,11 @@ export default function PressKitPage() {
 
       {/* Resources */}
       <Section>
-        <SectionHeader
-          overline="Resources"
-          title="Additional assets"
-          className="mb-12"
-        />
+        <SectionHeader overline="Resources" title="Additional assets" className="mb-12" />
         <div className="grid gap-4 sm:grid-cols-2">
           {resources.map((resource) => {
             const Wrapper = resource.internal ? Link : "a";
-            const wrapperProps = resource.internal
-              ? { href: resource.href }
-              : { href: resource.href };
+            const wrapperProps = resource.internal ? { href: resource.href } : { href: resource.href };
             return (
               <Wrapper
                 key={resource.name}
@@ -276,10 +251,11 @@ export default function PressKitPage() {
                   </p>
                   <p className="text-sm text-muted-foreground">{resource.description}</p>
                 </div>
-                {resource.internal
-                  ? <ExternalLink className="h-5 w-5 text-muted-foreground group-hover:text-ring transition-colors shrink-0" />
-                  : <Download className="h-5 w-5 text-muted-foreground group-hover:text-ring transition-colors shrink-0" />
-                }
+                {resource.internal ? (
+                  <ExternalLink className="h-5 w-5 text-muted-foreground group-hover:text-ring transition-colors shrink-0" />
+                ) : (
+                  <Download className="h-5 w-5 text-muted-foreground group-hover:text-ring transition-colors shrink-0" />
+                )}
               </Wrapper>
             );
           })}
@@ -292,46 +268,28 @@ export default function PressKitPage() {
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
             Connect with us
           </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-8">
-            Official channels
-          </h2>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-8">Official channels</h2>
           <div className="flex flex-wrap gap-4 justify-center">
             <Button variant="outline" asChild>
-              <a
-                href="https://linkedin.com/company/techtank-to"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <a href="https://linkedin.com/company/techtank-to" target="_blank" rel="noopener noreferrer">
                 LinkedIn
                 <ExternalLink className="ml-2 h-4 w-4" />
               </a>
             </Button>
             <Button variant="outline" asChild>
-              <a
-                href="https://instagram.com/techtankto"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <a href="https://instagram.com/techtankto" target="_blank" rel="noopener noreferrer">
                 Instagram
                 <ExternalLink className="ml-2 h-4 w-4" />
               </a>
             </Button>
             <Button variant="outline" asChild>
-              <a
-                href="https://youtube.com/@TechTankTo"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <a href="https://youtube.com/@TechTankTo" target="_blank" rel="noopener noreferrer">
                 YouTube
                 <ExternalLink className="ml-2 h-4 w-4" />
               </a>
             </Button>
             <Button variant="outline" asChild>
-              <a
-                href="https://github.com/tech-tankorg"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <a href="https://github.com/tech-tankorg" target="_blank" rel="noopener noreferrer">
                 GitHub
                 <ExternalLink className="ml-2 h-4 w-4" />
               </a>
@@ -343,26 +301,19 @@ export default function PressKitPage() {
       {/* Usage Terms */}
       <Section>
         <div className="max-w-3xl mx-auto">
-          <SectionHeader
-            overline="Usage terms"
-            title="How to use our assets"
-            className="mb-8"
-          />
+          <SectionHeader overline="Usage terms" title="How to use our assets" className="mb-8" />
           <div className="bg-card rounded-xl border border-border p-6 space-y-4">
             <p className="text-foreground">
-              <strong>Permitted:</strong> Use our logos and assets to reference
-              TechTank TO in press coverage, event listings, partnership
-              announcements, and sponsor materials with proper attribution.
+              <strong>Permitted:</strong> Use our logos and assets to reference TechTank TO in press coverage, event
+              listings, partnership announcements, and sponsor materials with proper attribution.
             </p>
             <p className="text-foreground">
-              <strong>Not permitted:</strong>{' '}Modifying logo colors, proportions,
-              or elements; using assets to imply endorsement without written
-              permission; using assets in ways that could damage TechTank&apos;s
-              reputation.
+              <strong>Not permitted:</strong> Modifying logo colors, proportions, or elements; using assets to imply
+              endorsement without written permission; using assets in ways that could damage TechTank&apos;s reputation.
             </p>
             <p className="text-muted-foreground text-sm">
-              For questions about asset usage or to request permission for
-              special use cases, please contact us at techtankto@gmail.com.
+              For questions about asset usage or to request permission for special use cases, please contact us at
+              techtankto@gmail.com.
             </p>
           </div>
         </div>
@@ -374,12 +325,8 @@ export default function PressKitPage() {
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-ring mb-4">
             Media contact
           </span>
-          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">
-            Get in touch
-          </h2>
-          <p className="text-muted-foreground">
-            For press inquiries, interviews, and partnership discussions.
-          </p>
+          <h2 className="font-display text-3xl font-semibold text-foreground mb-4">Get in touch</h2>
+          <p className="text-muted-foreground">For press inquiries, interviews, and partnership discussions.</p>
         </div>
         <div className="max-w-xl mx-auto">
           <ContactCard context="For press inquiries, interviews, and partnership requests." />

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -59,13 +59,7 @@ export function Footer() {
           {/* Brand column */}
           <div className="col-span-2 lg:col-span-1">
             <Link href="/" className="flex items-center">
-              <Image
-                src="/images/logos/dark.svg"
-                alt="TechTank TO"
-                width={128}
-                height={56}
-                className="h-10 w-auto"
-              />
+              <Image src="/images/logos/dark.svg" alt="TechTank TO" width={128} height={56} className="h-10 w-auto" />
             </Link>
             <p className="mt-4 text-sm text-primary-foreground/70 dark:text-foreground/70 leading-relaxed">
               Toronto&apos;s inclusive tech community. Year-round events since 2023.

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -58,9 +58,7 @@ export function Header() {
         <div className="hidden lg:flex lg:items-center lg:gap-2">
           <ThemeToggle />
           <Button variant="primary" size="sm" asChild>
-            <Link href="/#join-us">
-              Join us
-            </Link>
+            <Link href="/#join-us">Join us</Link>
           </Button>
         </div>
 
@@ -73,11 +71,7 @@ export function Header() {
             onClick={toggleMobileMenu}
             aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
           >
-            {mobileMenuOpen ? (
-              <X className="h-6 w-6" />
-            ) : (
-              <Menu className="h-6 w-6" />
-            )}
+            {mobileMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
           </button>
         </div>
       </nav>
@@ -98,9 +92,7 @@ export function Header() {
             ))}
             <div className="pt-4 border-t border-border">
               <Button variant="primary" size="sm" className="w-full" asChild>
-                <Link href="/#join-us">
-                  Join us
-                </Link>
+                <Link href="/#join-us">Join us</Link>
               </Button>
             </div>
           </div>

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -1,24 +1,20 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as AccordionPrimitive from "@radix-ui/react-accordion"
-import { ChevronDown } from "lucide-react"
+import * as React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDown } from "lucide-react";
 
-import { cn } from "@/utils/theme"
+import { cn } from "@/utils/theme";
 
-const Accordion = AccordionPrimitive.Root
+const Accordion = AccordionPrimitive.Root;
 
 const AccordionItem = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
 >(({ className, ...props }, ref) => (
-  <AccordionPrimitive.Item
-    ref={ref}
-    className={cn("border-b", className)}
-    {...props}
-  />
-))
-AccordionItem.displayName = "AccordionItem"
+  <AccordionPrimitive.Item ref={ref} className={cn("border-b", className)} {...props} />
+));
+AccordionItem.displayName = "AccordionItem";
 
 const AccordionTrigger = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Trigger>,
@@ -29,7 +25,7 @@ const AccordionTrigger = React.forwardRef<
       ref={ref}
       className={cn(
         "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
-        className
+        className,
       )}
       {...props}
     >
@@ -37,8 +33,8 @@ const AccordionTrigger = React.forwardRef<
       <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
-))
-AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+));
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
 
 const AccordionContent = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Content>,
@@ -51,8 +47,8 @@ const AccordionContent = React.forwardRef<
   >
     <div className={cn("pb-4 pt-0", className)}>{children}</div>
   </AccordionPrimitive.Content>
-))
+));
 
-AccordionContent.displayName = AccordionPrimitive.Content.displayName
+AccordionContent.displayName = AccordionPrimitive.Content.displayName;
 
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -8,17 +8,12 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
-        secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        destructive:
-          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        default: "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary: "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive: "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-foreground",
-        warning:
-          "border-transparent bg-warning text-warning-foreground hover:bg-warning/80",
-        success:
-          "border-transparent bg-success text-success-foreground hover:bg-success/80",
+        warning: "border-transparent bg-warning text-warning-foreground hover:bg-warning/80",
+        success: "border-transparent bg-success text-success-foreground hover:bg-success/80",
       },
       size: {
         sm: "gap-1 px-2 py-0.5 text-[10px]",
@@ -29,20 +24,16 @@ const badgeVariants = cva(
       variant: "default",
       size: "md",
     },
-  }
+  },
 );
 
-interface BadgeProps
-  extends React.HTMLAttributes<HTMLElement>,
-    VariantProps<typeof badgeVariants> {
+interface BadgeProps extends React.HTMLAttributes<HTMLElement>, VariantProps<typeof badgeVariants> {
   asChild?: boolean;
 }
 
 function Badge({ className, variant, size, asChild = false, ...props }: BadgeProps) {
   const Comp = asChild ? Slot : "span";
-  return (
-    <Comp className={cn(badgeVariants({ variant, size }), className)} {...props} />
-  );
+  return <Comp className={cn(badgeVariants({ variant, size }), className)} {...props} />;
 }
 
 export { Badge };

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -9,8 +9,10 @@ const buttonVariants = cva(
     variants: {
       variant: {
         primary: "bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-ring",
-        secondary: "bg-warning text-warning-foreground hover:bg-warning/90 hover:text-warning-foreground focus-visible:ring-ring",
-        outline: "border-2 border-primary text-primary hover:bg-primary hover:text-primary-foreground focus-visible:ring-ring",
+        secondary:
+          "bg-warning text-warning-foreground hover:bg-warning/90 hover:text-warning-foreground focus-visible:ring-ring",
+        outline:
+          "border-2 border-primary text-primary hover:bg-primary hover:text-primary-foreground focus-visible:ring-ring",
         ghost: "text-foreground/70 hover:bg-foreground/5 hover:text-foreground focus-visible:ring-ring",
         nav: "font-medium text-muted-foreground hover:bg-muted/60 focus-visible:ring-ring",
       },
@@ -36,27 +38,19 @@ const buttonVariants = cva(
       variant: "primary",
       size: "md",
     },
-  }
+  },
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, isActive, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, isActive }), className)}
-        ref={ref}
-        {...props}
-      />
-    );
-  }
+    return <Comp className={cn(buttonVariants({ variant, size, isActive }), className)} ref={ref} {...props} />;
+  },
 );
 
 Button.displayName = "Button";
-

--- a/components/ui/contact-card.tsx
+++ b/components/ui/contact-card.tsx
@@ -23,7 +23,7 @@ export function ContactCard({
   return (
     <div className="rounded-2xl glass p-6 lg:p-8 space-y-4">
       <p className="text-sm text-muted-foreground">{context}</p>
-      
+
       {/* Email */}
       <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground">
@@ -41,11 +41,7 @@ export function ContactCard({
             className="inline-flex items-center justify-center h-7 w-7 rounded-lg bg-card/50 hover:bg-secondary text-muted-foreground hover:text-secondary-foreground transition-colors"
             aria-label={copied ? "Copied" : "Copy email"}
           >
-            {copied ? (
-              <Check className="h-3.5 w-3.5" />
-            ) : (
-              <Copy className="h-3.5 w-3.5" />
-            )}
+            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
           </button>
         </div>
       </div>

--- a/components/ui/copy-button.tsx
+++ b/components/ui/copy-button.tsx
@@ -19,11 +19,7 @@ export function CopyButton({ text }: CopyButtonProps) {
 
   return (
     <Button variant="ghost" size="sm" onClick={handleCopy}>
-      {copied ? (
-        <Check className="mr-2 h-4 w-4" />
-      ) : (
-        <Copy className="mr-2 h-4 w-4" />
-      )}
+      {copied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
       {copied ? "Copied!" : "Copy to clipboard"}
     </Button>
   );

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -55,7 +55,7 @@ export function Dialog({ open, onClose, labelledBy, className, children }: Dialo
           "w-[calc(100%-2rem)] max-w-md max-h-[85dvh] rounded-2xl",
           "md:max-w-xl md:max-h-[80dvh]",
           "lg:max-w-2xl",
-          className
+          className,
         )}
         role="dialog"
         aria-modal="true"
@@ -75,11 +75,9 @@ export function Dialog({ open, onClose, labelledBy, className, children }: Dialo
           </Button>
         </div>
 
-        <div className="flex flex-1 flex-col gap-5 overflow-hidden px-6 md:px-8 lg:px-10 pb-4 min-h-0">
-          {children}
-        </div>
+        <div className="flex flex-1 flex-col gap-5 overflow-hidden px-6 md:px-8 lg:px-10 pb-4 min-h-0">{children}</div>
       </div>
     </>,
-    document.body
+    document.body,
   );
 }

--- a/components/ui/dual-cta.tsx
+++ b/components/ui/dual-cta.tsx
@@ -17,42 +17,22 @@ export function DualCTA() {
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-amber-dark mb-2">
             Stay in the loop
           </span>
-          <h3 className="font-display text-lg lg:text-xl font-bold text-foreground mb-2">
-            Never miss an event
-          </h3>
+          <h3 className="font-display text-lg lg:text-xl font-bold text-foreground mb-2">Never miss an event</h3>
           <p className="text-sm text-muted-foreground mb-4 max-w-sm">
             Subscribe to our Luma calendar and follow us on socials.
           </p>
           <div className="flex flex-wrap gap-2">
             {eventLinks.map((link) => (
-              <Button
-                key={link.id}
-                variant="primary"
-                size="sm"
-                asChild
-              >
-                <a
-                  href={link.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+              <Button key={link.id} variant="primary" size="sm" asChild>
+                <a href={link.url} target="_blank" rel="noopener noreferrer">
                   {link.name}
                   <ExternalLink className="ml-2 h-3.5 w-3.5" />
                 </a>
               </Button>
             ))}
             {socialLinks.map((link) => (
-              <Button
-                key={link.id}
-                variant={link.type === "primary" ? "primary" : "outline"}
-                size="sm"
-                asChild
-              >
-                <a
-                  href={link.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+              <Button key={link.id} variant={link.type === "primary" ? "primary" : "outline"} size="sm" asChild>
+                <a href={link.url} target="_blank" rel="noopener noreferrer">
                   {link.name}
                   <ExternalLink className="ml-2 h-3.5 w-3.5" />
                 </a>
@@ -69,28 +49,15 @@ export function DualCTA() {
           <span className="inline-block text-xs font-semibold uppercase tracking-widest text-amber-dark mb-2">
             Get involved
           </span>
-          <h3 className="font-display text-lg lg:text-xl font-bold text-foreground mb-2">
-            Want to contribute?
-          </h3>
-          <p className="text-sm text-muted-foreground mb-4 max-w-sm">
-            Speak, host, sponsor, or volunteer.
-          </p>
+          <h3 className="font-display text-lg lg:text-xl font-bold text-foreground mb-2">Want to contribute?</h3>
+          <p className="text-sm text-muted-foreground mb-4 max-w-sm">Speak, host, sponsor, or volunteer.</p>
           <div className="flex flex-wrap gap-2">
             <Button variant="primary" size="sm" asChild>
               <Link href="/get-involved">Get involved</Link>
             </Button>
             {contributeLinks.map((link) => (
-              <Button
-                key={link.id}
-                variant="outline"
-                size="sm"
-                asChild
-              >
-                <a
-                  href={link.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+              <Button key={link.id} variant="outline" size="sm" asChild>
+                <a href={link.url} target="_blank" rel="noopener noreferrer">
                   {link.name}
                   <ExternalLink className="ml-2 h-3.5 w-3.5" />
                 </a>

--- a/components/ui/event-browser.tsx
+++ b/components/ui/event-browser.tsx
@@ -15,14 +15,16 @@ type DisplayMode = "cards" | "grid" | "list";
 const CATEGORY_TAGS: Record<Exclude<CategoryFilter, "all" | "other">, string[]> = {
   "tech-talks": ["Tech Talk", "Panel", "Workshop"],
   "coffee-chats": ["Coffee Chat"],
-  "socials": ["Social"],
-  "sports": ["Sports"],
+  socials: ["Social"],
+  sports: ["Sports"],
 };
 
 function matchesCategory(event: Event, cat: CategoryFilter): boolean {
   if (cat === "all") return true;
   if (cat === "other") {
-    return !Object.values(CATEGORY_TAGS).flat().some((t) => event.tags.includes(t));
+    return !Object.values(CATEGORY_TAGS)
+      .flat()
+      .some((t) => event.tags.includes(t));
   }
   const required = CATEGORY_TAGS[cat];
   if (cat === "socials") {
@@ -57,11 +59,12 @@ export function EventBrowser({ events }: EventBrowserProps) {
     return result;
   }, [events, category]);
 
-  useEffect(() => { setVisibleCount(PAGE_SIZE); }, [category]);
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [category]);
 
   const visible = filtered.slice(0, visibleCount);
   const hasMore = visibleCount < filtered.length;
-
 
   const categories: { id: CategoryFilter; label: string }[] = [
     { id: "all", label: "All" },
@@ -71,7 +74,6 @@ export function EventBrowser({ events }: EventBrowserProps) {
     { id: "sports", label: "Sports" },
     { id: "other", label: "Other" },
   ];
-
 
   return (
     <div>
@@ -87,7 +89,7 @@ export function EventBrowser({ events }: EventBrowserProps) {
                 "px-3 py-1.5 rounded-full text-sm font-medium transition-colors",
                 category === c.id
                   ? "bg-primary text-primary-foreground"
-                  : "bg-muted text-muted-foreground hover:bg-muted/80"
+                  : "bg-muted text-muted-foreground hover:bg-muted/80",
               )}
             >
               {c.label}
@@ -101,7 +103,9 @@ export function EventBrowser({ events }: EventBrowserProps) {
             onClick={() => setDisplayMode("cards")}
             className={cn(
               "p-1.5 rounded-md transition-colors",
-              displayMode === "cards" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+              displayMode === "cards"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
             )}
             aria-label="Cards view"
           >
@@ -111,7 +115,9 @@ export function EventBrowser({ events }: EventBrowserProps) {
             onClick={() => setDisplayMode("grid")}
             className={cn(
               "p-1.5 rounded-md transition-colors",
-              displayMode === "grid" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+              displayMode === "grid"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
             )}
             aria-label="Grid view"
           >
@@ -121,7 +127,9 @@ export function EventBrowser({ events }: EventBrowserProps) {
             onClick={() => setDisplayMode("list")}
             className={cn(
               "p-1.5 rounded-md transition-colors",
-              displayMode === "list" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"
+              displayMode === "list"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
             )}
             aria-label="List view"
           >
@@ -137,9 +145,7 @@ export function EventBrowser({ events }: EventBrowserProps) {
 
       {/* Events */}
       {filtered.length === 0 ? (
-        <div className="text-center py-16 text-muted-foreground">
-          No events match the current filters.
-        </div>
+        <div className="text-center py-16 text-muted-foreground">No events match the current filters.</div>
       ) : displayMode === "cards" ? (
         <CardsView events={visible} />
       ) : displayMode === "grid" ? (
@@ -213,16 +219,16 @@ function GridView({ events }: { events: Event[] }) {
               <Badge variant={isUpcoming ? "warning" : "secondary"} size="sm" className="self-start">
                 {isUpcoming ? "Upcoming" : "Past"}
               </Badge>
-              {event.tags[0] && (
-                <span className="text-[10px] text-white">{event.tags[0]}</span>
-              )}
+              {event.tags[0] && <span className="text-[10px] text-white">{event.tags[0]}</span>}
 
               <p className="text-white text-xs font-semibold line-clamp-2 leading-snug">
                 {event.eventUrl ? (
                   <a href={event.eventUrl} target="_blank" rel="noopener noreferrer" className="hover:underline">
                     {event.title}
                   </a>
-                ) : event.title}
+                ) : (
+                  event.title
+                )}
               </p>
 
               <div className="flex items-center gap-1 text-[10px] text-white/70">
@@ -234,7 +240,12 @@ function GridView({ events }: { events: Event[] }) {
                 <div className="flex items-center gap-1 text-[10px] text-white/70">
                   <MapPin className="h-2.5 w-2.5 shrink-0" />
                   {locationUrl ? (
-                    <a href={locationUrl} target="_blank" rel="noopener noreferrer" className="hover:underline truncate">
+                    <a
+                      href={locationUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hover:underline truncate"
+                    >
                       {locationText}
                     </a>
                   ) : (
@@ -297,7 +308,9 @@ function ListView({ events }: { events: Event[] }) {
                   <a href={event.eventUrl} target="_blank" rel="noopener noreferrer" className="hover:underline">
                     {event.title}
                   </a>
-                ) : event.title}
+                ) : (
+                  event.title
+                )}
               </p>
               {location && (
                 <p className="text-xs text-muted-foreground truncate">
@@ -306,7 +319,9 @@ function ListView({ events }: { events: Event[] }) {
                     <a href={event.host.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
                       {location}
                     </a>
-                  ) : location}
+                  ) : (
+                    location
+                  )}
                 </p>
               )}
             </div>
@@ -319,12 +334,22 @@ function ListView({ events }: { events: Event[] }) {
                 {event.status === "upcoming" ? "Upcoming" : "Past"}
               </Badge>
               {event.albumUrl && (
-                <a href={event.albumUrl} target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-foreground">
+                <a
+                  href={event.albumUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-muted-foreground hover:text-foreground"
+                >
                   <Camera className="h-3.5 w-3.5" />
                 </a>
               )}
               {event.youtubeUrl && (
-                <a href={event.youtubeUrl} target="_blank" rel="noopener noreferrer" className="text-muted-foreground hover:text-foreground">
+                <a
+                  href={event.youtubeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-muted-foreground hover:text-foreground"
+                >
                   <Play className="h-3.5 w-3.5" />
                 </a>
               )}

--- a/components/ui/event-card.tsx
+++ b/components/ui/event-card.tsx
@@ -42,21 +42,15 @@ export function EventCard({ event, variant = "compact" }: EventCardProps) {
       <div className="group relative overflow-hidden rounded-2xl glass">
         <div className="p-6">
           <div className="flex flex-wrap items-center gap-2 mb-3">
-            <Badge variant={isUpcoming ? "warning" : "secondary"}>
-              {isUpcoming ? "Upcoming" : "Past"}
-            </Badge>
-            {event.tags[0] && (
-              <span className="ml-auto text-xs text-muted-foreground">{event.tags[0]}</span>
-            )}
+            <Badge variant={isUpcoming ? "warning" : "secondary"}>{isUpcoming ? "Upcoming" : "Past"}</Badge>
+            {event.tags[0] && <span className="ml-auto text-xs text-muted-foreground">{event.tags[0]}</span>}
           </div>
 
           <h3 className="font-display text-xl font-bold text-foreground mb-2 line-clamp-2">
             <TitleWrapper>{event.title}</TitleWrapper>
           </h3>
 
-          {event.pitch && (
-            <p className="text-sm text-muted-foreground mb-3 line-clamp-2">{event.pitch}</p>
-          )}
+          {event.pitch && <p className="text-sm text-muted-foreground mb-3 line-clamp-2">{event.pitch}</p>}
 
           <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1.5">
             <Calendar className="h-4 w-4 shrink-0" />
@@ -99,7 +93,12 @@ export function EventCard({ event, variant = "compact" }: EventCardProps) {
               )}
               {event.youtubeUrl && (
                 <Badge variant="secondary" asChild>
-                  <a href={event.youtubeUrl} target="_blank" rel="noopener noreferrer" aria-label="Watch recap on YouTube">
+                  <a
+                    href={event.youtubeUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Watch recap on YouTube"
+                  >
                     <Play className="h-3 w-3 fill-current" />
                     Recap
                   </a>
@@ -118,9 +117,7 @@ export function EventCard({ event, variant = "compact" }: EventCardProps) {
         <Badge variant={isUpcoming ? "warning" : "secondary"} size="sm">
           {isUpcoming ? "Upcoming" : "Past"}
         </Badge>
-        {event.tags[0] && (
-          <span className="ml-auto text-[10px] text-muted-foreground">{event.tags[0]}</span>
-        )}
+        {event.tags[0] && <span className="ml-auto text-[10px] text-muted-foreground">{event.tags[0]}</span>}
       </div>
 
       <h3 className="font-display text-sm font-bold text-foreground mb-2 line-clamp-2">
@@ -148,7 +145,13 @@ export function EventCard({ event, variant = "compact" }: EventCardProps) {
       {event.sponsors && event.sponsors.length > 0 && (
         <div className="flex flex-wrap items-center gap-1 text-xs text-muted-foreground mb-2">
           {event.sponsors.map((s) => (
-            <a key={s.id} href={s.url} target="_blank" rel="noopener noreferrer" className="hover:underline line-clamp-1">
+            <a
+              key={s.id}
+              href={s.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline line-clamp-1"
+            >
               {s.name}
             </a>
           ))}

--- a/components/ui/fish-canvas.tsx
+++ b/components/ui/fish-canvas.tsx
@@ -1,5 +1,5 @@
-'use client';
-import { useEffect, useRef, useState } from 'react';
+"use client";
+import { useEffect, useRef, useState } from "react";
 
 interface Fish {
   x: number;
@@ -99,7 +99,7 @@ export default function FishCanvas() {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
     const dpr = window.devicePixelRatio || 1;
@@ -113,9 +113,7 @@ export default function FishCanvas() {
       canvas!.width = W * dpr;
       canvas!.height = H * dpr;
       ctx!.scale(dpr, dpr);
-      fishRef.current = Array.from({ length: FISH_COUNT }, (_, i) =>
-        makeFish(i, W, H)
-      );
+      fishRef.current = Array.from({ length: FISH_COUNT }, (_, i) => makeFish(i, W, H));
     }
 
     function loop(ts: number) {
@@ -129,8 +127,7 @@ export default function FishCanvas() {
         const dx = f.x - mouseRef.current.x;
         const dy = f.y - mouseRef.current.y;
         const d = Math.hypot(dx, dy);
-        f.targetOpacity =
-          d < REVEAL_RADIUS ? Math.pow(1 - d / REVEAL_RADIUS, 0.6) : 0;
+        f.targetOpacity = d < REVEAL_RADIUS ? Math.pow(1 - d / REVEAL_RADIUS, 0.6) : 0;
         f.opacity += (f.targetOpacity - f.opacity) * Math.min(dt * 6, 1);
         drawFish(ctx!, f, t);
       }
@@ -140,11 +137,11 @@ export default function FishCanvas() {
 
     resize();
     rafRef.current = requestAnimationFrame(loop);
-    window.addEventListener('resize', resize);
+    window.addEventListener("resize", resize);
 
     return () => {
       cancelAnimationFrame(rafRef.current);
-      window.removeEventListener('resize', resize);
+      window.removeEventListener("resize", resize);
     };
   }, []);
 
@@ -153,7 +150,7 @@ export default function FishCanvas() {
       mouseRef.current = { x: e.clientX, y: e.clientY };
       setCursorPos({ x: e.clientX, y: e.clientY });
     }
-    
+
     function handleTouchMove(e: TouchEvent) {
       if (e.touches.length > 0) {
         mouseRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
@@ -161,18 +158,16 @@ export default function FishCanvas() {
       }
     }
 
-    window.addEventListener('mousemove', handleMouseMove);
-    window.addEventListener('touchmove', handleTouchMove);
-    window.addEventListener('touchstart', handleTouchMove);
-    
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("touchmove", handleTouchMove);
+    window.addEventListener("touchstart", handleTouchMove);
+
     return () => {
-      window.removeEventListener('mousemove', handleMouseMove);
-      window.removeEventListener('touchmove', handleTouchMove);
-      window.removeEventListener('touchstart', handleTouchMove);
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("touchmove", handleTouchMove);
+      window.removeEventListener("touchstart", handleTouchMove);
     };
   }, []);
 
-  return (
-      <canvas ref={canvasRef} className="absolute inset-0 z-0 w-full h-full" />
-  );
+  return <canvas ref={canvasRef} className="absolute inset-0 z-0 w-full h-full" />;
 }

--- a/components/ui/marquee.tsx
+++ b/components/ui/marquee.tsx
@@ -34,16 +34,9 @@ export function Marquee({
         }
       >
         {Array.from({ length: copies }).map((_, copyIndex) => (
-          <div
-            key={copyIndex}
-            className="flex flex-none"
-            aria-hidden={copyIndex > 0 || undefined}
-          >
+          <div key={copyIndex} className="flex flex-none" aria-hidden={copyIndex > 0 || undefined}>
             {childArray.map((child, i) => (
-              <div
-                key={i}
-                className="marquee-item flex-none flex items-center justify-center px-8"
-              >
+              <div key={i} className="marquee-item flex-none flex items-center justify-center px-8">
                 {child}
               </div>
             ))}

--- a/components/ui/og-image.tsx
+++ b/components/ui/og-image.tsx
@@ -10,15 +10,11 @@ export const size = {
 const logoPath = join(process.cwd(), "public/images/logos/light.png");
 
 async function loadGoogleFont(font: string, text: string) {
-  const url = `https://fonts.googleapis.com/css2?family=${font}&text=${encodeURIComponent(
-    text,
-  )}`;
+  const url = `https://fonts.googleapis.com/css2?family=${font}&text=${encodeURIComponent(text)}`;
 
   const css = await fetch(url).then((res) => res.text());
 
-  const resource = css.match(
-    /src: url\((.+)\) format\('(opentype|truetype)'\)/,
-  );
+  const resource = css.match(/src: url\((.+)\) format\('(opentype|truetype)'\)/);
 
   if (!resource) {
     throw new Error("Failed to load font");
@@ -32,17 +28,13 @@ type CreateOGImageParams = {
   imageAlt?: string;
 };
 
-export async function createOGImage({
-  title,
-  imageAlt = "TechTank TO",
-}: CreateOGImageParams) {
+export async function createOGImage({ title, imageAlt = "TechTank TO" }: CreateOGImageParams) {
   const hasTitle = Boolean(title?.trim());
 
   const logo = await readFile(logoPath);
   const logoSrc = `data:image/png;base64,${logo.toString("base64")}`;
 
-  const font =
-    hasTitle && title ? await loadGoogleFont("Inter:wght@700", title) : null;
+  const font = hasTitle && title ? await loadGoogleFont("Inter:wght@700", title) : null;
 
   return new ImageResponse(
     <div

--- a/components/ui/role-card.tsx
+++ b/components/ui/role-card.tsx
@@ -44,14 +44,10 @@ export function RoleCard({
       </div>
 
       {/* Overline */}
-      <span className="text-xs font-semibold uppercase tracking-widest text-amber-dark mb-2">
-        {overline}
-      </span>
+      <span className="text-xs font-semibold uppercase tracking-widest text-amber-dark mb-2">{overline}</span>
 
       {/* Title */}
-      <h3 className="font-display text-xl font-bold text-foreground mb-3">
-        {title}
-      </h3>
+      <h3 className="font-display text-xl font-bold text-foreground mb-3">{title}</h3>
 
       {/* Description */}
       <p className="text-muted-foreground text-sm leading-relaxed mb-6">{description}</p>
@@ -89,11 +85,7 @@ export const roleCardsData: RoleCardProps[] = [
     title: "Attend an event",
     description:
       "The easiest way to start. All events are listed on our Luma calendar. Show up, meet people, see if it clicks.",
-    benefits: [
-      "No signup required",
-      "Meet the community in person",
-      "Keeps most events accessible",
-    ],
+    benefits: ["No signup required", "Meet the community in person", "Keeps most events accessible"],
     href: "/events",
     ctaText: "Browse upcoming events",
   },
@@ -103,11 +95,7 @@ export const roleCardsData: RoleCardProps[] = [
     title: "Speak or Facilitate",
     description:
       "Got something to share? We're always looking for speakers, panelists, and workshop facilitators. You don't need to be a senior engineer or a public figure.",
-    benefits: [
-      "30-45 min talk + Q&A",
-      "Any tech topic welcome",
-      "Recorded and published to YouTube",
-    ],
+    benefits: ["30-45 min talk + Q&A", "Any tech topic welcome", "Recorded and published to YouTube"],
     href: "/get-involved/speak-or-facilitate",
     ctaText: "Apply to speak",
   },
@@ -117,11 +105,7 @@ export const roleCardsData: RoleCardProps[] = [
     title: "Host an event",
     description:
       "If your company has space and wants to support community-driven tech programming in Toronto, we'd love to talk.",
-    benefits: [
-      "40-120 attendees",
-      "~6:00-8:30pm on weeknights",
-      "Logo on event marketing",
-    ],
+    benefits: ["40-120 attendees", "~6:00-8:30pm on weeknights", "Logo on event marketing"],
     href: "/get-involved/host",
     ctaText: "Host an event",
   },
@@ -131,11 +115,7 @@ export const roleCardsData: RoleCardProps[] = [
     title: "Sponsor TechTank",
     description:
       "If your company has budget or resources and wants to support community-driven tech programming in Toronto, we'd love to talk.",
-    benefits: [
-      "Logo on website and marketing",
-      "Speaker slot options",
-      "Reach Toronto tech talent",
-    ],
+    benefits: ["Logo on website and marketing", "Speaker slot options", "Reach Toronto tech talent"],
     href: "/get-involved/sponsor",
     ctaText: "Sponsor TechTank",
   },
@@ -145,11 +125,7 @@ export const roleCardsData: RoleCardProps[] = [
     title: "Join the Organizer Team",
     description:
       "We're building out a more structured volunteer leadership team with defined roles and a 6-month commitment. If you want to help shape what TechTank becomes, this is the path.",
-    benefits: [
-      "Defined leadership roles",
-      "6-month commitment",
-      "Shape TechTank's direction",
-    ],
+    benefits: ["Defined leadership roles", "6-month commitment", "Shape TechTank's direction"],
     href: "/get-involved/organizer",
     ctaText: "Express interest in organizing",
   },

--- a/components/ui/section.tsx
+++ b/components/ui/section.tsx
@@ -50,13 +50,7 @@ interface SectionHeaderProps extends VariantProps<typeof sectionHeaderVariants> 
   className?: string;
 }
 
-export function SectionHeader({
-  overline,
-  title,
-  description,
-  align,
-  className,
-}: SectionHeaderProps) {
+export function SectionHeader({ overline, title, description, align, className }: SectionHeaderProps) {
   return (
     <div className={cn(sectionHeaderVariants({ align }), className)}>
       {overline && (
@@ -64,12 +58,8 @@ export function SectionHeader({
           {overline}
         </span>
       )}
-      <h2 className="font-display text-2xl font-bold text-foreground lg:text-3xl text-balance">
-        {title}
-      </h2>
-      {description && (
-        <p className="mt-3 text-base text-muted-foreground leading-relaxed">{description}</p>
-      )}
+      <h2 className="font-display text-2xl font-bold text-foreground lg:text-3xl text-balance">{title}</h2>
+      {description && <p className="mt-3 text-base text-muted-foreground leading-relaxed">{description}</p>}
     </div>
   );
 }

--- a/components/ui/social-feed.tsx
+++ b/components/ui/social-feed.tsx
@@ -32,7 +32,7 @@ function InstagramPostCard({ post }: { post: InstagramPostWithId }) {
   const video = getCoverVideo(post);
   const postUrl = post.shortcode
     ? `https://instagram.com/p/${post.shortcode}`
-    : instagramUrl ?? "https://instagram.com/techtankto";
+    : (instagramUrl ?? "https://instagram.com/techtankto");
 
   return (
     <article className="group relative glass rounded-2xl overflow-hidden transition-all flex flex-col">
@@ -48,7 +48,7 @@ function InstagramPostCard({ post }: { post: InstagramPostWithId }) {
               preload="auto"
               className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
             >
-              <source src={video.replace(/\.mp4$/, '.webm')} type="video/webm" />
+              <source src={video.replace(/\.mp4$/, ".webm")} type="video/webm" />
               <source src={video} type="video/mp4" />
             </video>
           ) : cover ? (
@@ -61,9 +61,7 @@ function InstagramPostCard({ post }: { post: InstagramPostWithId }) {
             />
           ) : null}
           {post.featured && (
-            <span className="absolute top-3 left-3 tag bg-warning text-warning-foreground text-xs">
-              Featured
-            </span>
+            <span className="absolute top-3 left-3 tag bg-warning text-warning-foreground text-xs">Featured</span>
           )}
         </div>
       )}
@@ -72,9 +70,7 @@ function InstagramPostCard({ post }: { post: InstagramPostWithId }) {
           <span className="text-[#E4405F]">
             <InstagramIcon className="h-5 w-5" />
           </span>
-          <span className="text-xs text-muted-foreground uppercase tracking-wide font-medium shrink-0">
-            Instagram
-          </span>
+          <span className="text-xs text-muted-foreground uppercase tracking-wide font-medium shrink-0">Instagram</span>
           <span className="text-xs text-muted-foreground/50 shrink-0">·</span>
           <span className="text-xs text-muted-foreground min-w-[8.5em] shrink-0">
             {formatDate(post.date, post.createdAtRaw)}
@@ -114,14 +110,9 @@ export function SocialFeed() {
         {getAllSocialLinks()
           .filter((link) => ["slack", "linkedin", "instagram"].includes(link.id))
           .map((link) => (
-            <Button
-              key={link.id}
-              variant={link.type === "primary" ? "primary" : "outline"}
-              size="sm"
-              asChild
-            >
+            <Button key={link.id} variant={link.type === "primary" ? "primary" : "outline"} size="sm" asChild>
               <a
-                href={link.id === "instagram" ? instagramUrl ?? link.url : link.url}
+                href={link.id === "instagram" ? (instagramUrl ?? link.url) : link.url}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/components/ui/sponsors-marquee.tsx
+++ b/components/ui/sponsors-marquee.tsx
@@ -22,7 +22,11 @@ export function SponsorsMarquee({ className }: { className?: string }) {
             width={120}
             height={40}
             className="w-auto h-full object-contain opacity-70 hover:opacity-100 transition-all duration-300 dark:brightness-0 dark:invert"
-            style={{ width: "auto", height: "100%", ...(sponsor.scale ? { transform: `scale(${sponsor.scale})` } : {}) }}
+            style={{
+              width: "auto",
+              height: "100%",
+              ...(sponsor.scale ? { transform: `scale(${sponsor.scale})` } : {}),
+            }}
           />
         </a>
       ))}

--- a/components/ui/stats-marquee.tsx
+++ b/components/ui/stats-marquee.tsx
@@ -13,12 +13,8 @@ export function StatsMarquee({ className }: { className?: string }) {
     <Marquee duration="25s" itemWidth="300px" copies={5} className={className}>
       {items.map((item) => (
         <div key={item.label} className="flex flex-col items-center text-center">
-          <span className="font-display text-xl lg:text-2xl font-bold text-foreground">
-            {item.value}
-          </span>
-          <span className="text-xs text-foreground/60 whitespace-nowrap">
-            {item.label}
-          </span>
+          <span className="font-display text-xl lg:text-2xl font-bold text-foreground">{item.value}</span>
+          <span className="text-xs text-foreground/60 whitespace-nowrap">{item.label}</span>
         </div>
       ))}
     </Marquee>

--- a/components/ui/team-avatar.tsx
+++ b/components/ui/team-avatar.tsx
@@ -52,7 +52,7 @@ export function TeamAvatar({ name, avatar, size = "md", className }: TeamAvatarP
           s.box,
           s.ring && `ring ${p.ring}`,
           s.ring,
-          className
+          className,
         )}
       >
         <Image
@@ -74,7 +74,7 @@ export function TeamAvatar({ name, avatar, size = "md", className }: TeamAvatarP
         s.ring && `ring ${p.ring}`,
         s.ring,
         p.bg,
-        className
+        className,
       )}
     >
       <span className={cn("font-display font-bold", s.text, p.text)}>{initials(name)}</span>

--- a/components/ui/team-card.tsx
+++ b/components/ui/team-card.tsx
@@ -51,9 +51,7 @@ function CoreBody({ name, pronouns, role, bio }: TeamMember) {
     <div className="min-w-0 flex-1">
       <p className="font-display text-lg font-semibold text-foreground leading-tight">{name}</p>
       <p className="text-xs text-muted-foreground mt-0.5">{pronouns}</p>
-      {role && (
-        <p className="mt-1 text-xs font-semibold text-ring uppercase tracking-wide">{role}</p>
-      )}
+      {role && <p className="mt-1 text-xs font-semibold text-ring uppercase tracking-wide">{role}</p>}
       {bio ? (
         <p className="mt-4 text-sm text-muted-foreground leading-relaxed line-clamp-2">{bio}</p>
       ) : (
@@ -93,11 +91,7 @@ export function TeamCard({ member, variant = "core", className }: TeamCardProps)
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className={cn(teamCardVariants({ variant }), className)}
-      >
+      <button type="button" onClick={() => setOpen(true)} className={cn(teamCardVariants({ variant }), className)}>
         {variant === "board" && (
           <>
             <div className="pointer-events-none absolute -top-8 -right-8 h-40 w-40 rounded-full bg-white/10 dark:bg-white/5" />

--- a/components/ui/team-profile-hint.tsx
+++ b/components/ui/team-profile-hint.tsx
@@ -1,7 +1,5 @@
 export function TeamProfileHint() {
   return (
-    <p className="mt-3 text-xs font-semibold text-ring group-hover:text-ring/80 transition-colors">
-      View profile →
-    </p>
+    <p className="mt-3 text-xs font-semibold text-ring group-hover:text-ring/80 transition-colors">View profile →</p>
   );
 }

--- a/components/ui/theme-provider.tsx
+++ b/components/ui/theme-provider.tsx
@@ -2,9 +2,6 @@
 
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 
-export function ThemeProvider({
-  children,
-  ...props
-}: React.ComponentProps<typeof NextThemesProvider>) {
+export function ThemeProvider({ children, ...props }: React.ComponentProps<typeof NextThemesProvider>) {
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
 }

--- a/constants/events.ts
+++ b/constants/events.ts
@@ -20,7 +20,7 @@ export const events: Event[] = [
     pitch: "Welcoming coffee meetup for women and gender-diverse folks in tech",
     start_at: "2026-05-02T11:00:00",
     venue: "Prema Coffee and Bar",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://lu.ma/3ea6eq1s",
     imagePath: "/images/luma/bca86cee-3fdb-403a-bb09-ccc095690401.jpeg",
@@ -35,7 +35,8 @@ export const events: Event[] = [
     status: "past",
     eventUrl: "https://lu.ma/qwpt54ke",
     imagePath: "/images/luma/024f2a7f-8df2-47c2-b24d-a7c48aeab793.jpeg",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipM-VmIz5kOG18HrCZIcQyfVLgKKsCQSS_SWIo2ODM5DME1Z7BEoQOoMD5JbBujfkA?key=WVVLWkFVXzNsYkpTNkN4MU5uYUNRNEpDQVZuVzJ3",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipM-VmIz5kOG18HrCZIcQyfVLgKKsCQSS_SWIo2ODM5DME1Z7BEoQOoMD5JbBujfkA?key=WVVLWkFVXzNsYkpTNkN4MU5uYUNRNEpDQVZuVzJ3",
   },
   {
     id: "ci-optimization-brainstation",
@@ -48,7 +49,8 @@ export const events: Event[] = [
     eventUrl: "https://lu.ma/7h4g008b",
     imagePath: "/images/luma/5d9909f0-ece1-4b30-bdde-b4af7ec8b4da.jpeg",
     sponsors: [sponsors.brainstation],
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipN3f4J0Ya2sv76VCQXhdkKipehavLCc3v4kcdfwqqosjY2jN-KWfT3X4wrqCiRy4w?key=WEF6OUk3alhLb3dzOEJ5SWlsU2tVM2x1eDkxNUpn",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipN3f4J0Ya2sv76VCQXhdkKipehavLCc3v4kcdfwqqosjY2jN-KWfT3X4wrqCiRy4w?key=WEF6OUk3alhLb3dzOEJ5SWlsU2tVM2x1eDkxNUpn",
     speakers: [
       {
         name: "Emily Xiong",
@@ -64,7 +66,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2026-04-11T11:00:00",
     venue: "Prema Coffee and Bar",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://lu.ma/cye39lls",
     imagePath: "/images/luma/bca86cee-3fdb-403a-bb09-ccc095690401.jpeg",
@@ -86,7 +88,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2026-01-17T11:00:00",
     venue: "Prema Coffee and Bar",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://lu.ma/mbafwfgu",
     imagePath: "/images/luma/799c848f-b71f-4d62-99a1-a93afcf4089c.jpeg",
@@ -98,7 +100,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2025-12-20T11:00:00",
     venue: "Prema Coffee and Bar",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://lu.ma/q3w5yoeb",
     imagePath: "/images/luma/b7019fa7-2bd2-4607-b69a-f2ad33cbc09c.jpeg",
@@ -120,7 +122,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2025-11-15T11:00:00",
     venue: "Prema Coffee and Bar",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://lu.ma/bafv7trd",
     imagePath: "/images/luma/b7019fa7-2bd2-4607-b69a-f2ad33cbc09c.jpeg",
@@ -131,7 +133,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2025-10-18T11:00:00",
     venue: "Prema Coffee and Bar",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://www.meetup.com/techtank-to/events/308164572/",
     imagePath: "/images/meetup/highres_524928803.jpeg",
@@ -146,7 +148,8 @@ export const events: Event[] = [
     status: "past",
     eventUrl: "https://lu.ma/u2mzq5bn",
     imagePath: "/images/luma/71320253-f6a1-441e-95d5-4217915cd1db.jpeg",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipPPmVC7Jg5of2zIp8CgLxyavCSvyu-3ekKf_nEVwqqNA3lX4VBuVijVBSvZ62dNng?key=ZmtQTTRtUWYzejJwaXV5Wi1rOHl1TmxhTVNJYmRR",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipPPmVC7Jg5of2zIp8CgLxyavCSvyu-3ekKf_nEVwqqNA3lX4VBuVijVBSvZ62dNng?key=ZmtQTTRtUWYzejJwaXV5Wi1rOHl1TmxhTVNJYmRR",
   },
   {
     id: "agentic-programming-7shifts",
@@ -158,7 +161,8 @@ export const events: Event[] = [
     eventUrl: "https://lu.ma/s6f56qtz",
     imagePath: "/images/luma/f75dc08b-1fe1-4bb4-acd0-7dce871d028e.jpeg",
     host: sponsors["7shifts"],
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipNHIuIQ3GEwyuE7hRn3rrREKk2jRULCv3DkSatNFoAVgNYpQrzOd3VHmpsbT5L15w?key=UVFQal9MbTNiVmZhUnlOQVZ0U05iR3BfRlJxdFh3",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipNHIuIQ3GEwyuE7hRn3rrREKk2jRULCv3DkSatNFoAVgNYpQrzOd3VHmpsbT5L15w?key=UVFQal9MbTNiVmZhUnlOQVZ0U05iR3BfRlJxdFh3",
   },
   {
     id: "mentorship-meetup-2025",
@@ -177,7 +181,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2025-09-06T11:00:00",
     venue: "Prema Coffee and Bar",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://www.meetup.com/techtank-to/events/308163824/",
     imagePath: "/images/meetup/highres_528812977.jpeg",
@@ -198,7 +202,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2025-08-02T11:00:00",
     venue: "Prema Coffee and Bar",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://www.meetup.com/techtank-to/events/308163788/",
     imagePath: "/images/meetup/highres_524928803.jpeg",
@@ -210,7 +214,8 @@ export const events: Event[] = [
     start_at: "2025-06-21T12:00:00",
     tags: ["Sports", "Social"],
     status: "past",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipMpnt5xDbFhqPFjq-d3e6NNoGiRUMTXxxbCQ-jTbOPnEE1tx6RMZEDt6s0ILEOetA?key=M1BBanJKUDdQWWdJMW41aFJoMUExakRwTzhrQWlB",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipMpnt5xDbFhqPFjq-d3e6NNoGiRUMTXxxbCQ-jTbOPnEE1tx6RMZEDt6s0ILEOetA?key=M1BBanJKUDdQWWdJMW41aFJoMUExakRwTzhrQWlB",
   },
   {
     id: "supercollider-techweek-2025",
@@ -233,7 +238,8 @@ export const events: Event[] = [
     eventUrl: "https://lu.ma/mbmwbu15",
     imagePath: "/images/luma/c9166e5b-8fd8-453a-abb8-a9d8cbe1cc0d.jpeg",
     host: sponsors["7shifts"],
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipMingUvuBFdNA4ES6wYi3UCHzRT3k9Il3wlWnFoUu_-5X8jztaoTjtAloU7TLIMJg?key=LXo2S0U1LXE2RmpJMk1HQXhfb0NISG1ncE1md1VR",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipMingUvuBFdNA4ES6wYi3UCHzRT3k9Il3wlWnFoUu_-5X8jztaoTjtAloU7TLIMJg?key=LXo2S0U1LXE2RmpJMk1HQXhfb0NISG1ncE1md1VR",
   },
   {
     id: "code-diversity-coffee-2025-05",
@@ -241,7 +247,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2025-05-24T11:00:00",
     venue: "Prema Coffee and Bar",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://www.meetup.com/techtank-to/events/307465132/",
     imagePath: "/images/meetup/highres_527561328.jpeg",
@@ -256,7 +262,8 @@ export const events: Event[] = [
     status: "past",
     eventUrl: "https://lu.ma/ekdq0p25",
     imagePath: "/images/luma/f6eb44a9-e019-40cf-b3b7-87eeea4cc5a5.jpeg",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipNsmSeqY9wxLMtqnFkDoPaj4X5T-cmuUkYkVHYHPUopyT4-b_IYhiPajDguMT-CSQ?key=NGlBeXM1bERMeDVKeGNXR2NZOWN5WG9PakZackRR",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipNsmSeqY9wxLMtqnFkDoPaj4X5T-cmuUkYkVHYHPUopyT4-b_IYhiPajDguMT-CSQ?key=NGlBeXM1bERMeDVKeGNXR2NZOWN5WG9PakZackRR",
   },
   {
     id: "code-diversity-coffee-2025-04",
@@ -264,7 +271,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2025-04-26T11:00:00",
     venue: "Prema Coffee and Bar",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://www.meetup.com/techtank-to/events/306889689/",
     imagePath: "/images/meetup/highres_524928803.jpeg",
@@ -286,7 +293,8 @@ export const events: Event[] = [
       { name: "Lucas Tran", title: "Senior Software Developer", talkTitle: "Lessons from the Trenches" },
     ],
     youtubeUrl: "https://www.youtube.com/watch?v=4MSJq2GBsIc",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipOb1lKTP_ktVaptdlB6GndudP3YQ77pW6BR3IxcDA2YV86ZNaHZe3M0Hp2iD6UoLA?key=SGxsS0xFRVRNZGdFVGJVQ1ZXN1ZtODBrZDNrNzRR",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipOb1lKTP_ktVaptdlB6GndudP3YQ77pW6BR3IxcDA2YV86ZNaHZe3M0Hp2iD6UoLA?key=SGxsS0xFRVRNZGdFVGJVQ1ZXN1ZtODBrZDNrNzRR",
   },
   {
     id: "code-diversity-coffee-2025-03",
@@ -294,7 +302,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2025-03-15T11:00:00",
     venue: "Prema Coffee and Bar",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://www.meetup.com/techtank-to/events/306586846/",
     imagePath: "/images/meetup/highres_524928803.jpeg",
@@ -305,7 +313,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2025-02-15T11:00:00",
     venue: "Carbonic Coffee",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://www.meetup.com/techtank-to/events/305857202/",
     imagePath: "/images/meetup/highres_524928803.jpeg",
@@ -321,7 +329,8 @@ export const events: Event[] = [
     imagePath: "/images/meetup/highres_525722753.jpeg",
     host: sponsors.cohere,
     youtubeUrl: "https://www.youtube.com/watch?v=f8ONw6O_rco",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipMrTfiNbI7_NSGioh-DLR6Slvp51pBjf1cShVzeToyKNr982BbkOEPmrqFYhd7vMg?key=VUp4V1ZGNzFibHBpRUNESkZYQ3BhVElob1RsdmdB",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipMrTfiNbI7_NSGioh-DLR6Slvp51pBjf1cShVzeToyKNr982BbkOEPmrqFYhd7vMg?key=VUp4V1ZGNzFibHBpRUNESkZYQ3BhVElob1RsdmdB",
   },
   {
     id: "code-diversity-coffee-2025-01",
@@ -329,7 +338,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2025-01-11T11:00:00",
     venue: "Carbonic Coffee",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://www.meetup.com/techtank-to/events/305395398/",
     imagePath: "/images/meetup/highres_524928803.jpeg",
@@ -345,7 +354,8 @@ export const events: Event[] = [
     status: "past",
     eventUrl: "https://lu.ma/eqp4ccn5",
     imagePath: "/images/luma/2671403b-57d3-4af9-b22d-2b3879c7b4dc.jpeg",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipNaxy4wPaRA3EwJOduVBxlFXvGGqBsDmYRoAFw7_ChOrWGOjRo8Kk1TKYA5tiaE6g?key=ZHVrQjhicDk2c0w3dG9tQVc1MlRGMmV4cTRUc1d3",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipNaxy4wPaRA3EwJOduVBxlFXvGGqBsDmYRoAFw7_ChOrWGOjRo8Kk1TKYA5tiaE6g?key=ZHVrQjhicDk2c0w3dG9tQVc1MlRGMmV4cTRUc1d3",
   },
   {
     id: "code-diversity-coffee-2024-12",
@@ -353,7 +363,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2024-12-14T11:00:00",
     venue: "Carbonic Coffee",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://www.meetup.com/techtank-to/events/304806485/",
     imagePath: "/images/meetup/highres_524928803.jpeg",
@@ -368,7 +378,8 @@ export const events: Event[] = [
     status: "past",
     eventUrl: "https://lu.ma/8qe5mdb7",
     imagePath: "/images/luma/7445101b-ae32-40a1-b19a-c8f36ad2529a.jpeg",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipOXFVlljbwPWfZ2MVv5rhWpTIaWzLb6Jdfp9aqRvtYP241OIvn3cbVMN-qooI1Fmg?key=ZkY0eVZvQXNpQXRZYUVCRTk1ZFEybnpZejJSRFlR",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipOXFVlljbwPWfZ2MVv5rhWpTIaWzLb6Jdfp9aqRvtYP241OIvn3cbVMN-qooI1Fmg?key=ZkY0eVZvQXNpQXRZYUVCRTk1ZFEybnpZejJSRFlR",
   },
   {
     id: "code-diversity-coffee-2024-11",
@@ -376,7 +387,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2024-11-16T11:00:00",
     venue: "Carbonic Coffee",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://www.meetup.com/techtank-to/events/304348630/",
     imagePath: "/images/meetup/highres_524471440.jpeg",
@@ -392,7 +403,8 @@ export const events: Event[] = [
     eventUrl: "https://www.meetup.com/techtank-to/events/304263016/",
     imagePath: "/images/meetup/highres_524451822.jpeg",
     youtubeUrl: "https://www.youtube.com/watch?v=2UTsy-Lbulk",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipMfuV2mdrwgETwmivv4zQUu8pSRAzOG0D9J6j4nCpnNDKPMAgWL5ru6sYqMaMOOQg?key=OGJrMmFMR2NGT1IzaGxqTVFIRjVlaVJJbXNSaGd3",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipMfuV2mdrwgETwmivv4zQUu8pSRAzOG0D9J6j4nCpnNDKPMAgWL5ru6sYqMaMOOQg?key=OGJrMmFMR2NGT1IzaGxqTVFIRjVlaVJJbXNSaGd3",
   },
   {
     id: "edtech-ai-accessibility",
@@ -405,7 +417,8 @@ export const events: Event[] = [
     eventUrl: "https://www.meetup.com/techtank-to/events/303655206/",
     imagePath: "/images/meetup/highres_523810554.jpeg",
     youtubeUrl: "https://www.youtube.com/watch?v=N50r7eIEIS0",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipMwzeGDJqNkRSSagw_D8v3F73XeaPR9kmpQcpYjHCCuMx7nZ94feDaTGMA55whrLg?key=QzdzTnpRdHpiaHNaOE0zNnVIUE5EQlMxM0kxYzFR",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipMwzeGDJqNkRSSagw_D8v3F73XeaPR9kmpQcpYjHCCuMx7nZ94feDaTGMA55whrLg?key=QzdzTnpRdHpiaHNaOE0zNnVIUE5EQlMxM0kxYzFR",
   },
   {
     id: "cypress-overwhelmed-dev",
@@ -430,7 +443,8 @@ export const events: Event[] = [
     eventUrl: "https://www.meetup.com/techtank-to/events/302940980/",
     imagePath: "/images/meetup/highres_523034935.jpeg",
     youtubeUrl: "https://www.youtube.com/watch?v=NOlSKs5PLpM",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipMPoK9UuL4g8MKPP8Tk8tI2FTppYtQQ-Nf0ga6DZXjFmqXT5SHTYikca8rhmltqhg?key=djduZGhZaHpJTi04SEZ2SVg3NUo0ZTRqcUlVY0Rn",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipMPoK9UuL4g8MKPP8Tk8tI2FTppYtQQ-Nf0ga6DZXjFmqXT5SHTYikca8rhmltqhg?key=djduZGhZaHpJTi04SEZ2SVg3NUo0ZTRqcUlVY0Rn",
   },
   {
     id: "code-diversity-coffee-2024-09",
@@ -438,7 +452,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2024-09-14T11:00:00",
     venue: "Carbonic Coffee",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://www.meetup.com/techtank-to/events/303330348/",
     imagePath: "/images/meetup/highres_521950379.jpeg",
@@ -464,7 +478,8 @@ export const events: Event[] = [
     status: "past",
     eventUrl: "https://lu.ma/jkr3i7pz",
     imagePath: "/images/luma/f26d4d6d-417f-4d0e-a901-c0094391be56.jpeg",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipMgtyV8CNEuz-qajiP1CHJXhOThudbAQwu8JRpN_OSpPnjsb1H8PBPNI1old3yukQ?key=TVZaMExWQnVWQ1RvRlFFVGdQVGZCV3BXQ3k0ZlF3",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipMgtyV8CNEuz-qajiP1CHJXhOThudbAQwu8JRpN_OSpPnjsb1H8PBPNI1old3yukQ?key=TVZaMExWQnVWQ1RvRlFFVGdQVGZCV3BXQ3k0ZlF3",
   },
   {
     id: "ai-insights-experts",
@@ -477,7 +492,8 @@ export const events: Event[] = [
     eventUrl: "https://www.meetup.com/techtank-to/events/302337555/",
     imagePath: "/images/meetup/highres_522500582.jpeg",
     youtubeUrl: "https://www.youtube.com/watch?v=RUco7XrbMqk",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipMlGtrOSia0VXZaDqAcjItENfxwXFdxJO2A9QCKGwXcRPn46nY5e_DB9puMgfky9Q?key=eWNXOGh0SEZqcDdRaDVwRHVEWEF5SjBfRkRvTzFn",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipMlGtrOSia0VXZaDqAcjItENfxwXFdxJO2A9QCKGwXcRPn46nY5e_DB9puMgfky9Q?key=eWNXOGh0SEZqcDdRaDVwRHVEWEF5SjBfRkRvTzFn",
   },
   {
     id: "code-diversity-coffee-2024-08",
@@ -485,7 +501,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2024-08-10T11:00:00",
     venue: "Carbonic Coffee",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://www.meetup.com/techtank-to/events/302503778/",
     imagePath: "/images/meetup/highres_521950379.jpeg",
@@ -499,7 +515,8 @@ export const events: Event[] = [
     status: "past",
     eventUrl: "https://lu.ma/cidoy6p6",
     imagePath: "/images/luma/1dc01730-5cbd-466a-8f80-ef9e420a29bb.jpeg",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipNm1fut4HKxSRTpQ-6RkNQDkXsrzHhYfCaQwkoZAOWpw6b64L3iLU1yA3MHl_r8aQ?key=M2pWYXcySC1pazV4dzdxX2hIMFc5RnN6SHA3Q1d3",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipNm1fut4HKxSRTpQ-6RkNQDkXsrzHhYfCaQwkoZAOWpw6b64L3iLU1yA3MHl_r8aQ?key=M2pWYXcySC1pazV4dzdxX2hIMFc5RnN6SHA3Q1d3",
   },
   {
     id: "tankolympics",
@@ -510,7 +527,8 @@ export const events: Event[] = [
     status: "past",
     eventUrl: "https://lu.ma/55hizq8f",
     imagePath: "/images/luma/b6c5f6a3-1f3a-4ebd-9d29-075b9d6d74dc.jpeg",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipMaV0hBrR-eYX20MmtDBemZSZGUE3Y_kvO0JF9Cfm4crS27KpoU9tuY2u1aGNXWAA?key=OHk5TlJRNklhVTFXMzNGYTZ5Y09qOTN5ejM0RWtn",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipMaV0hBrR-eYX20MmtDBemZSZGUE3Y_kvO0JF9Cfm4crS27KpoU9tuY2u1aGNXWAA?key=OHk5TlJRNklhVTFXMzNGYTZ5Y09qOTN5ejM0RWtn",
   },
   {
     id: "mini-webpack-scratch",
@@ -523,7 +541,8 @@ export const events: Event[] = [
     eventUrl: "https://www.meetup.com/techtank-to/events/301699806/",
     imagePath: "/images/meetup/highres_521809945.jpeg",
     youtubeUrl: "https://www.youtube.com/watch?v=iIjdAXX-oD4",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipNyu6nkeQkkImW1usVfuDT6nr64NVj_WG5P6geHbZlDnLnKbZFP0kMGkovhsji1oA?key=R292TkpacE9ybHVMNTlfdVhvRHYtVGJEbFlZa0xn",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipNyu6nkeQkkImW1usVfuDT6nr64NVj_WG5P6geHbZlDnLnKbZFP0kMGkovhsji1oA?key=R292TkpacE9ybHVMNTlfdVhvRHYtVGJEbFlZa0xn",
   },
   {
     id: "softball-sashimis-2024",
@@ -532,7 +551,8 @@ export const events: Event[] = [
     start_at: "2024-07-13T12:00:00",
     tags: ["Sports", "Social"],
     status: "past",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipMmBy4aNt0rNAsHwMagst6jvo93awXW5yyWd4yCw9g5u0vdHpN7BRRHedJ8ofNEpQ?key=TXRZZ2FCazlCSFROZmdmQ1cwYXMwbmxYXy1ldmln",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipMmBy4aNt0rNAsHwMagst6jvo93awXW5yyWd4yCw9g5u0vdHpN7BRRHedJ8ofNEpQ?key=TXRZZ2FCazlCSFROZmdmQ1cwYXMwbmxYXy1ldmln",
   },
   {
     id: "code-diversity-coffee-2024-07",
@@ -540,7 +560,7 @@ export const events: Event[] = [
     pitch: "Monthly coffee chat for women and gender-diverse folks in tech",
     start_at: "2024-07-13T11:00:00",
     venue: "Carbonic Coffee",
-    tags: ["Coffee Chat", "CodeDiversity", "Social",],
+    tags: ["Coffee Chat", "CodeDiversity", "Social"],
     status: "past",
     eventUrl: "https://www.meetup.com/techtank-to/events/301852269/",
     imagePath: "/images/meetup/highres_521950379.jpeg",
@@ -552,7 +572,8 @@ export const events: Event[] = [
     start_at: "2024-06-15T12:00:00",
     tags: ["Social", "Charity"],
     status: "past",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipNM9FBTNWpRR8DWT99MItot1HtgKiLEccHtwjYZIXBqPyQa8s4-ATrTlPNbCjf1gA?key=WGhjeENGV3VlZ1NpV3lQWjV6bE9OXzJ6b2lEaWN3",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipNM9FBTNWpRR8DWT99MItot1HtgKiLEccHtwjYZIXBqPyQa8s4-ATrTlPNbCjf1gA?key=WGhjeENGV3VlZ1NpV3lQWjV6bE9OXzJ6b2lEaWN3",
   },
   {
     id: "networking-101-2024",
@@ -577,7 +598,8 @@ export const events: Event[] = [
     eventUrl: "https://www.meetup.com/techtank-to/events/300591167/",
     imagePath: "/images/meetup/highres_520941912.jpeg",
     youtubeUrl: "https://www.youtube.com/watch?v=tMoqGyfVkGA",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipMllK8NZdIjH0tP8lf0fw7JoQzXgse-6qCsWP2Kvh1lKWdGAiz_a1eeocYuoAntrA?key=cUphRG83Mzg1X0pSVzY2OTJfNTZ5Wlota20tY0pn",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipMllK8NZdIjH0tP8lf0fw7JoQzXgse-6qCsWP2Kvh1lKWdGAiz_a1eeocYuoAntrA?key=cUphRG83Mzg1X0pSVzY2OTJfNTZ5Wlota20tY0pn",
   },
   {
     id: "ai-prompting-101",
@@ -598,7 +620,8 @@ export const events: Event[] = [
     start_at: "2024-04-20T12:00:00",
     tags: ["Anniversary", "Social"],
     status: "past",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipN5YllsNHTVeUJKlSnd8bD4jyTo6muTTiMdHifF3DhT0olsYLxMbHynTtJ8jHJ7Uw?key=a1NmcTQ1VUpwWVB1OXNpb0tzeVRhN2hmM1NqcEFR",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipN5YllsNHTVeUJKlSnd8bD4jyTo6muTTiMdHifF3DhT0olsYLxMbHynTtJ8jHJ7Uw?key=a1NmcTQ1VUpwWVB1OXNpb0tzeVRhN2hmM1NqcEFR",
   },
   {
     id: "epic-quest-javascript",
@@ -611,7 +634,8 @@ export const events: Event[] = [
     eventUrl: "https://www.meetup.com/techtank-to/events/300175753/",
     imagePath: "/images/meetup/highres_520152027.jpeg",
     youtubeUrl: "https://www.youtube.com/watch?v=Q5DvWKxpaBE",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipNLPqEiBg7_95ZuKAxeC9GxdOVSUf3RmG8a5Hr5LWmBP8jRnPDGXNlBqkA4Sf2aXQ?key=UUltWXp4ODRJcDFYaXhOLXVrUE1GcGozZ0c0SFFR",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipNLPqEiBg7_95ZuKAxeC9GxdOVSUf3RmG8a5Hr5LWmBP8jRnPDGXNlBqkA4Sf2aXQ?key=UUltWXp4ODRJcDFYaXhOLXVrUE1GcGozZ0c0SFFR",
   },
   {
     id: "track-field-2024",
@@ -635,7 +659,8 @@ export const events: Event[] = [
     imagePath: "/images/meetup/highres_519276676.jpeg",
     host: sponsors.cohere,
     youtubeUrl: "https://www.youtube.com/watch?v=nRoKA93lJqY",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipOn_EKK627wNTlgtoEjoRR-RIYqwDMZfV8cdxNx5-MAXTT_pvwWZAU3Jd8fgsZ2Lg?key=eG9aR1A1NzhQa01MN09TSGFGUkxnaldjcTJ2WHhR",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipOn_EKK627wNTlgtoEjoRR-RIYqwDMZfV8cdxNx5-MAXTT_pvwWZAU3Jd8fgsZ2Lg?key=eG9aR1A1NzhQa01MN09TSGFGUkxnaldjcTJ2WHhR",
   },
   {
     id: "accessible-nav-menus",
@@ -714,7 +739,8 @@ export const events: Event[] = [
     start_at: "2024-02-17T12:00:00",
     tags: ["Social", "Trip"],
     status: "past",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipOdL17zISJwXuA-sOQpNz71wSZ5plWDiQ112VjuKLxMFMX3hLObJUJ6v5J_c-asHA?key=U3BrY3NOVnk3eHBLRUJYMHFDNnBVMmJ0eFpTbm9B",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipOdL17zISJwXuA-sOQpNz71wSZ5plWDiQ112VjuKLxMFMX3hLObJUJ6v5J_c-asHA?key=U3BrY3NOVnk3eHBLRUJYMHFDNnBVMmJ0eFpTbm9B",
   },
   {
     id: "burnout-in-tech",
@@ -748,7 +774,8 @@ export const events: Event[] = [
     start_at: "2023-12-14T12:00:00",
     tags: ["Social", "Holiday"],
     status: "past",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipNJCcEC8dFz06_EsD32Tpot7evg7OY9ke9lb3Qs8itCUKgczd9V3iTdaKXVPb5qTw?key=S1RNYjVFRjZyRXRVQzFBR3lGVk1KRFJPOUlIQjJn",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipNJCcEC8dFz06_EsD32Tpot7evg7OY9ke9lb3Qs8itCUKgczd9V3iTdaKXVPb5qTw?key=S1RNYjVFRjZyRXRVQzFBR3lGVk1KRFJPOUlIQjJn",
   },
   {
     id: "skating-2023",
@@ -784,7 +811,8 @@ export const events: Event[] = [
     eventUrl: "https://www.meetup.com/techtank-to/events/297145894/",
     imagePath: "/images/meetup/highres_517035730.jpeg",
     youtubeUrl: "https://www.youtube.com/watch?v=Q89KAMThfCw",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipN7795hAt6xtwWmIIPlBoijkf8svVZFKd4v7vTrDfhJdYe0u5DAn8wSlT4bNKgHig?key=Q1o4MzdZT1dWSHlzS0QyS0E0Qk1jSzVUSTNvTnZB",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipN7795hAt6xtwWmIIPlBoijkf8svVZFKd4v7vTrDfhJdYe0u5DAn8wSlT4bNKgHig?key=Q1o4MzdZT1dWSHlzS0QyS0E0Qk1jSzVUSTNvTnZB",
   },
   {
     id: "transitioning-fullstack",
@@ -817,7 +845,8 @@ export const events: Event[] = [
     start_at: "2023-10-28T12:00:00",
     tags: ["Social", "Outdoors"],
     status: "past",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipOg2itOXIvPeeQKFEFScI2UCeOojdcuGpMGoJXJftFFaKlCVDhzhdkk2PNfrICpzA?key=TmRwakJkdl8zMWlYZDM2dlZiT2ZUSWwwN1U2MmtR",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipOg2itOXIvPeeQKFEFScI2UCeOojdcuGpMGoJXJftFFaKlCVDhzhdkk2PNfrICpzA?key=TmRwakJkdl8zMWlYZDM2dlZiT2ZUSWwwN1U2MmtR",
   },
   {
     id: "halloween-2023",
@@ -828,7 +857,8 @@ export const events: Event[] = [
     status: "past",
     eventUrl: "https://lu.ma/tou5yec8",
     imagePath: "/images/luma/4be95679-e8c7-4149-bbba-60b80ff57c04.jpeg",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipMbVRHwXl8qR8eWRaxk0jqxbUxRBD4ic1arOmYFPQQNPaFonrTiGJU4pf_rfFFMxg?key=SXlVb0s5dEZqRnMyejh3QkcyR2o3NTFvQzhEaXRB",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipMbVRHwXl8qR8eWRaxk0jqxbUxRBD4ic1arOmYFPQQNPaFonrTiGJU4pf_rfFFMxg?key=SXlVb0s5dEZqRnMyejh3QkcyR2o3NTFvQzhEaXRB",
   },
   {
     id: "llms-what-how",
@@ -841,7 +871,8 @@ export const events: Event[] = [
     imagePath: "/images/meetup/highres_516203971.jpeg",
     host: sponsors.cohere,
     youtubeUrl: "https://www.youtube.com/watch?v=L61l0VzQ5j4",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipPFf6pYTwSxFt1sG8sco1i_tdRYmRzxFSlGLXokJjlMXsc4ZT9288pNP0Z7-_Q71A?key=aVM3VjA3WU5QOW5XaExMLW1BTFoxbkdCQllERDhB",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipPFf6pYTwSxFt1sG8sco1i_tdRYmRzxFSlGLXokJjlMXsc4ZT9288pNP0Z7-_Q71A?key=aVM3VjA3WU5QOW5XaExMLW1BTFoxbkdCQllERDhB",
   },
   {
     id: "junior-to-midlevel",
@@ -866,7 +897,8 @@ export const events: Event[] = [
     eventUrl: "https://www.meetup.com/techtank-to/events/295642016/",
     imagePath: "/images/meetup/highres_515354669.jpeg",
     youtubeUrl: "https://www.youtube.com/watch?v=IKrZuYJGBKo",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipOG-h347VHP9BpUaj9VGXpH1RbYpvM9VqJPbGMPw22afLsIUrmW1Mc9vPDpBBO8tg?key=NVdxWnV2ckFSZG0zeDdyMlVaUS1VNDFCWV9QRTZB",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipOG-h347VHP9BpUaj9VGXpH1RbYpvM9VqJPbGMPw22afLsIUrmW1Mc9vPDpBBO8tg?key=NVdxWnV2ckFSZG0zeDdyMlVaUS1VNDFCWV9QRTZB",
   },
   {
     id: "bowling-2023",
@@ -878,7 +910,8 @@ export const events: Event[] = [
     status: "past",
     eventUrl: "https://lu.ma/om45mvv3",
     imagePath: "/images/luma/default-retro4.jpeg",
-    albumUrl: "https://photos.google.com/u/2/share/AF1QipNJf7YltaKvL5Cq_bX4O8Nt0heaFeetF1UuqVj54JoxVEzjPm4F85nQPHj_LDKpdw?key=V2JKcjBkTDczWVZWWHNpNUl4OVJGOGQxNmQxb3BB",
+    albumUrl:
+      "https://photos.google.com/u/2/share/AF1QipNJf7YltaKvL5Cq_bX4O8Nt0heaFeetF1UuqVj54JoxVEzjPm4F85nQPHj_LDKpdw?key=V2JKcjBkTDczWVZWWHNpNUl4OVJGOGQxNmQxb3BB",
   },
   {
     id: "continuous-learning-tech",
@@ -893,4 +926,3 @@ export const events: Event[] = [
     youtubeUrl: "https://www.youtube.com/watch?v=6Mf6CDJnE4U",
   },
 ];
-

--- a/constants/instagram-posts.ts
+++ b/constants/instagram-posts.ts
@@ -15,267 +15,363 @@ export interface InstagramPost {
 
 const instagramPosts: Record<string, InstagramPost> = {
   "2024-05-14-C69JJhR2qP": {
-    caption: "🌟 Dive into the world of AI Prompting with us at #StudyTank! 🚀\nJoin our StudyTank session tonight at 7:00 p.m. as we explore the art of crafting well-written prompts to elicit desired behaviors from AI models.\nDon’t miss out on practical tips from our guest teacher, Nhi Nguyen!\nRSVP now at the link in our bio on the app Meetup\nhttps://www.meetup.com/techtank-to/events/300782288\n#AI #TechTalks #StudyTank #TechTank #TechTankTo #FollowUs #TechCommunity #followforfollowback #follow4followback #onlineevent #onlineevents #aiprompts #techenthusiast #techenthusiasts #coder #programmer #dev #developer #designer\n#techtanktoronto #swimwithus #iykyk #foryou #technology #aiprompt #artificialintellegence #toolsandtips #lifehack #quicktips\n#careergrowth",
+    caption:
+      "🌟 Dive into the world of AI Prompting with us at #StudyTank! 🚀\nJoin our StudyTank session tonight at 7:00 p.m. as we explore the art of crafting well-written prompts to elicit desired behaviors from AI models.\nDon’t miss out on practical tips from our guest teacher, Nhi Nguyen!\nRSVP now at the link in our bio on the app Meetup\nhttps://www.meetup.com/techtank-to/events/300782288\n#AI #TechTalks #StudyTank #TechTank #TechTankTo #FollowUs #TechCommunity #followforfollowback #follow4followback #onlineevent #onlineevents #aiprompts #techenthusiast #techenthusiasts #coder #programmer #dev #developer #designer\n#techtanktoronto #swimwithus #iykyk #foryou #technology #aiprompt #artificialintellegence #toolsandtips #lifehack #quicktips\n#careergrowth",
     date: "2024-05-14",
     shortcode: "C69JJh-R2qP",
     pk: 18027008243035969,
     createdAtRaw: 1715703598,
     media: [
-      { type: "image", path: "/media/instagram/2024-05-14-C69JJhR2qP/techtankto_C69JJh-R2qP_3367888333715237519.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-05-14-C69JJhR2qP/techtankto_C69JJh-R2qP_3367888333715237519.webp" },
+    ],
   },
   "2024-05-17-C7FJzyxWnV": {
-    caption: "🌟 Yesterday at TechTank’s ‘Guppy Talks,’ we delved into ‘Engineering Wellness: Innovations and Challenges in Health Tech.’\nAttendees enjoyed insightful discussions with our expert panelists: Marta, Niya (Sorry I mispronounced your name it is pronounced “Nee-ya”!) and Roveena. Fellow enthusiasts and tech professionals explored new health technology trends:\nWhite Labeling: League’s approach to offering branded health solutions.\nDigital Prescriptions and Medical Health Records: Innovations by Healthie and the transition from paper charts to fully digital systems.\nImpact of the Pandemic: The acceleration of telemedicine and changes in patient-provider interactions.\nData Privacy and Security: Addressing the challenges of data integration and ensuring privacy.\nAPI Development: Creating custom APIs for better data exchange.\nEHR Document Transfer: Using databases like Google Fire for efficient document transfer.\nInter-network Communication: Overcoming the siloed nature of health networks.\nWearable Technology: Utilizing smartwatches to monitor health metrics and predict medical events.\nCase Studies Sharing: Platforms like Figure 1 for healthcare professionals to share and discuss cases.\nStartup vs. Large Company Dynamics: Handling innovation and integration in different organizational settings.\nHuge thanks to our sponsor, @7shifts, and everyone who made it an unforgettable Thursday evening!\nHere is the link to join 7shifts talent and apply online 👇 🔗 https://www.gem.com/form?formID=236bc24b-f0e9-4c98-8c7e-b5a113dcfc49\nSpecial thanks to @blondies_pizza for catering the event!\nA HUGE thank you to all the volunteers making this event go smoothly! We couldn’t do this without you!\nStay tuned for more events with @airicodes_ . 🚀\n#TechTank #HealthTech #Innovation #GuppyTalks #TorontoEvents #7Shifts #healthtechsaveslives\n#techsaveslives #techtankto #techtankers #torontotechevents #networking #professionalnetworking #toronto #6ix #yyz #downtown #blondies #nonprofit #volunteers #freeevents #torontoevent #bloorcourt #bloorcourtvillage #slack #meetup #healthtech #healthtechnology #techdiscussion",
+    caption:
+      "🌟 Yesterday at TechTank’s ‘Guppy Talks,’ we delved into ‘Engineering Wellness: Innovations and Challenges in Health Tech.’\nAttendees enjoyed insightful discussions with our expert panelists: Marta, Niya (Sorry I mispronounced your name it is pronounced “Nee-ya”!) and Roveena. Fellow enthusiasts and tech professionals explored new health technology trends:\nWhite Labeling: League’s approach to offering branded health solutions.\nDigital Prescriptions and Medical Health Records: Innovations by Healthie and the transition from paper charts to fully digital systems.\nImpact of the Pandemic: The acceleration of telemedicine and changes in patient-provider interactions.\nData Privacy and Security: Addressing the challenges of data integration and ensuring privacy.\nAPI Development: Creating custom APIs for better data exchange.\nEHR Document Transfer: Using databases like Google Fire for efficient document transfer.\nInter-network Communication: Overcoming the siloed nature of health networks.\nWearable Technology: Utilizing smartwatches to monitor health metrics and predict medical events.\nCase Studies Sharing: Platforms like Figure 1 for healthcare professionals to share and discuss cases.\nStartup vs. Large Company Dynamics: Handling innovation and integration in different organizational settings.\nHuge thanks to our sponsor, @7shifts, and everyone who made it an unforgettable Thursday evening!\nHere is the link to join 7shifts talent and apply online 👇 🔗 https://www.gem.com/form?formID=236bc24b-f0e9-4c98-8c7e-b5a113dcfc49\nSpecial thanks to @blondies_pizza for catering the event!\nA HUGE thank you to all the volunteers making this event go smoothly! We couldn’t do this without you!\nStay tuned for more events with @airicodes_ . 🚀\n#TechTank #HealthTech #Innovation #GuppyTalks #TorontoEvents #7Shifts #healthtechsaveslives\n#techsaveslives #techtankto #techtankers #torontotechevents #networking #professionalnetworking #toronto #6ix #yyz #downtown #blondies #nonprofit #volunteers #freeevents #torontoevent #bloorcourt #bloorcourtvillage #slack #meetup #healthtech #healthtechnology #techdiscussion",
     shortcode: "C7FJz-yxWnV",
     pk: 17975828336569876,
     createdAtRaw: 1715980471,
     media: [
-      { type: "image", path: "/media/instagram/2024-05-17-C7FJzyxWnV/techtankto_C7FJz-yxWnV_3370143050692389333.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-05-17-C7FJzyxWnV/techtankto_C7FJz-yxWnV_3370143050692389333.webp" },
+    ],
   },
   "2024-05-27-C7ekq8xusC8": {
-    caption: "🚀 Next #StudyTank Session: Networking 101🚀\nLearning is not just about acquiring knowledge; it’s also about effectively communicating what we’ve learned. By teaching others, we solidify our own understanding. Through this initiative, we aim to foster a culture of sharing, learning, and mutual growth within Study Tank.\nJoin us online!👇\n📅 Date: June 4 🕖 Time: 7-8 PM EST 📍 Location: Online Event\n🌟 #Joinus for an exciting session on networking with Sammy Lam, where we’ll dive into practical strategies and techniques for the art of networking in the tech space.\nWhether connecting online or at professional events, this session will help you build and maintain valuable professional relationships that can significantly enhance your career. Don’t miss out on this opportunity to boost your networking skills and drive your career growth!\n📲 Please register on the Meetup app! Link in Bio\n#StudyTank #Networking #CareerGrowth #TechNetworking #ProfessionalDevelopment #learningtogether #networkingevent #TechCommunity #careerdevelopment #SkillBuilding #professionalnetworking #ProfessionalSkills #OnlineLearning #NetworkingTips #CareerSuccess #TechTank #TechTankto #TechTankToronto #TechTanker #TechTankers #developers #devlife #devcommunity #softwaredeveloper #softwareengineer #careertransition",
+    caption:
+      "🚀 Next #StudyTank Session: Networking 101🚀\nLearning is not just about acquiring knowledge; it’s also about effectively communicating what we’ve learned. By teaching others, we solidify our own understanding. Through this initiative, we aim to foster a culture of sharing, learning, and mutual growth within Study Tank.\nJoin us online!👇\n📅 Date: June 4 🕖 Time: 7-8 PM EST 📍 Location: Online Event\n🌟 #Joinus for an exciting session on networking with Sammy Lam, where we’ll dive into practical strategies and techniques for the art of networking in the tech space.\nWhether connecting online or at professional events, this session will help you build and maintain valuable professional relationships that can significantly enhance your career. Don’t miss out on this opportunity to boost your networking skills and drive your career growth!\n📲 Please register on the Meetup app! Link in Bio\n#StudyTank #Networking #CareerGrowth #TechNetworking #ProfessionalDevelopment #learningtogether #networkingevent #TechCommunity #careerdevelopment #SkillBuilding #professionalnetworking #ProfessionalSkills #OnlineLearning #NetworkingTips #CareerSuccess #TechTank #TechTankto #TechTankToronto #TechTanker #TechTankers #developers #devlife #devcommunity #softwaredeveloper #softwareengineer #careertransition",
     date: "2024-05-27",
     shortcode: "C7ekq8xusC8",
     pk: 18030870997869439,
     createdAtRaw: 1716825711,
     media: [
-      { type: "image", path: "/media/instagram/2024-05-27-C7ekq8xusC8/techtankto_C7ekq8xusC8_3377298051725705404.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-05-27-C7ekq8xusC8/techtankto_C7ekq8xusC8_3377298051725705404.webp",
+      },
+    ],
   },
   "2024-05-28-C7hQBJuBg0": {
-    caption: "When the #JavaScript bugs get you down…😢💻\nMy code will go on 🫡 🚢\n🌊🎶 🐠\n#MyCode #javascriptdeveloper #Coding #programminglife #Dev #devmemes #techlife #Coder #stuggle #celinedion #myheartwillgoon #codelife #techjokes #programmermemes #javascripts #TechTank #Debugging #Techtankto #techtanktoronto #techtanker #techtankers #titanicvibes\n#geekhumor #crying #toronto #techevents #fun #memes #memesdaily",
+    caption:
+      "When the #JavaScript bugs get you down…😢💻\nMy code will go on 🫡 🚢\n🌊🎶 🐠\n#MyCode #javascriptdeveloper #Coding #programminglife #Dev #devmemes #techlife #Coder #stuggle #celinedion #myheartwillgoon #codelife #techjokes #programmermemes #javascripts #TechTank #Debugging #Techtankto #techtanktoronto #techtanker #techtankers #titanicvibes\n#geekhumor #crying #toronto #techevents #fun #memes #memesdaily",
     date: "2024-05-28",
     shortcode: "C7hQBJ_uBg0",
     pk: 18078786448486335,
     createdAtRaw: 1716915803,
     media: [
-      { type: "image", path: "/media/instagram/2024-05-28-C7hQBJuBg0/techtankto_C7hQBJ_uBg0_3378051643700942900.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-05-28-C7hQBJuBg0/techtankto_C7hQBJ_uBg0_3378051643700942900.webp" },
+    ],
   },
   "2024-05-31-C7o69MmuY1m": {
-    caption: "Deploying on a Friday? 😅\nGet ready for a rollercoaster of emotions! 🫠\nSpare a thought for the brave soul on call. 💻💔\n#techlife #fridaydeploy #oncall #TechTank #techtankto #friday #techtanktoronto #techtankers #techtanker #devops #codelife #itcommunity #softwareengineering #techhumor #techmemes #deploymentdays #sysadmin #techtips #codingproblems #techworld #programmerlife #itsupport #debugging #memesdaily #softwaredeveloper #yyz #torontoevents",
+    caption:
+      "Deploying on a Friday? 😅\nGet ready for a rollercoaster of emotions! 🫠\nSpare a thought for the brave soul on call. 💻💔\n#techlife #fridaydeploy #oncall #TechTank #techtankto #friday #techtanktoronto #techtankers #techtanker #devops #codelife #itcommunity #softwareengineering #techhumor #techmemes #deploymentdays #sysadmin #techtips #codingproblems #techworld #programmerlife #itsupport #debugging #memesdaily #softwaredeveloper #yyz #torontoevents",
     date: "2024-05-31",
     shortcode: "C7o69MmuY1m",
     pk: 18017741879093672,
     createdAtRaw: 1717173847,
     media: [
-      { type: "image", path: "/media/instagram/2024-05-31-C7o69MmuY1m/techtankto_C7mQW2PObG8_3379460509198299580.webp" },
-      { type: "image", path: "/media/instagram/2024-05-31-C7o69MmuY1m/techtankto_C7o69MmuY1m_3380210812461878630.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-05-31-C7o69MmuY1m/techtankto_C7mQW2PObG8_3379460509198299580.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-05-31-C7o69MmuY1m/techtankto_C7o69MmuY1m_3380210812461878630.webp",
+      },
+    ],
   },
   "2024-06-02-C6wKWQOT7D": {
-    caption: "🌟 Join us tomorrow for an enriching evening at TechTank’s ‘Guppy Talks’ event! 🐠 🐟 🐠\nDelve into the realm of health technology as we explore ‘Engineering Wellness: Innovations and Challenges in Health Tech.’\nReminder to RSVP on Meetup 🚀\n🔗 meetup.com/techtank-to/events/300591167/\nOr check out our links in the bio! 🐠\nThis event will be IN-PERSON on Thursday, May 16th (doors open 6pm) and hosted at the Roof Garden building (1 Roof Garden Lane, Toronto, ON M6H 1R2), thanks to our sponsors, 7Shifts 🙏\nWe’ll have drinks, food, and great conversations.\nPanelists: Marta Kule (she/her) - Senior Software Engineer, League Niya Panamdanam (she/her) - Senior Software Engineer, Healthie Roveena Sequeira (she/her) - MD CCFP(EM), Emergency Medicine Physician, Niagara Health, & Assistant Clinical Professor (Adjunct)\nModerator:  Riaz Virani (he/him), Community Organizer at TechTank\nSchedule: 6:00pm - 6:45pm - Get to the venue, eat, socialize! 6:45pm - 7:45pm - Announcements / Panel discussion 7:45pm - 8:30pm - Hang out some more, ask questions\nℹ️ For more information about us and free events, please visit www.techtankto.com\nAbout our Sponsor: 7Shifts, a leading tech company streamlining team management for over 40,000 restaurants worldwide, optimizing scheduling, communication, and compliance while reducing overhead costs.\n#TechTank #HealthTech #innovation #GuppyTalks #techtankto #techtankers #techtanker #TorontoEvents #7Shifts #inperson #networking #torontonetworking #free #RestaurantTech #techpanel #panel #torontoevents #meetup #rsvp #tomorrow #healthtechnology #yyz #6ix #gta #downtowntoronto #techtanktoronto #jobseekers #techsociety #medicaltechnology #restauranttechnology",
+    caption:
+      "🌟 Join us tomorrow for an enriching evening at TechTank’s ‘Guppy Talks’ event! 🐠 🐟 🐠\nDelve into the realm of health technology as we explore ‘Engineering Wellness: Innovations and Challenges in Health Tech.’\nReminder to RSVP on Meetup 🚀\n🔗 meetup.com/techtank-to/events/300591167/\nOr check out our links in the bio! 🐠\nThis event will be IN-PERSON on Thursday, May 16th (doors open 6pm) and hosted at the Roof Garden building (1 Roof Garden Lane, Toronto, ON M6H 1R2), thanks to our sponsors, 7Shifts 🙏\nWe’ll have drinks, food, and great conversations.\nPanelists: Marta Kule (she/her) - Senior Software Engineer, League Niya Panamdanam (she/her) - Senior Software Engineer, Healthie Roveena Sequeira (she/her) - MD CCFP(EM), Emergency Medicine Physician, Niagara Health, & Assistant Clinical Professor (Adjunct)\nModerator:  Riaz Virani (he/him), Community Organizer at TechTank\nSchedule: 6:00pm - 6:45pm - Get to the venue, eat, socialize! 6:45pm - 7:45pm - Announcements / Panel discussion 7:45pm - 8:30pm - Hang out some more, ask questions\nℹ️ For more information about us and free events, please visit www.techtankto.com\nAbout our Sponsor: 7Shifts, a leading tech company streamlining team management for over 40,000 restaurants worldwide, optimizing scheduling, communication, and compliance while reducing overhead costs.\n#TechTank #HealthTech #innovation #GuppyTalks #techtankto #techtankers #techtanker #TorontoEvents #7Shifts #inperson #networking #torontonetworking #free #RestaurantTech #techpanel #panel #torontoevents #meetup #rsvp #tomorrow #healthtechnology #yyz #6ix #gta #downtowntoronto #techtanktoronto #jobseekers #techsociety #medicaltechnology #restauranttechnology",
     date: "2024-06-02",
     shortcode: "C6_wKWQOT7D",
     pk: 17855448786190591,
     createdAtRaw: 1717298507,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-02-C6wKWQOT7D/techtankto_C6_wKWQOT7D_3368622863618227907.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-06-02-C6wKWQOT7D/techtankto_C6_wKWQOT7D_3368622863618227907.webp" },
+    ],
   },
   "2024-06-02-C7Cb4LUx2iy": {
-    caption: "Connect and thrive with TechTank this summer! 🌅\n#Throwback to our cottage retreat as we eagerly await the upcoming long weekend.\nJoin us on #Slack to our inclusive tech community and unforgettable memories. Who’s ready to dive in? 🤿\n🐠 🐟 🐠\n#TechTankTo #SummerFun #TechCommunity #techtank #techtanker #techtankers #tb #tbt #thursday #sunset #toronto #dev #developers #devcommunity #cottage #victoriadaylongweekend #longsummer #techtanktoronto #slackcommunity #coders #mentorship #studytank #studyonline #meetup",
+    caption:
+      "Connect and thrive with TechTank this summer! 🌅\n#Throwback to our cottage retreat as we eagerly await the upcoming long weekend.\nJoin us on #Slack to our inclusive tech community and unforgettable memories. Who’s ready to dive in? 🤿\n🐠 🐟 🐠\n#TechTankTo #SummerFun #TechCommunity #techtank #techtanker #techtankers #tb #tbt #thursday #sunset #toronto #dev #developers #devcommunity #cottage #victoriadaylongweekend #longsummer #techtanktoronto #slackcommunity #coders #mentorship #studytank #studyonline #meetup",
     date: "2024-06-02",
     shortcode: "C7Cb4LUx2iy",
     pk: 18266614033215377,
     createdAtRaw: 1717298477,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-02-C7Cb4LUx2iy/techtankto_C7Cb4LUx2iy_3369378078932822194.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-02-C7Cb4LUx2iy/techtankto_C7Cb4LUx2iy_3369378078932822194.webp",
+      },
+    ],
   },
   "2024-06-02-C7Cc9Nvxnf": {
-    caption: "☀️ Embrace the warmth of summer with TechTank!\nThrowback to our 2023 retreat, and get ready for another Long Weekend full of tech and sunshine.\nJoin us on our slack community and make unforgettable memories! 💪 👨‍💻 👩‍💻 🧑‍💻\n#TechTank #SummerVibes #TechCommunity #TechTankTo\n#thursday #tb #tbt #throwback #summer #warm #longweekendvibes #goodvibesonly #4dayweekend #longweekend #victoriaday #sunset #igsunset #techtanker #techtankers #toronto #6ix #tech #slack #studytank #coders #developers #devcommunity #codewithus #meetpeople #network",
+    caption:
+      "☀️ Embrace the warmth of summer with TechTank!\nThrowback to our 2023 retreat, and get ready for another Long Weekend full of tech and sunshine.\nJoin us on our slack community and make unforgettable memories! 💪 👨‍💻 👩‍💻 🧑‍💻\n#TechTank #SummerVibes #TechCommunity #TechTankTo\n#thursday #tb #tbt #throwback #summer #warm #longweekendvibes #goodvibesonly #4dayweekend #longweekend #victoriaday #sunset #igsunset #techtanker #techtankers #toronto #6ix #tech #slack #studytank #coders #developers #devcommunity #codewithus #meetpeople #network",
     date: "2024-06-02",
     shortcode: "C7Cc9Nvxnf-",
     pk: 18049939513732333,
     createdAtRaw: 1717298424,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-02-C7Cc9Nvxnf/techtankto_C7Cc9Nvxnf-_3369382823177123838.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-06-02-C7Cc9Nvxnf/techtankto_C7Cc9Nvxnf-_3369382823177123838.webp" },
+    ],
   },
   "2024-06-02-C7CchFRxfEi": {
-    caption: "💪 Empower yourself with the TechTank community!\nAs we countdown to another four day long weekend, dive into the warmth of relaxation and connections.\nThat sweater is hilarious 😂\nJoin our inclusive tech community for an unforgettable experience! 🐠 🐟 🐠\n#TechTank #Empowerment #SummerAdventure\n#techtanktoronto #techtanker #techtankers #devcommunity\n#TechTankTo #SummerFun #TechCommunity #developers #devcommunity #longweekend #victoriadaylongweekend #cottageweekend #4dayweekend #studytank #mentor #studycode #studywithme #slackcommunity #socials #torontoevents #continuelearning #thursday #tb #tbt #throwback",
+    caption:
+      "💪 Empower yourself with the TechTank community!\nAs we countdown to another four day long weekend, dive into the warmth of relaxation and connections.\nThat sweater is hilarious 😂\nJoin our inclusive tech community for an unforgettable experience! 🐠 🐟 🐠\n#TechTank #Empowerment #SummerAdventure\n#techtanktoronto #techtanker #techtankers #devcommunity\n#TechTankTo #SummerFun #TechCommunity #developers #devcommunity #longweekend #victoriadaylongweekend #cottageweekend #4dayweekend #studytank #mentor #studycode #studywithme #slackcommunity #socials #torontoevents #continuelearning #thursday #tb #tbt #throwback",
     date: "2024-06-02",
     shortcode: "C7CchFRxfEi",
     pk: 18019116218216505,
     createdAtRaw: 1717298463,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-02-C7CchFRxfEi/techtankto_C7CchFRxfEi_3369380889938489634.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-02-C7CchFRxfEi/techtankto_C7CchFRxfEi_3369380889938489634.webp",
+      },
+    ],
   },
   "2024-06-02-C7W3AlHxKfh": {
-    caption: "When the excitement of starting a new project outweighs the guilt of unfinished ones. 😂\nWe’ve all been there with project hopping.\nFYI #StudyTank Session has been posted check out our website for more information. 🐠\n🔗 www.techtankto.com\n#DevLife #techtankto #techtank #techtankers #techtanker #TechTankMemes #NewProject #unfinishedproject #ProgrammerHumor #DevJokes #CodingReality #CodeConfessions #Programmer #DevMemes #TechHumor\n#IncompleteTasks\n#Tech #Procrastination\n#Programming #NewProjectHype #OldProject #DeveloperLife",
+    caption:
+      "When the excitement of starting a new project outweighs the guilt of unfinished ones. 😂\nWe’ve all been there with project hopping.\nFYI #StudyTank Session has been posted check out our website for more information. 🐠\n🔗 www.techtankto.com\n#DevLife #techtankto #techtank #techtankers #techtanker #TechTankMemes #NewProject #unfinishedproject #ProgrammerHumor #DevJokes #CodingReality #CodeConfessions #Programmer #DevMemes #TechHumor\n#IncompleteTasks\n#Tech #Procrastination\n#Programming #NewProjectHype #OldProject #DeveloperLife",
     date: "2024-06-02",
     shortcode: "C7W3AlHxKfh",
     pk: 18028667408031865,
     createdAtRaw: 1717298357,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-02-C7W3AlHxKfh/techtankto_C7W3AlHxKfh_3375126903177652193.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-02-C7W3AlHxKfh/techtankto_C7W3AlHxKfh_3375126903177652193.webp",
+      },
+    ],
   },
   "2024-06-02-C7cXA2mxC5g": {
-    caption: "Had an epic night at the Toronto social with Da Tank! 🐠 🐟\nWe hit up Midnight Arcade for endless retro games, delicious half-priced food, and incredible video game-themed cocktails.\n🕹️🎉\n📸 @nmpanam\nThis event was organized by TechTank. To join us next time, be sure to join our Slack community!\n🔗 https://techtankto.com/links/slack\nLink also in Bio!\n#GoodTimes #TorontoNights #RetroGaming #ArcadeLife #MidnightArcade #GamerVibes #CocktailMagic #HalfPricedEats #SocialNight #VideoGameLovers #TorontoEvents #DaTank #GamingCommunity #NostalgiaTrip #TorontoFun #TechTank #kensingtonmarket #6ix",
+    caption:
+      "Had an epic night at the Toronto social with Da Tank! 🐠 🐟\nWe hit up Midnight Arcade for endless retro games, delicious half-priced food, and incredible video game-themed cocktails.\n🕹️🎉\n📸 @nmpanam\nThis event was organized by TechTank. To join us next time, be sure to join our Slack community!\n🔗 https://techtankto.com/links/slack\nLink also in Bio!\n#GoodTimes #TorontoNights #RetroGaming #ArcadeLife #MidnightArcade #GamerVibes #CocktailMagic #HalfPricedEats #SocialNight #VideoGameLovers #TorontoEvents #DaTank #GamingCommunity #NostalgiaTrip #TorontoFun #TechTank #kensingtonmarket #6ix",
     date: "2024-06-02",
     shortcode: "C7cXA2mxC5g",
     pk: 18025321271173342,
     createdAtRaw: 1717298310,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-02-C7cXA2mxC5g/techtankto_C7cXA2mxC5g_3376675034323234400.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-02-C7cXA2mxC5g/techtankto_C7cXA2mxC5g_3376675034323234400.webp",
+      },
+    ],
   },
   "2024-06-02-C7cXqLJxf7d": {
-    caption: "Last night’s Toronto social with Da Tank was a blast! 💥\nWe spent the evening at Midnight Arcade enjoying unlimited retro games, tasty half-priced food, and awesome video game-themed cocktails. 🕹️✨\n📸 @nmpanam\nHuge thanks to TechTank for organizing. Want to join the fun next time? Join our Slack community!\n🔗 https://techtankto.com/links/slack\nOr check the link in bio!\n#TorontoNights #RetroGaming #ArcadeFun #MidnightArcade #GamingNight #CocktailVibes #HalfPricedFood #SocialEvent #GamerCommunity #TorontoEvents #DaTank #TechTank #VideoGameNight #NostalgiaGaming #TorontoLife",
+    caption:
+      "Last night’s Toronto social with Da Tank was a blast! 💥\nWe spent the evening at Midnight Arcade enjoying unlimited retro games, tasty half-priced food, and awesome video game-themed cocktails. 🕹️✨\n📸 @nmpanam\nHuge thanks to TechTank for organizing. Want to join the fun next time? Join our Slack community!\n🔗 https://techtankto.com/links/slack\nOr check the link in bio!\n#TorontoNights #RetroGaming #ArcadeFun #MidnightArcade #GamingNight #CocktailVibes #HalfPricedFood #SocialEvent #GamerCommunity #TorontoEvents #DaTank #TechTank #VideoGameNight #NostalgiaGaming #TorontoLife",
     date: "2024-06-02",
     shortcode: "C7cXqLJxf7d",
     pk: 18267872848232888,
     createdAtRaw: 1717298295,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-02-C7cXqLJxf7d/techtankto_C66tKOhxvH3_3367202286299705847.webp" },
-      { type: "image", path: "/media/instagram/2024-06-02-C7cXqLJxf7d/techtankto_C7cXqLJxf7d_3376677873883938525.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-02-C7cXqLJxf7d/techtankto_C66tKOhxvH3_3367202286299705847.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-02-C7cXqLJxf7d/techtankto_C7cXqLJxf7d_3376677873883938525.webp",
+      },
+    ],
   },
   "2024-06-02-C7cskGFP5": {
-    caption: "🎉 Hey Y’all! We had a blast at The Midnight Arcade in downtown Toronto! 🕹️\n📍 @midnight.arcade\nOrganized by @nmpana, this event was so fun! 🤩\nMissed out? Don’t worry!\nJoin our TechTank Slack community and stay updated on all our events.\nCheck our website for more info and get ready for the next epic night! 🌟👾\n🐠 www.techtankto.com 🐠\n#TechTank #TechTankers #Toronto #stayconnected #JoinUs #ArcadeFun #CommunityVibes #GameNight #RetroGaming #NextLevelFun #SocialEvents #Networking #TechCommunity #FunTimes #activitiesinToronto #ClassicGames #EventRecap #daTank #torontosocial #techtanktoronto #techtankto",
+    caption:
+      "🎉 Hey Y’all! We had a blast at The Midnight Arcade in downtown Toronto! 🕹️\n📍 @midnight.arcade\nOrganized by @nmpana, this event was so fun! 🤩\nMissed out? Don’t worry!\nJoin our TechTank Slack community and stay updated on all our events.\nCheck our website for more info and get ready for the next epic night! 🌟👾\n🐠 www.techtankto.com 🐠\n#TechTank #TechTankers #Toronto #stayconnected #JoinUs #ArcadeFun #CommunityVibes #GameNight #RetroGaming #NextLevelFun #SocialEvents #Networking #TechCommunity #FunTimes #activitiesinToronto #ClassicGames #EventRecap #daTank #torontosocial #techtanktoronto #techtankto",
     date: "2024-06-02",
     shortcode: "C7cskGFP_5-",
     pk: 18050106079730009,
     createdAtRaw: 1717298274,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-02-C7cskGFP5/techtankto_C7cskGFP_5-_3376769815099211390.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-06-02-C7cskGFP5/techtankto_C7cskGFP_5-_3376769815099211390.webp" },
+    ],
   },
   "2024-06-02-C7pxQozOzxs": {
-    caption: "🌍 Tomorrow marks the beginning of June, recognized as National Indigenous History Month in Canada! ✨\nJoin us in learning, reflecting, and honoring the rich and diverse cultures of the First Nations, Inuit, and Métis, who have lived and thrived on this land from long before it was called ‘Canada,’ whose resilience and presence continues to impact and shape our culture and our land. 🌱\n💡 As a community that celebrates diversity and inclusion, TechTank is committed to engaging in further learning and sharing important resources such as:\nThe Indigenous Friends Association (IFA) @indigenousfriends\nAn Indigenous-led tech not-for-profit organization that ignites the Spirit of Indigenous communities to create, engage and renovate digital technologies through ethical and communal values.\n🔗 Website: www.indigenousfriends.org\nThe Centre for Indigenous Innovation and Technology Promoting excellence & diversity in technology training & innovation. CIIT aims to increase Indigenous representation in the tech industry and approach problem-solving with an Indigenous lens. 🔗 Website: www.ciit.io\nCanadian Council for Indigenous Business Dedicated to building a prosperous Indigenous economy by fostering relationships between Indigenous and non-Indigenous peoples, businesses, and communities through diverse programming. 🔗 Website: www.ccab.com\nIf you have any resources you’d like to share with us, please let us know via our Slack community! 🔗 Join our Slack community: https://techtankto.com/links/slack\n“Shine Bright” is an energetic pop song fused with youthful voices and a hopefully message of resilience and hope. Created by a group of youth from Quaqtag, Nunavik in Northern Quebec. @nwejinantv\n#indigenoushistorymonth #celebratediversity #indigenousheritage #learnfromthepast #strongertogether #resources #embracingcultures #JUNE #NIHM2024 #nhim #Developer #devcommunity #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers #inclusivecommunity #diversity #inclusion #Canada #Toronto #YYZ #torontononprofit",
+    caption:
+      "🌍 Tomorrow marks the beginning of June, recognized as National Indigenous History Month in Canada! ✨\nJoin us in learning, reflecting, and honoring the rich and diverse cultures of the First Nations, Inuit, and Métis, who have lived and thrived on this land from long before it was called ‘Canada,’ whose resilience and presence continues to impact and shape our culture and our land. 🌱\n💡 As a community that celebrates diversity and inclusion, TechTank is committed to engaging in further learning and sharing important resources such as:\nThe Indigenous Friends Association (IFA) @indigenousfriends\nAn Indigenous-led tech not-for-profit organization that ignites the Spirit of Indigenous communities to create, engage and renovate digital technologies through ethical and communal values.\n🔗 Website: www.indigenousfriends.org\nThe Centre for Indigenous Innovation and Technology Promoting excellence & diversity in technology training & innovation. CIIT aims to increase Indigenous representation in the tech industry and approach problem-solving with an Indigenous lens. 🔗 Website: www.ciit.io\nCanadian Council for Indigenous Business Dedicated to building a prosperous Indigenous economy by fostering relationships between Indigenous and non-Indigenous peoples, businesses, and communities through diverse programming. 🔗 Website: www.ccab.com\nIf you have any resources you’d like to share with us, please let us know via our Slack community! 🔗 Join our Slack community: https://techtankto.com/links/slack\n“Shine Bright” is an energetic pop song fused with youthful voices and a hopefully message of resilience and hope. Created by a group of youth from Quaqtag, Nunavik in Northern Quebec. @nwejinantv\n#indigenoushistorymonth #celebratediversity #indigenousheritage #learnfromthepast #strongertogether #resources #embracingcultures #JUNE #NIHM2024 #nhim #Developer #devcommunity #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers #inclusivecommunity #diversity #inclusion #Canada #Toronto #YYZ #torontononprofit",
     date: "2024-06-02",
     shortcode: "C7pxQozOzxs",
     pk: 17882936193063784,
     createdAtRaw: 1717298172,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-02-C7pxQozOzxs/techtankto_C7pxQozOzxs_3380449642918132844.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-02-C7pxQozOzxs/techtankto_C7pxQozOzxs_3380449642918132844.webp",
+      },
+    ],
   },
   "2024-06-02-C7suzTLuDSF": {
-    caption: "🌈 Happy Pride Month from TechTank 🫶🏻\nLive with pride and be proud of who you are!\n✨ We hope this Pride Month brings you joy, a deep sense of community, and the happiness of feeling seen and heard for your authentic selves!\n💜 We love our LGBTQ+ colleagues, friends, and family members, and we aim to create an inclusive environment where everyone feels valued and respected, not only in June, but all year round 🏳️‍🌈💫.\n💡 As part of our commitment to diversity and inclusion, TechTank hosts monthly coffee chats (aka our “Code Diversity” group) dedicated to supporting women and gender-diverse individuals in tech. These meetings offer a supportive space for sharing experiences, networking, and promoting initiatives that enhance gender diversity in our industry.\nJoin the Code Diversity group from our Slack community:\n🔗 https://techtankto.com/links/slack\nLet’s make this Pride Month one to remember by spreading love, acceptance, and empowerment together!💗\n💬 Repost this post on your stories and let’s continue to build a supportive and inclusive tech space together! 🏳️‍🌈 ✨\n#PrideMonth #CelebrateDiversity #LGBTQ #Inclusion #Queer #TechCommunity #SupportPride #DiversityInTech #StrongerTogether #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers #InclusiveCommunity #WomenInTech #NonBinaryInTech #June2024 #Developers #DEVcommunity #Toronto #YYZ #Motivational",
+    caption:
+      "🌈 Happy Pride Month from TechTank 🫶🏻\nLive with pride and be proud of who you are!\n✨ We hope this Pride Month brings you joy, a deep sense of community, and the happiness of feeling seen and heard for your authentic selves!\n💜 We love our LGBTQ+ colleagues, friends, and family members, and we aim to create an inclusive environment where everyone feels valued and respected, not only in June, but all year round 🏳️‍🌈💫.\n💡 As part of our commitment to diversity and inclusion, TechTank hosts monthly coffee chats (aka our “Code Diversity” group) dedicated to supporting women and gender-diverse individuals in tech. These meetings offer a supportive space for sharing experiences, networking, and promoting initiatives that enhance gender diversity in our industry.\nJoin the Code Diversity group from our Slack community:\n🔗 https://techtankto.com/links/slack\nLet’s make this Pride Month one to remember by spreading love, acceptance, and empowerment together!💗\n💬 Repost this post on your stories and let’s continue to build a supportive and inclusive tech space together! 🏳️‍🌈 ✨\n#PrideMonth #CelebrateDiversity #LGBTQ #Inclusion #Queer #TechCommunity #SupportPride #DiversityInTech #StrongerTogether #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers #InclusiveCommunity #WomenInTech #NonBinaryInTech #June2024 #Developers #DEVcommunity #Toronto #YYZ #Motivational",
     date: "2024-06-02",
     shortcode: "C7suzTLuDSF",
     pk: 18049391968676537,
     createdAtRaw: 1717300611,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-02-C7suzTLuDSF/techtankto_C7suzTLuDSF_3381283255678940293.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-02-C7suzTLuDSF/techtankto_C7suzTLuDSF_3381283255678940293.webp",
+      },
+    ],
   },
   "2024-06-03-C7wn1KJuj5o": {
-    caption: "🎉 Guppy Talks 2.0?!🎉\nThat’s right! Our panel discussion series has evolved into in-person meetups, and now we’re excited to announce Guppy Talks, the podcast for our global audience 🤘😎.\nGuppy Talks offers a unique take on the tech world, exploring a range of topics and fishing 🎣 for ideas from a fishbowl of random thoughts.\nDebut Episode: ‘Testing the Waters’\n🏊 We dive into: - The state of modern CSS\n- To DRY or not-to-DRY - Our growth as developers - Surprises in tech - The future of remote work - ⁠and more! 🧑‍💻\nJoin Riaz Virani, Chris Taeyoung Kim, Benjamin Lokash, Rana Selva Soyak, and special guest Nonso (George) Otoh as we navigate these uncharted waters together!\n🎙️ Listen now on: - Spotify: https://open.spotify.com/episode/2idIwKnGKXnl41CpEAODU3?si=e9e5734fd8a34112 - Apple Podcasts: https://podcasts.apple.com/ca/podcast/guppy-talks/id1749790391?i=1000657521798 - Or wherever you get your podcasts: https://podcasters.spotify.com/pod/show/techtank6\nOr check the link in bio!\nDon’t forget to follow/subscribe to Guppy Talks on your preferred platform for more episodes coming your way! ✨\nFor more info about TechTank and our community, visit techtankto.com or email us at techtankto@gmail.com.\nHappy listening 🎧!\n#podcast #guppytalks #TechTankTO #TechTank #TechTanker #TechTankers #techtanktoronto #TechCommunity #TorontoTech #PodcastAlert #TechKnowledge #TechEnthusiasts #TechTalks #CSS #RemoteWork #DeveloperLife #css3 #dry #remote #podcasting #podcastersofinstagram #developers #devlife #development #coders #softwaredeveloper #softwaredeveloper #devloper #educator #teacher",
+    caption:
+      "🎉 Guppy Talks 2.0?!🎉\nThat’s right! Our panel discussion series has evolved into in-person meetups, and now we’re excited to announce Guppy Talks, the podcast for our global audience 🤘😎.\nGuppy Talks offers a unique take on the tech world, exploring a range of topics and fishing 🎣 for ideas from a fishbowl of random thoughts.\nDebut Episode: ‘Testing the Waters’\n🏊 We dive into: - The state of modern CSS\n- To DRY or not-to-DRY - Our growth as developers - Surprises in tech - The future of remote work - ⁠and more! 🧑‍💻\nJoin Riaz Virani, Chris Taeyoung Kim, Benjamin Lokash, Rana Selva Soyak, and special guest Nonso (George) Otoh as we navigate these uncharted waters together!\n🎙️ Listen now on: - Spotify: https://open.spotify.com/episode/2idIwKnGKXnl41CpEAODU3?si=e9e5734fd8a34112 - Apple Podcasts: https://podcasts.apple.com/ca/podcast/guppy-talks/id1749790391?i=1000657521798 - Or wherever you get your podcasts: https://podcasters.spotify.com/pod/show/techtank6\nOr check the link in bio!\nDon’t forget to follow/subscribe to Guppy Talks on your preferred platform for more episodes coming your way! ✨\nFor more info about TechTank and our community, visit techtankto.com or email us at techtankto@gmail.com.\nHappy listening 🎧!\n#podcast #guppytalks #TechTankTO #TechTank #TechTanker #TechTankers #techtanktoronto #TechCommunity #TorontoTech #PodcastAlert #TechKnowledge #TechEnthusiasts #TechTalks #CSS #RemoteWork #DeveloperLife #css3 #dry #remote #podcasting #podcastersofinstagram #developers #devlife #development #coders #softwaredeveloper #softwaredeveloper #devloper #educator #teacher",
     date: "2024-06-03",
     shortcode: "C7wn1KJuj5o",
     pk: 18188319946288501,
     createdAtRaw: 1717431120,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-03-C7wn1KJuj5o/techtankto_C7wn1KJuj5o_3382378497002061416.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-03-C7wn1KJuj5o/techtankto_C7wn1KJuj5o_3382378497002061416.webp",
+      },
+    ],
   },
   "2024-06-06-C74WqthOQf0": {
-    caption: "Summer vibes and hiking trails calling! 🌞🌲 #ThrowbackThursday to those sunny adventures in the great outdoors. Let’s relive those epic summertime memories! 🏞️\nDon't forget to take breaks from coding to get some fresh air and bright sun ☀️🩵\n#TechTank #summervibes #TechCommunity #TechTankTo #thursday #hiking #tb #tbt #throwback #summer #warm #goodvibesonly #techtankers #toronto #6ix #tech #slack #studytank #coders #developers #devcommunity #codewithus #meetpeople #network #coding #selfcare",
+    caption:
+      "Summer vibes and hiking trails calling! 🌞🌲 #ThrowbackThursday to those sunny adventures in the great outdoors. Let’s relive those epic summertime memories! 🏞️\nDon't forget to take breaks from coding to get some fresh air and bright sun ☀️🩵\n#TechTank #summervibes #TechCommunity #TechTankTo #thursday #hiking #tb #tbt #throwback #summer #warm #goodvibesonly #techtankers #toronto #6ix #tech #slack #studytank #coders #developers #devcommunity #codewithus #meetpeople #network #coding #selfcare",
     date: "2024-06-06",
     shortcode: "C74WqthOQf0",
     pk: 17897279247007839,
     createdAtRaw: 1717695488,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-06-C74WqthOQf0/techtankto_C74WqthOQf0_3384554804066530675.webp" },
-      { type: "image", path: "/media/instagram/2024-06-06-C74WqthOQf0/techtankto_C74WqthOQf0_3384554804074814185.webp" },
-      { type: "image", path: "/media/instagram/2024-06-06-C74WqthOQf0/techtankto_C74WqthOQf0_3384554804125287770.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-06-C74WqthOQf0/techtankto_C74WqthOQf0_3384554804066530675.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-06-C74WqthOQf0/techtankto_C74WqthOQf0_3384554804074814185.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-06-C74WqthOQf0/techtankto_C74WqthOQf0_3384554804125287770.webp",
+      },
+    ],
   },
   "2024-06-06-C74av1COssc": {
-    caption: "Join the TechTank community and relive those epic summertime adventures with us! 🌞🌲\n#ThrowbackThursday to sunny hikes and great outdoor memories. Let’s create more together! 🌳🌐\n#TechTank #TechCommunity #SummerVibes #TechTankTo #Hiking #GoodVibesOnly #MeetPeople #Network #tbt #hikingadventures #CodeWithUs #DevCommunity #techtankers #techtanktoronto #slackcommunity #techtanker #developer #yyz #torontoevents #torontonetworking #datank #tb #throwback #throwbackmemories📷❤️ #throwback😍 #throwbackpicture",
+    caption:
+      "Join the TechTank community and relive those epic summertime adventures with us! 🌞🌲\n#ThrowbackThursday to sunny hikes and great outdoor memories. Let’s create more together! 🌳🌐\n#TechTank #TechCommunity #SummerVibes #TechTankTo #Hiking #GoodVibesOnly #MeetPeople #Network #tbt #hikingadventures #CodeWithUs #DevCommunity #techtankers #techtanktoronto #slackcommunity #techtanker #developer #yyz #torontoevents #torontonetworking #datank #tb #throwback #throwbackmemories📷❤️ #throwback😍 #throwbackpicture",
     date: "2024-06-06",
     shortcode: "C74av1COssc",
     pk: 18074119408503704,
     createdAtRaw: 1717692990,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-06-C74av1COssc/techtankto_C74av1COssc_3384572755939347228.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-06-C74av1COssc/techtankto_C74av1COssc_3384572755939347228.webp",
+      },
+    ],
   },
   "2024-06-07-C767bHluU6M": {
-    caption: "💼 Tips for Networking Success\nRecap notes from Study Tank: Networking 101 by Sammy Lam\n1️⃣ Be Authentic: Genuine interactions are more memorable and build stronger relationships.\n2️⃣ Follow Up: After initial meetings, follow up to maintain the connection and express your interest.\n3️⃣ Diversify Your Network: Connect with people from various backgrounds and roles to gain diverse insights and opportunities.\n4️⃣ Leverage Social Media: Use platforms like LinkedIn to stay connected and informed about industry trends and opportunities.\n5️⃣ Prepare for Conversations: Have a clear idea of what you want to discuss and what you hope to achieve from each networking interaction.\n6️⃣ Show Appreciation: Thank people for their time and insights, reinforcing a positive impression.\nBy applying these strategies and tips, you can enhance your networking efforts and build a robust professional network that supports your career growth. Let‘s thrive together! 🌟\nCheck out our bio @TechTankTo to watch the full recording of our previous StudyTank session on our YouTube channel\n❗️If you found these tips helpful, don‘t forget to save this post on your Instagram for future reference! ✅\n#TechTank #NetworkingSuccess #CareerGrowth #TechTankTo #techtankers #ProfessionalDevelopment #NetworkingTips #Authenticity #DiverseNetwork #toronto #Preparation #tech #slack #studytank #coders #developers #devcommunity #codewithus #meetpeople #network #coding #Appreciation #StayConnected #ThriveTogether",
+    caption:
+      "💼 Tips for Networking Success\nRecap notes from Study Tank: Networking 101 by Sammy Lam\n1️⃣ Be Authentic: Genuine interactions are more memorable and build stronger relationships.\n2️⃣ Follow Up: After initial meetings, follow up to maintain the connection and express your interest.\n3️⃣ Diversify Your Network: Connect with people from various backgrounds and roles to gain diverse insights and opportunities.\n4️⃣ Leverage Social Media: Use platforms like LinkedIn to stay connected and informed about industry trends and opportunities.\n5️⃣ Prepare for Conversations: Have a clear idea of what you want to discuss and what you hope to achieve from each networking interaction.\n6️⃣ Show Appreciation: Thank people for their time and insights, reinforcing a positive impression.\nBy applying these strategies and tips, you can enhance your networking efforts and build a robust professional network that supports your career growth. Let‘s thrive together! 🌟\nCheck out our bio @TechTankTo to watch the full recording of our previous StudyTank session on our YouTube channel\n❗️If you found these tips helpful, don‘t forget to save this post on your Instagram for future reference! ✅\n#TechTank #NetworkingSuccess #CareerGrowth #TechTankTo #techtankers #ProfessionalDevelopment #NetworkingTips #Authenticity #DiverseNetwork #toronto #Preparation #tech #slack #studytank #coders #developers #devcommunity #codewithus #meetpeople #network #coding #Appreciation #StayConnected #ThriveTogether",
     date: "2024-06-07",
     shortcode: "C767bHluU6M",
     pk: 17999273321398044,
     createdAtRaw: 1717777707,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-07-C767bHluU6M/techtankto_C767bHluU6M_3385279418241470092.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-07-C767bHluU6M/techtankto_C767bHluU6M_3385279418241470092.webp",
+      },
+    ],
   },
   "2024-06-11-C8FNlJBOVSb": {
-    caption: "🔥 Get ready to feast, TechTank crew! 🍔\nWe’re thrilled to announce our epic BBQ fundraiser! Bring your appetite and laughter for an unforgettable start to the long weekend! 🎉\nJoin us on Saturday, June 29th, for mouthwatering BBQ, refreshing drinks, and awesome memories! 🍻 Whether you’re a BBQ enthusiast or just love a good time, we’ve got something for everyone.\nRegister now: http://lu.ma/c6v8k87c (you can also find the direct link on our slack)\nHere’s the info:\n​​Location📍: Toronto - exact location will be shared once you register! ​​When: Saturday, June 29th, 12:30 PM ​​Fee💰: $30 per person* (covers food, rental space and keeps TechTank going for the year) ​​Dress Code: Cozy BBQ vibes 🍖🔥 ​​BYOB🍻 - we’ll be providing soft drinks, but please bring your own beer/alcohol! ​Dietary Restrictions🛑: To ensure we can accommodate for all the registrants’ dietary needs, please make sure you fill out the details about any dietary restrictions/allergies you may have! ​​ ​​​*(NB: If you’re currently not in a place to pay the fee, please contact someone from the admin team and we can find an arrangement for you!)\nSee you soon👋✨\n#TechTank #Summervibes #TechCommunity #TechTankTo #bbq #fundraiser #summer #goodvibesonly #techtankers #toronto #6ix #tech #slack #coders #developers #devcommunity #codewithus #meetpeople #networking #network #softwareengineer #techevents #Meetup #TorontoEvents",
+    caption:
+      "🔥 Get ready to feast, TechTank crew! 🍔\nWe’re thrilled to announce our epic BBQ fundraiser! Bring your appetite and laughter for an unforgettable start to the long weekend! 🎉\nJoin us on Saturday, June 29th, for mouthwatering BBQ, refreshing drinks, and awesome memories! 🍻 Whether you’re a BBQ enthusiast or just love a good time, we’ve got something for everyone.\nRegister now: http://lu.ma/c6v8k87c (you can also find the direct link on our slack)\nHere’s the info:\n​​Location📍: Toronto - exact location will be shared once you register! ​​When: Saturday, June 29th, 12:30 PM ​​Fee💰: $30 per person* (covers food, rental space and keeps TechTank going for the year) ​​Dress Code: Cozy BBQ vibes 🍖🔥 ​​BYOB🍻 - we’ll be providing soft drinks, but please bring your own beer/alcohol! ​Dietary Restrictions🛑: To ensure we can accommodate for all the registrants’ dietary needs, please make sure you fill out the details about any dietary restrictions/allergies you may have! ​​ ​​​*(NB: If you’re currently not in a place to pay the fee, please contact someone from the admin team and we can find an arrangement for you!)\nSee you soon👋✨\n#TechTank #Summervibes #TechCommunity #TechTankTo #bbq #fundraiser #summer #goodvibesonly #techtankers #toronto #6ix #tech #slack #coders #developers #devcommunity #codewithus #meetpeople #networking #network #softwareengineer #techevents #Meetup #TorontoEvents",
     date: "2024-06-11",
     shortcode: "C8FNlJBOVSb",
     pk: 18010803482426692,
     createdAtRaw: 1718121949,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-11-C8FNlJBOVSb/techtankto_C8FNlJBOVSb_3388174021575660699.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-11-C8FNlJBOVSb/techtankto_C8FNlJBOVSb_3388174021575660699.webp",
+      },
+    ],
   },
   "2024-06-17-C8KZhuXOWi": {
-    caption: "Throwback to the epic 1-year anniversary party for TechTank back in April! 🎉🕺💃🕴👯🏽‍♂️\nWe’re the ultimate party tech crew, and guess what?\nOur next social event is a BBQ! 🍖\n🔥 Don’t miss out—sign up now and join the fun!\n#ThrowbackThursday #TechTank #PartyTech #tbt #TechCommunity #TechTankTo #thursday #tb #throwback #summer #goodvibesonly #techtankers #toronto #6ix #tech #slack #coders #softwareengineers #developers #devcommunity #codewithus #meetpeople #network #coding #networking #techevents #Meetup #TorontoEvents",
+    caption:
+      "Throwback to the epic 1-year anniversary party for TechTank back in April! 🎉🕺💃🕴👯🏽‍♂️\nWe’re the ultimate party tech crew, and guess what?\nOur next social event is a BBQ! 🍖\n🔥 Don’t miss out—sign up now and join the fun!\n#ThrowbackThursday #TechTank #PartyTech #tbt #TechCommunity #TechTankTo #thursday #tb #throwback #summer #goodvibesonly #techtankers #toronto #6ix #tech #slack #coders #softwareengineers #developers #devcommunity #codewithus #meetpeople #network #coding #networking #techevents #Meetup #TorontoEvents",
     date: "2024-06-17",
     shortcode: "C8KZhuXO_Wi",
     pk: 18051044986663237,
     createdAtRaw: 1718659088,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-17-C8KZhuXOWi/techtankto_C8KZhuXO_Wi_3389633938237158818.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-06-17-C8KZhuXOWi/techtankto_C8KZhuXO_Wi_3389633938237158818.webp" },
+    ],
   },
   "2024-06-17-C8U41WLPrxq": {
-    caption: "Pride Month with TechTank's Code Diversity Group! 🏳️‍🌈🌈👥\nWe're dedicated to celebrating women and gender-diverse folks in tech, promoting inclusivity and diversity.\nConnect, learn, and grow with us. 🐠🐟🐠\nThis month we had an amazing discussion about valuing ourselves. Tips on salary and job negotiations ‼\n\"How strong the reserves upon which draw you never realize until you need them, but believe me they do not fail you.\" Odette Sanson  Don’t miss our next in-person meetup—join our Slack now!   #PrideMonth #TechTank #CodeDiversity #InclusiveTech #WomenInTech #NonBinaryInTech #Meetup #techtanktoronto #Techtankto #OdetteSanson #value #knowyourworth #techtanker #techtankers #tech #lgbtqtech #proud #nonbinary #nonbinaryintech #strongwomen #community #diversity #inclusivity  -------- Meta: date(YYYY-MM-DD): 2024-06-17 shortcode: C8U41WLPrxq pk: 18062472175566173 created_at_raw: 1718648654 ",
+    caption:
+      "Pride Month with TechTank's Code Diversity Group! 🏳️‍🌈🌈👥\nWe're dedicated to celebrating women and gender-diverse folks in tech, promoting inclusivity and diversity.\nConnect, learn, and grow with us. 🐠🐟🐠\nThis month we had an amazing discussion about valuing ourselves. Tips on salary and job negotiations ‼\n\"How strong the reserves upon which draw you never realize until you need them, but believe me they do not fail you.\" Odette Sanson  Don’t miss our next in-person meetup—join our Slack now!   #PrideMonth #TechTank #CodeDiversity #InclusiveTech #WomenInTech #NonBinaryInTech #Meetup #techtanktoronto #Techtankto #OdetteSanson #value #knowyourworth #techtanker #techtankers #tech #lgbtqtech #proud #nonbinary #nonbinaryintech #strongwomen #community #diversity #inclusivity  -------- Meta: date(YYYY-MM-DD): 2024-06-17 shortcode: C8U41WLPrxq pk: 18062472175566173 created_at_raw: 1718648654 ",
     media: [
-      { type: "image", path: "/media/instagram/2024-06-17-C8U41WLPrxq/techtankto_C8U41WLPrxq_3392586375864695914.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-17-C8U41WLPrxq/techtankto_C8U41WLPrxq_3392586375864695914.webp",
+      },
+    ],
   },
   "2024-06-19-C8Z1p08ODt7": {
-    caption: "🌈 Resource Share - New Report by Queertech 🌈\nQueering the Tech Ecosystem: Barriers and Opportunities\nWe are excited to share the release of a groundbreaking report by QueerTech that highlights the experiences of 2SLGBTQ+ individuals in the tech industry. This extensive research uncovers unique challenges and opportunities within the community.\n❤🧡💛💚💙💜🤎🖤🤍\n🔑 Key findings include: 👇\n🔴 Underrepresentation in the tech workforce (6-8%) and leadership (0.6-3%).🟢\n🟠 High rates of discrimination and harassment in job interviews and workplaces.🔵\n🟡 Decline of women in tech leadership, with only 1% of 2SLGBTQIA+ women in line for senior management.🟣\nOur goal is to raise awareness and drive real, positive change. The report offers actionable recommendations for tech companies to improve recruitment, retention, and workplace culture for 2SLGBTQ+ individuals. ❕🏳️‍🌈🏳️‍⚧️\nJoin us in building a tech industry that values diversity, inclusivity, and empathy. 🫂\nLearn more about the findings and recommendations: 🔗www.queertech.info/QueeringTechReport\n🐠🐟At TechTank, we are dedicated to promoting innovation and inclusivity in the tech sector. By sharing resources like this important report, we aim to empower all individuals, regardless of their background, to thrive in tech. 🧑‍💻👩‍💻👨‍💻\nTogether, we can create a more equitable and diverse industry. 🌟 💪💪🏻💪🏿💪🏼💪🏾💪🏽🦾\n#TechDiversity #LGBTQinTech #InclusionMatters #Pride2024 #QueerTech #TechTank #TechInnovation #TechInclusivity #techtankto #techtanktoronto #techtanker #techtankers #beproud #queerreads #tech #devcommunity #devlife #developers #swe #software #techindustry #jobmarket #statistics #queerstats",
+    caption:
+      "🌈 Resource Share - New Report by Queertech 🌈\nQueering the Tech Ecosystem: Barriers and Opportunities\nWe are excited to share the release of a groundbreaking report by QueerTech that highlights the experiences of 2SLGBTQ+ individuals in the tech industry. This extensive research uncovers unique challenges and opportunities within the community.\n❤🧡💛💚💙💜🤎🖤🤍\n🔑 Key findings include: 👇\n🔴 Underrepresentation in the tech workforce (6-8%) and leadership (0.6-3%).🟢\n🟠 High rates of discrimination and harassment in job interviews and workplaces.🔵\n🟡 Decline of women in tech leadership, with only 1% of 2SLGBTQIA+ women in line for senior management.🟣\nOur goal is to raise awareness and drive real, positive change. The report offers actionable recommendations for tech companies to improve recruitment, retention, and workplace culture for 2SLGBTQ+ individuals. ❕🏳️‍🌈🏳️‍⚧️\nJoin us in building a tech industry that values diversity, inclusivity, and empathy. 🫂\nLearn more about the findings and recommendations: 🔗www.queertech.info/QueeringTechReport\n🐠🐟At TechTank, we are dedicated to promoting innovation and inclusivity in the tech sector. By sharing resources like this important report, we aim to empower all individuals, regardless of their background, to thrive in tech. 🧑‍💻👩‍💻👨‍💻\nTogether, we can create a more equitable and diverse industry. 🌟 💪💪🏻💪🏿💪🏼💪🏾💪🏽🦾\n#TechDiversity #LGBTQinTech #InclusionMatters #Pride2024 #QueerTech #TechTank #TechInnovation #TechInclusivity #techtankto #techtanktoronto #techtanker #techtankers #beproud #queerreads #tech #devcommunity #devlife #developers #swe #software #techindustry #jobmarket #statistics #queerstats",
     date: "2024-06-19",
     shortcode: "C8Z1p08ODt7",
     pk: 17859828264176375,
     createdAtRaw: 1718813938,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-19-C8Z1p08ODt7/techtankto_C8Z1p08ODt7_3393979765008907131.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-19-C8Z1p08ODt7/techtankto_C8Z1p08ODt7_3393979765008907131.webp",
+      },
+    ],
   },
   "2024-06-21-C8e9VlsOwo": {
-    caption: "🎙️ Dive into the making of Guppy Talks our podcast! 🏊‍♂️🏊‍♀️🏊\nBehind the scenes as we unravel...\n💻 software engineering,\n📡 tech trends,\n📑 and work-life culture.\n👨‍💻👩‍💻🧑‍💻\nStay tuned for our latest episode! 🎤🎞\n🔍Let's see whats comes up next in our fishbowl of tech related topics.\nCheck the LIW in bio👇 or\n🔗podcasters.spotify.com/pod/show/techtank6\n🐟 🐠 🎏\n#GuppyTalks #PodcastLife #TechPodcast #TECHTANK #techtanktoronto #techtankto #techtankers #techtanker #SoftwareEngineering #WorkLifeBalance #coding #BehindTheScenes #PodcastProduction #TechTrends #StayTuned #PodcastersOfInstagram #TechDiscussion #Innovation #DigitalTransformation #GeekOut #PodcastingCommunity #TechCulture #PodcastCreators #GuppyPodcast #TechTopics #BehindTheMic #InDepthConversations #frontend #backend #InclusiveTech",
+    caption:
+      "🎙️ Dive into the making of Guppy Talks our podcast! 🏊‍♂️🏊‍♀️🏊\nBehind the scenes as we unravel...\n💻 software engineering,\n📡 tech trends,\n📑 and work-life culture.\n👨‍💻👩‍💻🧑‍💻\nStay tuned for our latest episode! 🎤🎞\n🔍Let's see whats comes up next in our fishbowl of tech related topics.\nCheck the LIW in bio👇 or\n🔗podcasters.spotify.com/pod/show/techtank6\n🐟 🐠 🎏\n#GuppyTalks #PodcastLife #TechPodcast #TECHTANK #techtanktoronto #techtankto #techtankers #techtanker #SoftwareEngineering #WorkLifeBalance #coding #BehindTheScenes #PodcastProduction #TechTrends #StayTuned #PodcastersOfInstagram #TechDiscussion #Innovation #DigitalTransformation #GeekOut #PodcastingCommunity #TechCulture #PodcastCreators #GuppyPodcast #TechTopics #BehindTheMic #InDepthConversations #frontend #backend #InclusiveTech",
     date: "2024-06-21",
     shortcode: "C8e9VlsOwo_",
     pk: 18328289557133984,
     createdAtRaw: 1718986684,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-21-C8e9VlsOwo/techtankto_C8e9VlsOwo__3395420933500635711.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-06-21-C8e9VlsOwo/techtankto_C8e9VlsOwo__3395420933500635711.webp" },
+    ],
   },
   "2024-06-24-C8msrFGOihO": {
-    caption: "QA on Monday morning finding another bug like... 🐡\nBack to testing I guess... software never ends! 😪\n#techtank #techtanktoronto #techtankto #techtankers #techtanker #DevLife #mondayblues #qa #developerhumor #codebug #blobfish #buglife #testingtime #devproblems #programmerhumour #debugging #codequality #techlife #Software #devmemes #qatesting #ithumour #codinglife #programmerproblems #Developer\n#softwaredeveloper #qualityassurance #bughunting",
+    caption:
+      "QA on Monday morning finding another bug like... 🐡\nBack to testing I guess... software never ends! 😪\n#techtank #techtanktoronto #techtankto #techtankers #techtanker #DevLife #mondayblues #qa #developerhumor #codebug #blobfish #buglife #testingtime #devproblems #programmerhumour #debugging #codequality #techlife #Software #devmemes #qatesting #ithumour #codinglife #programmerproblems #Developer\n#softwaredeveloper #qualityassurance #bughunting",
     date: "2024-06-24",
     shortcode: "C8msrFGOihO",
     pk: 18081122857470135,
     createdAtRaw: 1719245655,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-24-C8msrFGOihO/techtankto_C8msrFGOihO_3397599443354789966.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-24-C8msrFGOihO/techtankto_C8msrFGOihO_3397599443354789966.webp",
+      },
+    ],
   },
   "2024-06-25-C8p7857AnMc": {
-    caption: "🌈 Honoring Lynn Conway: a trailblazer in computer science and a fearless advocate for transgender rights.\nFrom pioneering microchip design to championing inclusivity in STEM, Lynn's legacy shines brightly. Her groundbreaking work, including co-developing the VLSI method, transformed chip design forever, making technology accessible to all. 💻✨\nBeyond her technical prowess, Lynn's journey as a transgender woman inspires. Despite challenges, she rose as an academic leader and a prominent voice for equality. Her resilience reminds us of the power of diversity in innovation. 💪🏳️‍⚧️\nToday, we celebrate Lynn Conway's remarkable contributions and commitment to progress. She will be deeply missed, but her impact lives on. 🌍\nTechTank is celebrating Lynn Conway's Legacy as a revolutionary innovator.\nPioneered Microchip Design: Co-developed VLSI method, democratizing chip design.\nMead-Conway Revolution: Standardized microchip design education, influencing thousands of students.\nAcademic Leader University of Michigan: Associate Dean & influential faculty member (1985-1998). Key Positions: NSF Chief Scientist, DARPA Assistant Director, MIT Visiting Professor.\nHonors: 5 U.S. patents, Member of National Academy of Engineering, numerous honorary doctorates. Transgender Rights Advocate\nEarly Transition: One of the first Americans to undergo modern gender transition.\nAdvocacy: Became a prominent voice for transgender rights and women in STEM.\nA true #Legacy of Inspiration\n#TechTank #LynnConway #WomenInSTEM #TransRights #TechPioneer #Inspiration #DiversityInTech #Memorial #LGBTQInTech #Innovators #EqualityInTech #Empowerment #TechCommunity",
+    caption:
+      "🌈 Honoring Lynn Conway: a trailblazer in computer science and a fearless advocate for transgender rights.\nFrom pioneering microchip design to championing inclusivity in STEM, Lynn's legacy shines brightly. Her groundbreaking work, including co-developing the VLSI method, transformed chip design forever, making technology accessible to all. 💻✨\nBeyond her technical prowess, Lynn's journey as a transgender woman inspires. Despite challenges, she rose as an academic leader and a prominent voice for equality. Her resilience reminds us of the power of diversity in innovation. 💪🏳️‍⚧️\nToday, we celebrate Lynn Conway's remarkable contributions and commitment to progress. She will be deeply missed, but her impact lives on. 🌍\nTechTank is celebrating Lynn Conway's Legacy as a revolutionary innovator.\nPioneered Microchip Design: Co-developed VLSI method, democratizing chip design.\nMead-Conway Revolution: Standardized microchip design education, influencing thousands of students.\nAcademic Leader University of Michigan: Associate Dean & influential faculty member (1985-1998). Key Positions: NSF Chief Scientist, DARPA Assistant Director, MIT Visiting Professor.\nHonors: 5 U.S. patents, Member of National Academy of Engineering, numerous honorary doctorates. Transgender Rights Advocate\nEarly Transition: One of the first Americans to undergo modern gender transition.\nAdvocacy: Became a prominent voice for transgender rights and women in STEM.\nA true #Legacy of Inspiration\n#TechTank #LynnConway #WomenInSTEM #TransRights #TechPioneer #Inspiration #DiversityInTech #Memorial #LGBTQInTech #Innovators #EqualityInTech #Empowerment #TechCommunity",
     date: "2024-06-25",
     shortcode: "C8p7857AnMc",
     pk: 18062164441588673,
     createdAtRaw: 1719354112,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-25-C8p7857AnMc/techtankto_C8p7857AnMc_3398511056962745510.webp" },
-      { type: "image", path: "/media/instagram/2024-06-25-C8p7857AnMc/techtankto_C8p7857AnMc_3398511057105558154.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-25-C8p7857AnMc/techtankto_C8p7857AnMc_3398511056962745510.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-25-C8p7857AnMc/techtankto_C8p7857AnMc_3398511057105558154.webp",
+      },
+    ],
   },
   "2024-06-26-C8sVauPXkc": {
-    caption: "🌈 Happy Pride! 🌈\nExcited to share an amazing opportunity for our 2SLGBTQIA+ community members! Whether you’re a seasoned AI/Tech professional or simply passionate about these fields, we encourage you to join 🏳️‍⚧️\nCohere’s annual Pride Camp celebrates creating space, longevity, and stability for queer folks in AI/Tech. Can’t attend in person? No worries! Join the livestream on Thursday, June 27, from 3:45 PM - 6:30 PM ET. 📅\nEvent link:\nhttps://www.linkedin.com/events/7210016485178556416/\nExpand your network, gain new perspectives, and connect with like-minded individuals. This year, they have a special keynote from @naoufelt, co-founder and CEO of QueerTech, along with a thought-provoking panel discussion on creating space and stability for our queer selves in the evolving AI/Tech landscape.\nShare this with anyone who might benefit! 🏳️‍🌈💻\n#Pride2024 #2SLGBTQIA #AI #Tech #CoherePrideCamp #Cohere #Inspiration #DiversityInTech #LGBTQInTech #EqualityInTech #Empowerment #TechCommunity #TechTank #TechTankTo #techtanktoronto #Toronto #techevents #TorontoEvents",
+    caption:
+      "🌈 Happy Pride! 🌈\nExcited to share an amazing opportunity for our 2SLGBTQIA+ community members! Whether you’re a seasoned AI/Tech professional or simply passionate about these fields, we encourage you to join 🏳️‍⚧️\nCohere’s annual Pride Camp celebrates creating space, longevity, and stability for queer folks in AI/Tech. Can’t attend in person? No worries! Join the livestream on Thursday, June 27, from 3:45 PM - 6:30 PM ET. 📅\nEvent link:\nhttps://www.linkedin.com/events/7210016485178556416/\nExpand your network, gain new perspectives, and connect with like-minded individuals. This year, they have a special keynote from @naoufelt, co-founder and CEO of QueerTech, along with a thought-provoking panel discussion on creating space and stability for our queer selves in the evolving AI/Tech landscape.\nShare this with anyone who might benefit! 🏳️‍🌈💻\n#Pride2024 #2SLGBTQIA #AI #Tech #CoherePrideCamp #Cohere #Inspiration #DiversityInTech #LGBTQInTech #EqualityInTech #Empowerment #TechCommunity #TechTank #TechTankTo #techtanktoronto #Toronto #techevents #TorontoEvents",
     date: "2024-06-26",
     shortcode: "C8sV_auPXkc",
     pk: 18043199395865191,
@@ -283,52 +379,69 @@ const instagramPosts: Record<string, InstagramPost> = {
     media: [
       { type: "image", path: "/media/instagram/2024-06-26-C8sVauPXkc/techtankto_C8r3lUiuDw-_3399054801017257022.webp" },
       { type: "image", path: "/media/instagram/2024-06-26-C8sVauPXkc/techtankto_C8sV_auPXkc_3399188529236874811.webp" },
-      { type: "image", path: "/media/instagram/2024-06-26-C8sVauPXkc/techtankto_C8sV_auPXkc_3399188529287030092.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-06-26-C8sVauPXkc/techtankto_C8sV_auPXkc_3399188529287030092.webp" },
+    ],
   },
   "2024-06-28-C8xTWmAvRv": {
-    caption: "🌈 Our Right to Be. Our Place to Be. Our Time to Be. 🌈\nAs we come to the end of Pride month, we reflect on the power of our collective voice. United, we fight to exist without adversity. Holding space for one another, we create safety in the communities we build. Celebrating the triumphs of generations before us, we continue their legacy for a future where we can all simply be.\nWe are here, and we always will be. 🌟\nOur celebration doesn’t end in June. ❗️\nAt TechTank, we aim to amplify and highlight our 2SLGBTQIA+ and other underserved communities all throughout the year. 🐠 🐟 🐠 🏳️‍🌈🏳️‍⚧️\nWe also asked people in our community to share their own version of “Be + ___,” expressing the importance of an inclusive tech community to them.\n🩷❤️🧡💛💚🩵💙💜🖤🩶🤍🤎\nHappy Pride and have a safe and fun Pride weekend! 🎉🏳️‍🌈\n#Pride #OurRightToBe #OurPlaceToBe #OurTimeToBe #2SLGBTQIA+ #Pride2024 #CelebratePride #techtankers #techtanker #InclusiveCommunity #TechTank #techtankto #TechForAll #DiversityInTech #techdiversity #inclusiveinnovation #devcommunity #toronto #nonprofit #community #pride #proud #be",
+    caption:
+      "🌈 Our Right to Be. Our Place to Be. Our Time to Be. 🌈\nAs we come to the end of Pride month, we reflect on the power of our collective voice. United, we fight to exist without adversity. Holding space for one another, we create safety in the communities we build. Celebrating the triumphs of generations before us, we continue their legacy for a future where we can all simply be.\nWe are here, and we always will be. 🌟\nOur celebration doesn’t end in June. ❗️\nAt TechTank, we aim to amplify and highlight our 2SLGBTQIA+ and other underserved communities all throughout the year. 🐠 🐟 🐠 🏳️‍🌈🏳️‍⚧️\nWe also asked people in our community to share their own version of “Be + ___,” expressing the importance of an inclusive tech community to them.\n🩷❤️🧡💛💚🩵💙💜🖤🩶🤍🤎\nHappy Pride and have a safe and fun Pride weekend! 🎉🏳️‍🌈\n#Pride #OurRightToBe #OurPlaceToBe #OurTimeToBe #2SLGBTQIA+ #Pride2024 #CelebratePride #techtankers #techtanker #InclusiveCommunity #TechTank #techtankto #TechForAll #DiversityInTech #techdiversity #inclusiveinnovation #devcommunity #toronto #nonprofit #community #pride #proud #be",
     date: "2024-06-28",
     shortcode: "C8xTWmAv-Rv",
     pk: 18232955245284006,
     createdAtRaw: 1719601522,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-28-C8xTWmAvRv/techtankto_C8xTWmAv-Rv_3400584309168399471.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-06-28-C8xTWmAvRv/techtankto_C8xTWmAv-Rv_3400584309168399471.webp" },
+    ],
   },
   "2024-06-28-C8xVNklv28l": {
-    caption: "🌈 Be Kind. Be Respectful. 🌈\nAs we come to the end of Pride month, we reflect on the inspiring messages from our community. 📝\nChristine’s words, “Be Kind. Be Respectful,” remind us of the core values that strengthen our inclusive tech community at TechTank.\nUnited, we fight to exist without adversity. Holding space for one another, we create safety in the communities we build. 🫂\nCelebrating the triumphs of generations before us, we continue their legacy for a future where we can all simply be. 🌈\nWe are here, and we always will be. 🌟\nOur celebration doesn’t end in June. At TechTank, we aim to amplify and highlight our 2SLGBTQIA+ and other underserved communities all throughout the year.\nHappy Pride and have a safe and fun Pride weekend! 🎉🏳️‍🌈\n#Pride #BeKindBeRespectful #2SLGBTQIA+ #Pride2024 #CelebratePride #InclusiveCommunity #Techtank #TechForAll #DiversityInTech #Techtankers #InclusiveInnovation #techtankto #techtanker #techtanktoronto #toronto #yyz #rainbow #pridemonth #prideally🏳️‍🌈 #prideallyear #proud #respectfully #be #respect #kind #safeprideplace",
+    caption:
+      "🌈 Be Kind. Be Respectful. 🌈\nAs we come to the end of Pride month, we reflect on the inspiring messages from our community. 📝\nChristine’s words, “Be Kind. Be Respectful,” remind us of the core values that strengthen our inclusive tech community at TechTank.\nUnited, we fight to exist without adversity. Holding space for one another, we create safety in the communities we build. 🫂\nCelebrating the triumphs of generations before us, we continue their legacy for a future where we can all simply be. 🌈\nWe are here, and we always will be. 🌟\nOur celebration doesn’t end in June. At TechTank, we aim to amplify and highlight our 2SLGBTQIA+ and other underserved communities all throughout the year.\nHappy Pride and have a safe and fun Pride weekend! 🎉🏳️‍🌈\n#Pride #BeKindBeRespectful #2SLGBTQIA+ #Pride2024 #CelebratePride #InclusiveCommunity #Techtank #TechForAll #DiversityInTech #Techtankers #InclusiveInnovation #techtankto #techtanker #techtanktoronto #toronto #yyz #rainbow #pridemonth #prideally🏳️‍🌈 #prideallyear #proud #respectfully #be #respect #kind #safeprideplace",
     date: "2024-06-28",
     shortcode: "C8xVNklv28l",
     pk: 18082877032485480,
     createdAtRaw: 1719602628,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-28-C8xVNklv28l/techtankto_C8xVNklv28l_3400592485259374373.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-28-C8xVNklv28l/techtankto_C8xVNklv28l_3400592485259374373.webp",
+      },
+    ],
   },
   "2024-06-28-C8xWT8nPYJ1": {
-    caption: "🌈 Be in Tune with the Light Inside You and Shine! 🌈\nAs we come to the end of Pride month, we reflect on the inspiring messages from our community. 💡\nLeslie’s words, “Be in tune with the light inside you and shine!” remind us of the brilliance and strength within each of us at TechTank 🙌\nUnited, we fight to exist without adversity. Holding space for one another, we create safety in the communities we build. 🫂\nCelebrating the triumphs of generations before us, we continue their legacy for a future where we can all simply be.\n❤️🧡💛💚🩵💙🩷💜🖤🩶🤍🤎\nWe are here, and we always will be. 🌟\nOur celebration doesn’t end in June. 🌈🌈🌈\nAt TechTank, we aim to amplify and highlight our 2SLGBTQIA+ and other underserved communities all throughout the year.\nHappy Pride and have a safe and fun Pride weekend! 🎉🏳️‍🌈\n#Pride #BeInTune #ShineBright #2SLGBTQIA+ #Pride2024 #CelebratePride #InclusiveCommunity #Techtank #TechForAll #DiversityInTech #TechtankPride #InclusiveInnovation #Be #pridemonth #pride🌈 #ally #toronto #techtankto #techtanktoronto #techtanker #techtankers #loveislove #prideparade #besafe #prideweekend #prideallyear #bethelight",
+    caption:
+      "🌈 Be in Tune with the Light Inside You and Shine! 🌈\nAs we come to the end of Pride month, we reflect on the inspiring messages from our community. 💡\nLeslie’s words, “Be in tune with the light inside you and shine!” remind us of the brilliance and strength within each of us at TechTank 🙌\nUnited, we fight to exist without adversity. Holding space for one another, we create safety in the communities we build. 🫂\nCelebrating the triumphs of generations before us, we continue their legacy for a future where we can all simply be.\n❤️🧡💛💚🩵💙🩷💜🖤🩶🤍🤎\nWe are here, and we always will be. 🌟\nOur celebration doesn’t end in June. 🌈🌈🌈\nAt TechTank, we aim to amplify and highlight our 2SLGBTQIA+ and other underserved communities all throughout the year.\nHappy Pride and have a safe and fun Pride weekend! 🎉🏳️‍🌈\n#Pride #BeInTune #ShineBright #2SLGBTQIA+ #Pride2024 #CelebratePride #InclusiveCommunity #Techtank #TechForAll #DiversityInTech #TechtankPride #InclusiveInnovation #Be #pridemonth #pride🌈 #ally #toronto #techtankto #techtanktoronto #techtanker #techtankers #loveislove #prideparade #besafe #prideweekend #prideallyear #bethelight",
     date: "2024-06-28",
     shortcode: "C8xWT8nPYJ1",
     pk: 18065039299512274,
     createdAtRaw: 1719603102,
     media: [
-      { type: "image", path: "/media/instagram/2024-06-28-C8xWT8nPYJ1/techtankto_C8uZtfxOeCd_3399767846362407069.webp" },
-      { type: "image", path: "/media/instagram/2024-06-28-C8xWT8nPYJ1/techtankto_C8xWT8nPYJ1_3400597321417589365.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-28-C8xWT8nPYJ1/techtankto_C8uZtfxOeCd_3399767846362407069.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-06-28-C8xWT8nPYJ1/techtankto_C8xWT8nPYJ1_3400597321417589365.webp",
+      },
+    ],
   },
   "2024-07-03-C892aoWOtZy": {
-    caption: "🌟 Event Alert by TechTank 🌟\nJoin us for our Monthly in-person Coffee Chat for Women & Gender-Diverse Folks in Tech! ☕✨\n📅 Date: Saturday, July 13 🕚 Time: 11 am 📍 Location: Carbonic Coffee\nTopic: Speaking Up Confidently, Even After Making a Mistake\nLet’s gather for great coffee, new connections, and an inspiring discussion on finding the courage to speak up, even when things don’t go perfectly. As Maggie Kuhn said, “Stand before the people you fear and speak your mind— even if your voice shakes.”\nSchedule: 11:00am - 11:30am - Arrival, grab drinks and snacks, socialize! 11:30am - 1:00pm - Group discussion, paired chats, and activities.\nCome join us and let’s explore this vital skill together! 💬✨\n7 spots left!\n🔗 https://www.meetup.com/techtank-to/events/301852269/\n#TechTank #WomenInTech #NonBinaryInTech #CoffeeChat #SpeakUp #CommunityEvent #CarbonicCoffee #TechTankTo #TechTankToronto #DiversityTech #devcommunity #queertech #techtoronto #techtankers #techtanker #toronto #techgirl #techgirls #techgirlsglobal #coders #queerinstem #queerintech #discussion #mistake #khun #maggiekhun #fear #standup",
+    caption:
+      "🌟 Event Alert by TechTank 🌟\nJoin us for our Monthly in-person Coffee Chat for Women & Gender-Diverse Folks in Tech! ☕✨\n📅 Date: Saturday, July 13 🕚 Time: 11 am 📍 Location: Carbonic Coffee\nTopic: Speaking Up Confidently, Even After Making a Mistake\nLet’s gather for great coffee, new connections, and an inspiring discussion on finding the courage to speak up, even when things don’t go perfectly. As Maggie Kuhn said, “Stand before the people you fear and speak your mind— even if your voice shakes.”\nSchedule: 11:00am - 11:30am - Arrival, grab drinks and snacks, socialize! 11:30am - 1:00pm - Group discussion, paired chats, and activities.\nCome join us and let’s explore this vital skill together! 💬✨\n7 spots left!\n🔗 https://www.meetup.com/techtank-to/events/301852269/\n#TechTank #WomenInTech #NonBinaryInTech #CoffeeChat #SpeakUp #CommunityEvent #CarbonicCoffee #TechTankTo #TechTankToronto #DiversityTech #devcommunity #queertech #techtoronto #techtankers #techtanker #toronto #techgirl #techgirls #techgirlsglobal #coders #queerinstem #queerintech #discussion #mistake #khun #maggiekhun #fear #standup",
     date: "2024-07-03",
     shortcode: "C892aoWOtZy",
     pk: 18038927353789500,
     createdAtRaw: 1720022893,
     media: [
-      { type: "image", path: "/media/instagram/2024-07-03-C892aoWOtZy/techtankto_C892aoWOtZy_3404116217902585458.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-07-03-C892aoWOtZy/techtankto_C892aoWOtZy_3404116217902585458.webp",
+      },
+    ],
   },
   "2024-07-04-C9Aek4COlz": {
-    caption: "🚀 #ThrowbackThursday to an electrifying April when we dove deep into the history of #JavaScript frameworks with amazing @thanniablanchet! 🌟\nAnd guess what? We’re back and ready to blow your minds again this month! 🔥\nJoin us on Tuesday, July 16th, for an evening dedicated to demystifying the art of building your own JavaScript module bundler! 🛠️✨\nWe’re thrilled to welcome Michael Rose, a principal software engineer and front-end enthusiast at Mimecast, who will guide us through the intricacies of creating a mini Webpack from scratch. 🌐🔧\nDon’t miss out!\nRSVP NOW on Meetup\n👉 https://www.meetup.com/techtank-to/events/301699806/ 👈\n#JavaScriptJourney #TankTalks #TechTank #DevCommunity #LearnBuildGrow #JSCompiler #Frontend #Thursday #tb #tbt #Throwback #TechTankers #Toronto #TechCommunity #TechTankTo #TechEvent #Meetpeople #Network #techtankto #techtanktoronto #techtanker #meetup #memories",
+    caption:
+      "🚀 #ThrowbackThursday to an electrifying April when we dove deep into the history of #JavaScript frameworks with amazing @thanniablanchet! 🌟\nAnd guess what? We’re back and ready to blow your minds again this month! 🔥\nJoin us on Tuesday, July 16th, for an evening dedicated to demystifying the art of building your own JavaScript module bundler! 🛠️✨\nWe’re thrilled to welcome Michael Rose, a principal software engineer and front-end enthusiast at Mimecast, who will guide us through the intricacies of creating a mini Webpack from scratch. 🌐🔧\nDon’t miss out!\nRSVP NOW on Meetup\n👉 https://www.meetup.com/techtank-to/events/301699806/ 👈\n#JavaScriptJourney #TankTalks #TechTank #DevCommunity #LearnBuildGrow #JSCompiler #Frontend #Thursday #tb #tbt #Throwback #TechTankers #Toronto #TechCommunity #TechTankTo #TechEvent #Meetpeople #Network #techtankto #techtanktoronto #techtanker #meetup #memories",
     date: "2024-07-04",
     shortcode: "C9Aek4COl-z",
     pk: 18037867567941870,
@@ -339,38 +452,50 @@ const instagramPosts: Record<string, InstagramPost> = {
       { type: "image", path: "/media/instagram/2024-07-04-C9Aek4COlz/techtankto_C9Aek4COl-z_3404855784301601365.webp" },
       { type: "image", path: "/media/instagram/2024-07-04-C9Aek4COlz/techtankto_C9Aek4COl-z_3404855784360124823.webp" },
       { type: "image", path: "/media/instagram/2024-07-04-C9Aek4COlz/techtankto_C9Aek4COl-z_3404855784360217576.webp" },
-      { type: "image", path: "/media/instagram/2024-07-04-C9Aek4COlz/techtankto_C9Aek4COl-z_3404855784402309323.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-07-04-C9Aek4COlz/techtankto_C9Aek4COl-z_3404855784402309323.webp" },
+    ],
   },
   "2024-07-05-C9DFZ0ZOrdB": {
-    caption: "🧑‍💻 👨‍💻 👩‍💻 When you spend all day coding and realize you’ve just been debugging the debugger… #HappyFriday !\n😅\nSometimes it’s a whole day reading and understanding someone else’s code too!\n#developerlife #CodingProblems #Debugging #FridayFeels #DevStruggles #SoftwareDeveloper #CodingLife #TechLife #CodeAllDay #FridayMood #ProgrammingHumor #TechHumor #CoderProblems #DebuggingLife #SoftwareEngineer #CodingCommunity #CodeLife #FridayVibes #DeveloperHumor #WeekendWarrior #techtank #techtankto #techtanktoronto #techtanker #techtankers #toronto",
+    caption:
+      "🧑‍💻 👨‍💻 👩‍💻 When you spend all day coding and realize you’ve just been debugging the debugger… #HappyFriday !\n😅\nSometimes it’s a whole day reading and understanding someone else’s code too!\n#developerlife #CodingProblems #Debugging #FridayFeels #DevStruggles #SoftwareDeveloper #CodingLife #TechLife #CodeAllDay #FridayMood #ProgrammingHumor #TechHumor #CoderProblems #DebuggingLife #SoftwareEngineer #CodingCommunity #CodeLife #FridayVibes #DeveloperHumor #WeekendWarrior #techtank #techtankto #techtanktoronto #techtanker #techtankers #toronto",
     date: "2024-07-05",
     shortcode: "C9DFZ0ZOrdB",
     pk: 17893663280963528,
     createdAtRaw: 1720198633,
     media: [
-      { type: "image", path: "/media/instagram/2024-07-05-C9DFZ0ZOrdB/techtankto_C9DFZ0ZOrdB_3405589507699554113.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-07-05-C9DFZ0ZOrdB/techtankto_C9DFZ0ZOrdB_3405589507699554113.webp",
+      },
+    ],
   },
   "2024-07-08-C9LEpc4vzNp": {
-    caption: "Hedy Lamarr wasn’t just a famous Hollywood actress. She was also a brilliant inventor who changed the world of wireless communication. 🌟 Born in Austria in 1914, she starred in classics like ‘Ziegfeld Girl’ and ‘Algiers.’ 🎬\nDuring World War II, Hedy co-invented a frequency hopping spread spectrum system to prevent radio-controlled torpedoes from being jammed. This innovation became the foundation for modern Wi-Fi, Bluetooth, and GPS. 📡✨\nThough her groundbreaking work was overlooked during her lifetime, Hedy’s contributions are now celebrated as essential to the tech we use every day.\nJoin us for the Women & Gender-Diverse Social this Saturday, July 13th @ 11am! The meetup link can be found in our bio. ❤️\n#HedyLamarr #TechTank #TechPioneer #Innovation #Inspiration #TechTankTo #WiFi #Bluetooth #GPS #WomenInTech #Engineering #TechHistory #WomenHistory #TechCommunity #EngineeringHeroes",
+    caption:
+      "Hedy Lamarr wasn’t just a famous Hollywood actress. She was also a brilliant inventor who changed the world of wireless communication. 🌟 Born in Austria in 1914, she starred in classics like ‘Ziegfeld Girl’ and ‘Algiers.’ 🎬\nDuring World War II, Hedy co-invented a frequency hopping spread spectrum system to prevent radio-controlled torpedoes from being jammed. This innovation became the foundation for modern Wi-Fi, Bluetooth, and GPS. 📡✨\nThough her groundbreaking work was overlooked during her lifetime, Hedy’s contributions are now celebrated as essential to the tech we use every day.\nJoin us for the Women & Gender-Diverse Social this Saturday, July 13th @ 11am! The meetup link can be found in our bio. ❤️\n#HedyLamarr #TechTank #TechPioneer #Innovation #Inspiration #TechTankTo #WiFi #Bluetooth #GPS #WomenInTech #Engineering #TechHistory #WomenHistory #TechCommunity #EngineeringHeroes",
     date: "2024-07-08",
     shortcode: "C9LEpc4vzNp",
     pk: 17870853516131109,
     createdAtRaw: 1720465967,
     media: [
-      { type: "image", path: "/media/instagram/2024-07-08-C9LEpc4vzNp/techtankto_C9LEpc4vzNp_3407837983737328489.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-07-08-C9LEpc4vzNp/techtankto_C9LEpc4vzNp_3407837983737328489.webp",
+      },
+    ],
   },
   "2024-07-10-C9P8eVgOztV": {
-    caption: "Friendly reminder to join us for our Monthly in-person Coffee Chat for Women & Gender-Diverse Folks in Tech coming up this Saturday ☕✨\n🕚 Time: 11 am 📍 Location: Carbonic Coffee\nMain Discussion Topic:\nSpeaking Up Confidently, Even After Making a Mistake\nHave you ever struggled to speak up after making a mistake?\nLet’s talk about it!\nMaggie Kuhn said, “Stand before the people you fear and speak your mind— even if your voice shakes.” This Saturday, we’ll explore how to find the courage to speak confidently, even when things don’t go as planned.\nWhat are your thoughts on this quote?\nHow do you handle speaking up in tough situations?\nShare your experiences with us or come join us for a morning of meaningful discussions, new connections, and, of course, great coffee.\nDon’t miss out—only 4 spots left!\nReservations on the meetup app.👇\n🔗 https://www.meetup.com/techtank-to/events/301852269/\n#TechTank #WomenInTech #NonBinaryInTech #CoffeeChat #SpeakUp #CommunityEvent #CarbonicCoffee #TechTankTo #TechTankToronto #DiversityTech #devcommunity #queertech #techtoronto #techtankers #techtanker #toronto #womensupportingwomen #coders #queerinstem #queerintech #discussion #mistake #khun #maggiekhun #fear #standup #speak #workplace #companyculture #worklife",
+    caption:
+      "Friendly reminder to join us for our Monthly in-person Coffee Chat for Women & Gender-Diverse Folks in Tech coming up this Saturday ☕✨\n🕚 Time: 11 am 📍 Location: Carbonic Coffee\nMain Discussion Topic:\nSpeaking Up Confidently, Even After Making a Mistake\nHave you ever struggled to speak up after making a mistake?\nLet’s talk about it!\nMaggie Kuhn said, “Stand before the people you fear and speak your mind— even if your voice shakes.” This Saturday, we’ll explore how to find the courage to speak confidently, even when things don’t go as planned.\nWhat are your thoughts on this quote?\nHow do you handle speaking up in tough situations?\nShare your experiences with us or come join us for a morning of meaningful discussions, new connections, and, of course, great coffee.\nDon’t miss out—only 4 spots left!\nReservations on the meetup app.👇\n🔗 https://www.meetup.com/techtank-to/events/301852269/\n#TechTank #WomenInTech #NonBinaryInTech #CoffeeChat #SpeakUp #CommunityEvent #CarbonicCoffee #TechTankTo #TechTankToronto #DiversityTech #devcommunity #queertech #techtoronto #techtankers #techtanker #toronto #womensupportingwomen #coders #queerinstem #queerintech #discussion #mistake #khun #maggiekhun #fear #standup #speak #workplace #companyculture #worklife",
     date: "2024-07-10",
     shortcode: "C9P8eVgOztV",
     pk: 18049272550800304,
     createdAtRaw: 1720629454,
     media: [
-      { type: "image", path: "/media/instagram/2024-07-10-C9P8eVgOztV/techtankto_C9P8eVgOztV_3409209410407054165.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-07-10-C9P8eVgOztV/techtankto_C9P8eVgOztV_3409209410407054165.webp",
+      },
+    ],
   },
   "2024-07-13-C9SqlM3PjTw": {
     caption: "#TechTank #TooSweet #JuneMemories",
@@ -379,132 +504,160 @@ const instagramPosts: Record<string, InstagramPost> = {
     pk: 17873495958107150,
     createdAtRaw: 1720892030,
     media: [
-      { type: "image", path: "/media/instagram/2024-07-13-C9SqlM3PjTw/techtankto_C9SqlM3PjTw_3409975142258717936.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-07-13-C9SqlM3PjTw/techtankto_C9SqlM3PjTw_3409975142258717936.webp",
+      },
+    ],
   },
   "2024-07-16-C9AxLY3vh77": {
-    caption: "🚨 Event is back to schedule! 🥂\n🚀 Get ready for an exciting evening of coding and community! 🚀\nJoin us on Tuesday, July 16th at 6 PM at League (225 King St W Suite 800, Toronto, ON M5V 3M2) for a special in-person event featuring Michael Rose. 🌟\n🛠️ Topic: Building a Mini Webpack from Scratch\n🗣️ Speaker: Michael Rose, Principal Software Engineer at Mimecast\n🗓️ Schedule:\n6:00 PM - 6:45 PM: Arrival, food, and socializing 🍕🍻 6:45 PM - 7:45 PM: Announcements and presentation 🎤 7:45 PM - 8:30 PM: Q&A and more socializing 🤝\nDon’t miss out on great conversation, drinks, and the chance to learn how to create your own module bundler! 💻✨\nCheck out the source code and speaker notes here:\n🔗 github.com/msrose/weepack\n#JavaScript #Webpack #CodingEvent #TorontoTech #TechTalk #TechTank #TechTankTo #TechTankToronto #TechTankers #TechTanker #FrontEndDev #SoftwareEngineering #ModuleBundling #WebDevelopment #JSCommunity #LearnToCode #CodeNewbie #TechMeetup #Programming #DeveloperLife #TechCommunity #CodingLife #TechEvents #InPersonEvent #TorontoEvents #TechLearning #JS\n📅 Save the date and see you there! 👋\n✨ Sponsored by League - Leading the way in personalized healthcare experiences. ✨",
+    caption:
+      "🚨 Event is back to schedule! 🥂\n🚀 Get ready for an exciting evening of coding and community! 🚀\nJoin us on Tuesday, July 16th at 6 PM at League (225 King St W Suite 800, Toronto, ON M5V 3M2) for a special in-person event featuring Michael Rose. 🌟\n🛠️ Topic: Building a Mini Webpack from Scratch\n🗣️ Speaker: Michael Rose, Principal Software Engineer at Mimecast\n🗓️ Schedule:\n6:00 PM - 6:45 PM: Arrival, food, and socializing 🍕🍻 6:45 PM - 7:45 PM: Announcements and presentation 🎤 7:45 PM - 8:30 PM: Q&A and more socializing 🤝\nDon’t miss out on great conversation, drinks, and the chance to learn how to create your own module bundler! 💻✨\nCheck out the source code and speaker notes here:\n🔗 github.com/msrose/weepack\n#JavaScript #Webpack #CodingEvent #TorontoTech #TechTalk #TechTank #TechTankTo #TechTankToronto #TechTankers #TechTanker #FrontEndDev #SoftwareEngineering #ModuleBundling #WebDevelopment #JSCommunity #LearnToCode #CodeNewbie #TechMeetup #Programming #DeveloperLife #TechCommunity #CodingLife #TechEvents #InPersonEvent #TorontoEvents #TechLearning #JS\n📅 Save the date and see you there! 👋\n✨ Sponsored by League - Leading the way in personalized healthcare experiences. ✨",
     date: "2024-07-16",
     shortcode: "C9AxLY3vh77",
     pk: 18411075100073582,
     createdAtRaw: 1721156510,
     media: [
-      { type: "image", path: "/media/instagram/2024-07-16-C9AxLY3vh77/techtankto_C9AxLY3vh77_3404937605190393595.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-07-16-C9AxLY3vh77/techtankto_C9AxLY3vh77_3404937605190393595.webp",
+      },
+    ],
   },
   "2024-07-16-C9NDwL7OBFx": {
-    caption: "🚨 Event is back to schedule! 🥂\n🚀 Exciting Event Next Week!🚀\nJoin us for a deep dive into module bundling! 🤿\nLearn how to:\n- Understand module bundling and its role in optimizing front-end apps. - See Webpack in action and even build a module bundler from scratch. - Discover why bundling is essential and how to master it in projects.\nBoost your coding skills and get ready to slice and dice your JavaScript like never before! 🛠️💻\n📅 Event Date: Tuesday, July 16 (doors open 6pm)\n📍 Location: League (225 King St W Suite #800, Toronto, ON M5V 3M2)\n🍻 Details: We’ll have drinks, food, and great conversation to boot.\n🗣️ Speaker: Michael Rose, Principal Software Engineer at Mimecast\n🔗 Source Code and Speaker Notes:\nhttps://github.com/msrose/weepack\nDon’t miss out – see you next week!\n#developerlife #Dev #codingevent #modulebundling #Webpack #JavaScript #FrontendDev #JS #CodingSkills #TechEvent #LearnToCode #WebDevelopment #devlifestyle #codingcommunity #SoftwareEngineering #DevLife #CodeOptimization #TechLearning #WebDevTools #ProgrammingLife #CodeLikeAPro #TechTankTalks #DeveloperEvent #TechTank #TechTankTo #TechTankToronto #TechTalks #TechTanker #TechTankers",
+    caption:
+      "🚨 Event is back to schedule! 🥂\n🚀 Exciting Event Next Week!🚀\nJoin us for a deep dive into module bundling! 🤿\nLearn how to:\n- Understand module bundling and its role in optimizing front-end apps. - See Webpack in action and even build a module bundler from scratch. - Discover why bundling is essential and how to master it in projects.\nBoost your coding skills and get ready to slice and dice your JavaScript like never before! 🛠️💻\n📅 Event Date: Tuesday, July 16 (doors open 6pm)\n📍 Location: League (225 King St W Suite #800, Toronto, ON M5V 3M2)\n🍻 Details: We’ll have drinks, food, and great conversation to boot.\n🗣️ Speaker: Michael Rose, Principal Software Engineer at Mimecast\n🔗 Source Code and Speaker Notes:\nhttps://github.com/msrose/weepack\nDon’t miss out – see you next week!\n#developerlife #Dev #codingevent #modulebundling #Webpack #JavaScript #FrontendDev #JS #CodingSkills #TechEvent #LearnToCode #WebDevelopment #devlifestyle #codingcommunity #SoftwareEngineering #DevLife #CodeOptimization #TechLearning #WebDevTools #ProgrammingLife #CodeLikeAPro #TechTankTalks #DeveloperEvent #TechTank #TechTankTo #TechTankToronto #TechTalks #TechTanker #TechTankers",
     date: "2024-07-16",
     shortcode: "C9NDwL7OBFx",
     pk: 18070593601548595,
     createdAtRaw: 1721156487,
     media: [
-      { type: "image", path: "/media/instagram/2024-07-16-C9NDwL7OBFx/techtankto_C9NDwL7OBFx_3408396998468440433.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-07-16-C9NDwL7OBFx/techtankto_C9NDwL7OBFx_3408396998468440433.webp",
+      },
+    ],
   },
   "2024-07-16-C9c08uPO9f1": {
-    caption: "🎉 Get ready to go for gold, TechTank crew! 🏅\nJoin us for an unforgettable Olympic-themed beach event! 🌊🏖️\nBACK TO OCEAN MANDATE!!\n📍 Location: Toronto Beach (exact spot shared upon registration) 🗓️ Date: Saturday, July 27th ⏰ Time: 3-7PM 👕 Dress Code: Sporty beach vibes! Be ready for games and sun! Optional bathing suits if you want to jump into the water 👙 🍻 BYOB & BYOF: This is a free event! We won’t provide food, but there are BBQs and restaurants around. Bring your own drinks! 🍹\n✨ Can’t wait to dive into fun with you all!\nNote: By signing up, you agree to TechTank’s Sport Waiver. ‼️\n🔗 Register here: lu.ma/55hizq8f?tk=J8MrsV\n#TechTank #TechTankTo #TechTankToronto #TechTankCrew #TechTanker #TechTankers #TechCommunity #Innovation #summer #hellosummer #BeachEvent #TeamBuilding #TechLife #TorontoEvents #Networking #TechEvents #OlympicTheme #SummerFun #BYOB #TechCulture #devcommunity #TechNetworking #funinthesun #BeachVibes #TorontoTech #TechGathering #sportbeach",
+    caption:
+      "🎉 Get ready to go for gold, TechTank crew! 🏅\nJoin us for an unforgettable Olympic-themed beach event! 🌊🏖️\nBACK TO OCEAN MANDATE!!\n📍 Location: Toronto Beach (exact spot shared upon registration) 🗓️ Date: Saturday, July 27th ⏰ Time: 3-7PM 👕 Dress Code: Sporty beach vibes! Be ready for games and sun! Optional bathing suits if you want to jump into the water 👙 🍻 BYOB & BYOF: This is a free event! We won’t provide food, but there are BBQs and restaurants around. Bring your own drinks! 🍹\n✨ Can’t wait to dive into fun with you all!\nNote: By signing up, you agree to TechTank’s Sport Waiver. ‼️\n🔗 Register here: lu.ma/55hizq8f?tk=J8MrsV\n#TechTank #TechTankTo #TechTankToronto #TechTankCrew #TechTanker #TechTankers #TechCommunity #Innovation #summer #hellosummer #BeachEvent #TeamBuilding #TechLife #TorontoEvents #Networking #TechEvents #OlympicTheme #SummerFun #BYOB #TechCulture #devcommunity #TechNetworking #funinthesun #BeachVibes #TorontoTech #TechGathering #sportbeach",
     date: "2024-07-16",
     shortcode: "C9c08uPO9f1",
     pk: 18063194065596977,
     createdAtRaw: 1721095790,
     media: [
-      { type: "image", path: "/media/instagram/2024-07-16-C9c08uPO9f1/techtankto_C9c08uPO9f1_3412835488874878965.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-07-16-C9c08uPO9f1/techtankto_C9c08uPO9f1_3412835488874878965.webp",
+      },
+    ],
   },
   "2024-07-18-C9kpAIONos": {
-    caption: "Throw back to last year’s bowling night fun! 🎳✨ Now it’s all about those sunny patio vibes.\nGet ready for our next outdoor event! 🏅TANKOLYMPICS | Return to Ocean Mandate 🌊\nJoin us for an unforgettable Olympic-themed beach event! Link in our bio 🔗\n#TechTankTo #SummerNights #TechTank #Thursday #tbt #summer #Throwback #TechTankers #Toronto #TechCommunity #TechEvent #Meetpeople #meetup #memories #goodvibesonly",
+    caption:
+      "Throw back to last year’s bowling night fun! 🎳✨ Now it’s all about those sunny patio vibes.\nGet ready for our next outdoor event! 🏅TANKOLYMPICS | Return to Ocean Mandate 🌊\nJoin us for an unforgettable Olympic-themed beach event! Link in our bio 🔗\n#TechTankTo #SummerNights #TechTank #Thursday #tbt #summer #Throwback #TechTankers #Toronto #TechCommunity #TechEvent #Meetpeople #meetup #memories #goodvibesonly",
     date: "2024-07-18",
     shortcode: "C9kpA_IONos",
     pk: 18033533795508278,
     createdAtRaw: 1721323895,
     media: [
       { type: "image", path: "/media/instagram/2024-07-18-C9kpAIONos/techtankto_C9kpA_IONos_3415034798190297072.webp" },
-      { type: "image", path: "/media/instagram/2024-07-18-C9kpAIONos/techtankto_C9kpA_IONos_3415034798307630168.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-07-18-C9kpAIONos/techtankto_C9kpA_IONos_3415034798307630168.webp" },
+    ],
   },
   "2024-07-20-C9nThXfPwQx": {
-    caption: "🎉 Recap Reel - Building a Mini Webpack from Scratch 🎉\n🚨UPDATE: THE EVENT HAPPENED! POWER WAS RESTORED!\nWe had an amazing time this month with Michael Rose’s deep dive into building your own webpack-like JavaScript module bundler!\nDespite the weather issues and flooding in Toronto, we made it work. Huge thanks to League for hosting us and to everyone who came out. #thanks 🌧️ ☔️\n✨ Highlights✨\n🔍 In-Depth Webpack Exploration: Michael’s step-by-step guide on creating a mini Webpack from scratch.\n🌧️ Virtual Welcome: Bhavna Muraleedharan of League greeted us virtually despite the weather conditions. We were super greatly welcomed were able to still use the office to host the event that night!\n🛠️ Hands-On Learning: Practical insights into module bundling and debugging.\n💬 Great Conversations: Engaging discussions on the complexities and solutions in module bundling.\nMissed it?\nWe’ve got you!\nCheck out the source code and speaker notes here by Michael Rose 🔗 https://github.com/msrose/weepack\n📅 See you next month!\nStay tuned on Slack for the YouTube recording and the Google Photos album! 📸\n📹 YouTube @techtankto to all our recording sessions.\n🚀 Don’t miss our next in person event: 🏐 🏖️\nThe Tankolympics on July 27th! ☀️\nRegister now 🔗 lu.ma/55hizq8f?tk=J8MrsV\nOur Sponsor: League is the CX platform that healthcare organizations rely on to create integrated, personalized experiences that people use everyday.\n🔗 league.com/about/\nTypo: What a* 🆒 office!\n#JavaScript #WebDevelopment #FrontendDev #Webpack #CodingLife #TechEvent #DevCommunity #SoftwareEngineering #TechTalks #codenewbie #Programming #TechNetworking #DevMeetup #LearnToCode #TechTank #JSCommunity #WebDev #DeveloperLife #CodeLearning #TorontoTech #TechTankTo #TechTankToronto #TechTankers #TechTanker #JS #webpack #torontoflood",
+    caption:
+      "🎉 Recap Reel - Building a Mini Webpack from Scratch 🎉\n🚨UPDATE: THE EVENT HAPPENED! POWER WAS RESTORED!\nWe had an amazing time this month with Michael Rose’s deep dive into building your own webpack-like JavaScript module bundler!\nDespite the weather issues and flooding in Toronto, we made it work. Huge thanks to League for hosting us and to everyone who came out. #thanks 🌧️ ☔️\n✨ Highlights✨\n🔍 In-Depth Webpack Exploration: Michael’s step-by-step guide on creating a mini Webpack from scratch.\n🌧️ Virtual Welcome: Bhavna Muraleedharan of League greeted us virtually despite the weather conditions. We were super greatly welcomed were able to still use the office to host the event that night!\n🛠️ Hands-On Learning: Practical insights into module bundling and debugging.\n💬 Great Conversations: Engaging discussions on the complexities and solutions in module bundling.\nMissed it?\nWe’ve got you!\nCheck out the source code and speaker notes here by Michael Rose 🔗 https://github.com/msrose/weepack\n📅 See you next month!\nStay tuned on Slack for the YouTube recording and the Google Photos album! 📸\n📹 YouTube @techtankto to all our recording sessions.\n🚀 Don’t miss our next in person event: 🏐 🏖️\nThe Tankolympics on July 27th! ☀️\nRegister now 🔗 lu.ma/55hizq8f?tk=J8MrsV\nOur Sponsor: League is the CX platform that healthcare organizations rely on to create integrated, personalized experiences that people use everyday.\n🔗 league.com/about/\nTypo: What a* 🆒 office!\n#JavaScript #WebDevelopment #FrontendDev #Webpack #CodingLife #TechEvent #DevCommunity #SoftwareEngineering #TechTalks #codenewbie #Programming #TechNetworking #DevMeetup #LearnToCode #TechTank #JSCommunity #WebDev #DeveloperLife #CodeLearning #TorontoTech #TechTankTo #TechTankToronto #TechTankers #TechTanker #JS #webpack #torontoflood",
     date: "2024-07-20",
     shortcode: "C9nThXfPwQx",
     pk: 17945473628827690,
     createdAtRaw: 1721495959,
     media: [
-      { type: "image", path: "/media/instagram/2024-07-20-C9nThXfPwQx/techtankto_C9nThXfPwQx_3415784698230539313.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-07-20-C9nThXfPwQx/techtankto_C9nThXfPwQx_3415784698230539313.webp",
+      },
+    ],
   },
   "2024-07-29-CA1UqhufU": {
-    caption: "🚀✨ Join us for our next in-person panel discussion in the heart of Toronto at the stunning Roof Garden event space! 🌆\n🍃 Get ready for an evening of insightful talks, networking, and learning from AI experts.\n📅 Date: Thursday, August 15th 🕕 Time: Doors open at 6 PM 📍 Location: Roof Garden, 1 Roof Garden Lane, Toronto, ON M6H 1R2 🙏 Thanks to our sponsor: 7Shifts\n🎤 Panelists: - Myles Harrison (he/him) - Consultant and Trainer, NLP From Scratch - Jay Alammar (he/him) - Director and Engineering Fellow, Cohere - Luke Galea (he/him) - CTO, 7Shifts - Ramy ElMallah (he/him) - PhD AI Researcher, University of Toronto - Moderator: Riaz Virani (he/him), Community Organizer @ TechTank\n🗓️ Schedule: - 6:00pm - 6:45pm: Arrival, food, and socializing 🍴🗣️ - 6:45pm - 7:45pm: Announcements & panel discussion 🎙️🧠 - 7:45pm - 8:30pm: More networking & Q&A 🤝❓\nWant to keep the conversation going? Join us at a nearby bar afterward! 🍻\n✨ Sponsor Spotlight: 7Shifts helps restaurants optimize scheduling, streamline communication, and ensure labor compliance. Trusted by over 40,000 restaurants globally! 🍽️👩‍🍳\nDon’t miss out on this fantastic evening! See you there! 💬🤩\n🔗 Register at meetup.com/techtank-to/events/302337555/\n#AI #paneldiscussion #Networking #TorontoEvents #TechTank #InPersonEvent #RoofGarden #AIExperts #TechCommunity #artificialintelligence #Insights #networkingevent #TorontoTech #TechTalks #TechTanker #techtantto\n#TechIndustry #AIInnovation #FutureOfAI #TorontoLife #7Shifts #LLM #TechPanel #AIResearch #TechInsights #TorontoNetworking #EventDetails #TorontoGathering #TorontoPanel #AIInToronto",
+    caption:
+      "🚀✨ Join us for our next in-person panel discussion in the heart of Toronto at the stunning Roof Garden event space! 🌆\n🍃 Get ready for an evening of insightful talks, networking, and learning from AI experts.\n📅 Date: Thursday, August 15th 🕕 Time: Doors open at 6 PM 📍 Location: Roof Garden, 1 Roof Garden Lane, Toronto, ON M6H 1R2 🙏 Thanks to our sponsor: 7Shifts\n🎤 Panelists: - Myles Harrison (he/him) - Consultant and Trainer, NLP From Scratch - Jay Alammar (he/him) - Director and Engineering Fellow, Cohere - Luke Galea (he/him) - CTO, 7Shifts - Ramy ElMallah (he/him) - PhD AI Researcher, University of Toronto - Moderator: Riaz Virani (he/him), Community Organizer @ TechTank\n🗓️ Schedule: - 6:00pm - 6:45pm: Arrival, food, and socializing 🍴🗣️ - 6:45pm - 7:45pm: Announcements & panel discussion 🎙️🧠 - 7:45pm - 8:30pm: More networking & Q&A 🤝❓\nWant to keep the conversation going? Join us at a nearby bar afterward! 🍻\n✨ Sponsor Spotlight: 7Shifts helps restaurants optimize scheduling, streamline communication, and ensure labor compliance. Trusted by over 40,000 restaurants globally! 🍽️👩‍🍳\nDon’t miss out on this fantastic evening! See you there! 💬🤩\n🔗 Register at meetup.com/techtank-to/events/302337555/\n#AI #paneldiscussion #Networking #TorontoEvents #TechTank #InPersonEvent #RoofGarden #AIExperts #TechCommunity #artificialintelligence #Insights #networkingevent #TorontoTech #TechTalks #TechTanker #techtantto\n#TechIndustry #AIInnovation #FutureOfAI #TorontoLife #7Shifts #LLM #TechPanel #AIResearch #TechInsights #TorontoNetworking #EventDetails #TorontoGathering #TorontoPanel #AIInToronto",
     date: "2024-07-29",
     shortcode: "C-A1Uqhu_fU",
     pk: 18083557162488657,
     createdAtRaw: 1722270415,
     media: [
-      { type: "image", path: "/media/instagram/2024-07-29-CA1UqhufU/techtankto_C-A1Uqhu_fU_3422970233319323604.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-07-29-CA1UqhufU/techtankto_C-A1Uqhu_fU_3422970233319323604.webp" },
+    ],
   },
   "2024-07-30-CBagSLP0do": {
-    caption: "⚠️ Flash Warning ⚠️\nThe best programming language? #Brainf*ck\nHosts of Guppy Talks🐠 @ranasoyak and @benjnil are joined by special guests @jc.malapit and @imjustkeding\nListen to the full episodes 🎙️ Link on our bio🐠😆\n#TechTank #GuppyTalks #Dev #codingcommunity #softwareengineering #Devlife #programming #TechTankers #Toronto #spotify #TechTankTo #techcommunity",
+    caption:
+      "⚠️ Flash Warning ⚠️\nThe best programming language? #Brainf*ck\nHosts of Guppy Talks🐠 @ranasoyak and @benjnil are joined by special guests @jc.malapit and @imjustkeding\nListen to the full episodes 🎙️ Link on our bio🐠😆\n#TechTank #GuppyTalks #Dev #codingcommunity #softwareengineering #Devlife #programming #TechTankers #Toronto #spotify #TechTankTo #techcommunity",
     date: "2024-07-30",
     shortcode: "C-BagSLP0do",
     pk: 18002963378422009,
     createdAtRaw: 1722376928,
     media: [
-      { type: "image", path: "/media/instagram/2024-07-30-CBagSLP0do/techtankto_C-BagSLP0do_3423133759526881128.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-07-30-CBagSLP0do/techtankto_C-BagSLP0do_3423133759526881128.webp" },
+    ],
   },
   "2024-07-31-CGa7pEvgFk": {
-    caption: "🌟 Join us for our Monthly Coffee Chat for Women & Gender-Diverse Folks in Tech! 🌟\n📅 Date: Saturday, Aug 10\n⏰ Time: 11:00 AM\n📍 Venue: Carbonic Coffee\nCome for the coffee, stay for the conversation! ☕️✨\nThis month’s topic: “Focus on what you can control and let go of worrying about everything else.”\nLet’s maximize our skills and make the most out of the cards we’ve been dealt. Only 7 spots left—grab yours now!\nSchedule: 11:00am - 11:30am: Arrive, grab your favorite drink, and mingle!\n11:30am - 1:00pm: Group discussion and interactive activities.\n🔗 Register on the Meetup app: https://www.meetup.com/techtank-to/events/302503778/\n#WomenInTech #NonBinaryInTech #TechCommunity #CoffeeChat #WomenEmpowerment #NetworkingEvent #InPersonEvent #TechEvent #TorontoTech #CarbonicCoffee #SkillBuilding #MindsetMatters #FocusOnYou #GrowthMindset #TechTalk #CommunityEvent #TechNetworking #techtank #techtankto #techtanker #techtankers #techtanktoronto #WomenWhoCode #SupportAndInspire #Meetup #TechMeetup",
+    caption:
+      "🌟 Join us for our Monthly Coffee Chat for Women & Gender-Diverse Folks in Tech! 🌟\n📅 Date: Saturday, Aug 10\n⏰ Time: 11:00 AM\n📍 Venue: Carbonic Coffee\nCome for the coffee, stay for the conversation! ☕️✨\nThis month’s topic: “Focus on what you can control and let go of worrying about everything else.”\nLet’s maximize our skills and make the most out of the cards we’ve been dealt. Only 7 spots left—grab yours now!\nSchedule: 11:00am - 11:30am: Arrive, grab your favorite drink, and mingle!\n11:30am - 1:00pm: Group discussion and interactive activities.\n🔗 Register on the Meetup app: https://www.meetup.com/techtank-to/events/302503778/\n#WomenInTech #NonBinaryInTech #TechCommunity #CoffeeChat #WomenEmpowerment #NetworkingEvent #InPersonEvent #TechEvent #TorontoTech #CarbonicCoffee #SkillBuilding #MindsetMatters #FocusOnYou #GrowthMindset #TechTalk #CommunityEvent #TechNetworking #techtank #techtankto #techtanker #techtankers #techtanktoronto #WomenWhoCode #SupportAndInspire #Meetup #TechMeetup",
     date: "2024-07-31",
     shortcode: "C-Ga7pEvgFk",
     pk: 17918516654951963,
     createdAtRaw: 1722457520,
     media: [
-      { type: "image", path: "/media/instagram/2024-07-31-CGa7pEvgFk/techtankto_C-Ga7pEvgFk_3424543014423232868.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-07-31-CGa7pEvgFk/techtankto_C-Ga7pEvgFk_3424543014423232868.webp" },
+    ],
   },
   "2024-08-13-CnSzF3OHAy": {
-    caption: "Join us for an epic tank-sports outing at Withrow Park! 🎾 🏐 🥎\n​Here’s the scoop:\n​👉 Where: Withrow Park - 725 Logan Ave, Toronto\n​👉 When: Saturday, Aug 31th, 3-7PM\n​👉 Dress Code: Sporty vibes! We’ll be playing softball, volleyball, and tennis, so make sure you’re dressed comfortably and ready for some action under the sun!\n​ 👉 BYOB & BYOF: This is a free event - we won’t be providing food, but there are BBQs and restaurants around. As usual, please BYOB 🍻🍹\n​Can’t wait to dive into the fun with y’all ✨\nRegister 🔗 lu.ma/cidoy6p6\n​(N.B.: By signing up for this event, you agree to TechTank’s Sport Waiver.)\n#techtank #techtankto #techtanktoronto #techtanker #techtankers #sportsday #socialtoronto #letshangout #softball #volleyball #tennis #bringyourgame #gameon #gg #devcommunity #devsocial #techsocialevents #sports #sashimis #igdaily #6ix #toronto #torontolife #torontoevents",
+    caption:
+      "Join us for an epic tank-sports outing at Withrow Park! 🎾 🏐 🥎\n​Here’s the scoop:\n​👉 Where: Withrow Park - 725 Logan Ave, Toronto\n​👉 When: Saturday, Aug 31th, 3-7PM\n​👉 Dress Code: Sporty vibes! We’ll be playing softball, volleyball, and tennis, so make sure you’re dressed comfortably and ready for some action under the sun!\n​ 👉 BYOB & BYOF: This is a free event - we won’t be providing food, but there are BBQs and restaurants around. As usual, please BYOB 🍻🍹\n​Can’t wait to dive into the fun with y’all ✨\nRegister 🔗 lu.ma/cidoy6p6\n​(N.B.: By signing up for this event, you agree to TechTank’s Sport Waiver.)\n#techtank #techtankto #techtanktoronto #techtanker #techtankers #sportsday #socialtoronto #letshangout #softball #volleyball #tennis #bringyourgame #gameon #gg #devcommunity #devsocial #techsocialevents #sports #sashimis #igdaily #6ix #toronto #torontolife #torontoevents",
     date: "2024-08-13",
     shortcode: "C-nSzF3OHAy",
     pk: 18048231700895200,
     createdAtRaw: 1723560954,
     media: [
-      { type: "image", path: "/media/instagram/2024-08-13-CnSzF3OHAy/techtankto_C-nSzF3OHAy_3433795916718960690.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-08-13-CnSzF3OHAy/techtankto_C-nSzF3OHAy_3433795916718960690.webp" },
+    ],
   },
   "2024-08-20-C5X4fJOYnp": {
-    caption: "🥎 Fear the Sashimis! Playoff season is on fire, we’re slicing home runs and serving up W’s! 🍣 Go Sashimis!!🔥\n#SoftballSquad #SashimisPower #TechTankTo #TechTankers #teamspirit #techtank #techtanktoronto #techtanker #sashimis #softball #toronto #gta #6ix #devcommunity",
+    caption:
+      "🥎 Fear the Sashimis! Playoff season is on fire, we’re slicing home runs and serving up W’s! 🍣 Go Sashimis!!🔥\n#SoftballSquad #SashimisPower #TechTankTo #TechTankers #teamspirit #techtank #techtanktoronto #techtanker #sashimis #softball #toronto #gta #6ix #devcommunity",
     date: "2024-08-20",
     shortcode: "C-5X4fJOYnp",
     pk: 18143865943336629,
     createdAtRaw: 1724171695,
     media: [
-      { type: "image", path: "/media/instagram/2024-08-20-C5X4fJOYnp/techtankto_C-5X4fJOYnp_3438884827275299305.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-08-20-C5X4fJOYnp/techtankto_C-5X4fJOYnp_3438884827275299305.webp" },
+    ],
   },
   "2024-08-29-CQpuckuRIf": {
-    caption: "🎉🏅 Recap from the Last #TankOlympics 🏅🎉\nMissed the last TankOlympics? Don’t worry—there’s more action coming your way before summer slips away! 🌞\nJoin us for an epic sports outing🔥\nLink on bio 🔗\n✨ We can’t wait to dive into the fun with y’all! ✨\n#TechTankTo #TechTankers #summer #memories #sports #TechCommunity #TechEvent #MeetPeople #Meetups",
+    caption:
+      "🎉🏅 Recap from the Last #TankOlympics 🏅🎉\nMissed the last TankOlympics? Don’t worry—there’s more action coming your way before summer slips away! 🌞\nJoin us for an epic sports outing🔥\nLink on bio 🔗\n✨ We can’t wait to dive into the fun with y’all! ✨\n#TechTankTo #TechTankers #summer #memories #sports #TechCommunity #TechEvent #MeetPeople #Meetups",
     date: "2024-08-29",
     shortcode: "C_QpuckuRIf",
     pk: 18248459479265088,
     createdAtRaw: 1724948431,
     media: [
-      { type: "image", path: "/media/instagram/2024-08-29-CQpuckuRIf/techtankto_C_QpuckuRIf_3445437226622194207.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-08-29-CQpuckuRIf/techtankto_C_QpuckuRIf_3445437226622194207.webp" },
+    ],
   },
   "2024-09-02-Cbh9wCvzkA": {
-    caption: "☀️Hope everyone’s enjoying their long weekend! TechTank had an amazing time at Withrow Park on Saturday, soaking up the last bit of summer ⚽️🥏🌳 While it’s bittersweet to see the long weekend winding down, it was the perfect way to recharge before the week begins!\nOur members are always on top of their game—active, competitive, and embracing their athletic spirit! 🏃‍♀️💪\n#TechTank #TechTanker #TechTankTo #TechCommunity #TorontoEvents #Meetup #Community #Social #Networking #Toronto #Summer #Memories",
+    caption:
+      "☀️Hope everyone’s enjoying their long weekend! TechTank had an amazing time at Withrow Park on Saturday, soaking up the last bit of summer ⚽️🥏🌳 While it’s bittersweet to see the long weekend winding down, it was the perfect way to recharge before the week begins!\nOur members are always on top of their game—active, competitive, and embracing their athletic spirit! 🏃‍♀️💪\n#TechTank #TechTanker #TechTankTo #TechCommunity #TorontoEvents #Meetup #Community #Social #Networking #Toronto #Summer #Memories",
     date: "2024-09-02",
     shortcode: "C_bh9wCvzkA",
     pk: 18092008786460907,
     createdAtRaw: 1725313533,
     media: [
-      { type: "image", path: "/media/instagram/2024-09-02-Cbh9wCvzkA/techtankto_C_bh9wCvzkA_3448499318690887936.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-09-02-Cbh9wCvzkA/techtankto_C_bh9wCvzkA_3448499318690887936.webp" },
+    ],
   },
   "2024-09-03-CdVqoFOP2e": {
-    caption: "Our latest meetup✨ We dove deep into the world of AI with some of the brightest minds in the industry 🧑‍💻\nA huge shoutout to our amazing panelists—Jay Alammar, Myles Harrison, Luke Galea, and Ramy ElMallah—who generously shared their knowledge and experiences with our community.\nThank you to our sponsor, @7shifts, for making this event possible and connecting us to the stunning RoofGarden space but also by providing delicious pizza 🍕and drinks 🍻 that kept us energized all night!❤️\nWe’ll be announcing the September meeting shortly - stay tuned for more details coming your way soon! 🚀\n#AI #AIInsights #TechCommunity #TorontoTech #Innovation #Meetup #TorontoEvents #TechTank #InPersonEvent #TechCommunity #TechTanker #TechTankTo #TechIndustry #TechInsights #TechTalk #Community #Networking #TechEvents #Toronto",
+    caption:
+      "Our latest meetup✨ We dove deep into the world of AI with some of the brightest minds in the industry 🧑‍💻\nA huge shoutout to our amazing panelists—Jay Alammar, Myles Harrison, Luke Galea, and Ramy ElMallah—who generously shared their knowledge and experiences with our community.\nThank you to our sponsor, @7shifts, for making this event possible and connecting us to the stunning RoofGarden space but also by providing delicious pizza 🍕and drinks 🍻 that kept us energized all night!❤️\nWe’ll be announcing the September meeting shortly - stay tuned for more details coming your way soon! 🚀\n#AI #AIInsights #TechCommunity #TorontoTech #Innovation #Meetup #TorontoEvents #TechTank #InPersonEvent #TechCommunity #TechTanker #TechTankTo #TechIndustry #TechInsights #TechTalk #Community #Networking #TechEvents #Toronto",
     date: "2024-09-03",
     shortcode: "C_dVqoFOP2e",
     pk: 18044417227799792,
@@ -516,439 +669,673 @@ const instagramPosts: Record<string, InstagramPost> = {
       { type: "image", path: "/media/instagram/2024-09-03-CdVqoFOP2e/techtankto_C_dVqoFOP2e_3448724800631708559.webp" },
       { type: "image", path: "/media/instagram/2024-09-03-CdVqoFOP2e/techtankto_C_dVqoFOP2e_3448724800690242522.webp" },
       { type: "image", path: "/media/instagram/2024-09-03-CdVqoFOP2e/techtankto_C_dVqoFOP2e_3448724800690372050.webp" },
-      { type: "image", path: "/media/instagram/2024-09-03-CdVqoFOP2e/techtankto_C_dVqoFOP2e_3448724800698623572.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-09-03-CdVqoFOP2e/techtankto_C_dVqoFOP2e_3448724800698623572.webp" },
+    ],
   },
   "2024-09-03-Cdm2SnujZM": {
-    caption: "Thank you ❤️\nWe couldn’t have done it without the unwavering support of our incredible sponsor, @7shifts. Their commitment to our community continues to set the bar high. Not only did they sponsor the event and connect us to the stunning RoofGarden space, but they also went above and beyond by providing delicious pizza 🍕and drinks 🍻🥤 And as if that wasn’t enough, they continued to support us at the post-event social, making sure the conversation and good vibes kept flowing long after the panel ended 🥹 \nA massive thank you to Raul Chedrese and the 7shifts team for making this all possible and for being such an integral part of our tech community! 🙏\n#AIInsights #TechCommunity #TorontoTech #Community #Meetup #TorontoEvents #TechTank #InPersonEvent #TechCommunity #TechTanker #TechTankTo #TechIndustry #TechInsights #TechTalk #Networking #TechEvents #Toronto",
+    caption:
+      "Thank you ❤️\nWe couldn’t have done it without the unwavering support of our incredible sponsor, @7shifts. Their commitment to our community continues to set the bar high. Not only did they sponsor the event and connect us to the stunning RoofGarden space, but they also went above and beyond by providing delicious pizza 🍕and drinks 🍻🥤 And as if that wasn’t enough, they continued to support us at the post-event social, making sure the conversation and good vibes kept flowing long after the panel ended 🥹 \nA massive thank you to Raul Chedrese and the 7shifts team for making this all possible and for being such an integral part of our tech community! 🙏\n#AIInsights #TechCommunity #TorontoTech #Community #Meetup #TorontoEvents #TechTank #InPersonEvent #TechCommunity #TechTanker #TechTankTo #TechIndustry #TechInsights #TechTalk #Networking #TechEvents #Toronto",
     date: "2024-09-03",
     shortcode: "C_dm2SnujZM",
     pk: 18034704305484162,
     createdAtRaw: 1725382811,
     media: [
-      { type: "image", path: "/media/instagram/2024-09-03-Cdm2SnujZM/techtankto_C_dm2SnujZM_3449083746248701516.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-09-03-Cdm2SnujZM/techtankto_C_dm2SnujZM_3449083746248701516.webp" },
+    ],
   },
   "2024-09-04-CgBVf3vCTS": {
-    caption: "🔍✨ Join us on Wednesday, September 18th, as @nikolovlazardotcom, full-stack developer, takes us through a forensic deep-dive into React Server Components (RSCs)—and solve the mystery of how they supercharge web performance🕵️‍♂️! This session will uncover how RSCs blend server-side and client-side rendering to boost web performance.\n🎤 Lazar is a dedicated educator, who loves to share insights and knowledge through his YouTube channel, online courses, and his own Discord server at creatures.sh.✨\nEvent Details: 🗓️ Date: Wednesday, September 18th ⌚ Time: 6:00 pm - 8:30 pm EST 📍 Location: Points, 111 Richmond St W, Toronto, ON M5H 2G4\nSchedule: 6:00pm - 6:45pm - Arrive, enjoy refreshments, and connect 6:45pm - 7:45pm - Announcements / Lazar’s presentation 7:45pm - 8:30pm - Q&A and networking\nThanks to our sponsors, Points (a Plusgrade company), for making this event possible and providing food and drinks 🙏\n👉 RSVP NOW on Meetup 👈 Link on bio 🔗\n#React #ReactServerComponents #WebPerformance #FrontEnd #TorontoEvents #TechTank #InPersonEvent #TechCommunity #Insights #TorontoTech #TechTanker #TechTankTo #TechIndustry #TechInsights #TechTalk #Community #Networking #TechEvents #Toronto",
+    caption:
+      "🔍✨ Join us on Wednesday, September 18th, as @nikolovlazardotcom, full-stack developer, takes us through a forensic deep-dive into React Server Components (RSCs)—and solve the mystery of how they supercharge web performance🕵️‍♂️! This session will uncover how RSCs blend server-side and client-side rendering to boost web performance.\n🎤 Lazar is a dedicated educator, who loves to share insights and knowledge through his YouTube channel, online courses, and his own Discord server at creatures.sh.✨\nEvent Details: 🗓️ Date: Wednesday, September 18th ⌚ Time: 6:00 pm - 8:30 pm EST 📍 Location: Points, 111 Richmond St W, Toronto, ON M5H 2G4\nSchedule: 6:00pm - 6:45pm - Arrive, enjoy refreshments, and connect 6:45pm - 7:45pm - Announcements / Lazar’s presentation 7:45pm - 8:30pm - Q&A and networking\nThanks to our sponsors, Points (a Plusgrade company), for making this event possible and providing food and drinks 🙏\n👉 RSVP NOW on Meetup 👈 Link on bio 🔗\n#React #ReactServerComponents #WebPerformance #FrontEnd #TorontoEvents #TechTank #InPersonEvent #TechCommunity #Insights #TorontoTech #TechTanker #TechTankTo #TechIndustry #TechInsights #TechTalk #Community #Networking #TechEvents #Toronto",
     date: "2024-09-04",
     shortcode: "C_gBVf3vCTS",
     pk: 18040077086023547,
     createdAtRaw: 1725463809,
     media: [
-      { type: "image", path: "/media/instagram/2024-09-04-CgBVf3vCTS/techtankto_C_gBVf3vCTS_3449763189942396114.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-09-04-CgBVf3vCTS/techtankto_C_gBVf3vCTS_3449763189942396114.webp" },
+    ],
   },
   "2024-09-16-C1y27uKuL": {
-    caption: "🎙️ Tune in to the latest episode of Guppy Talks! 🐠🎧\nWe’re diving into our fishbowl with Benjamin Lokash and Chris Taeyoung Kim, joined by guests Evert Pot and Anjalee Benedict, to discuss FE frameworks, SPAs, Neuralink, and mastering interview skills. This is just part 1, so stay tuned for part 2! 🔥\nProduced and edited by Benjamin Lokash with music and content editing by Chris Taeyoung Kim. Big shoutout to our recording directors Rana Selva Soyka and Riaz Virani!\nFor more info, visit techtankto.com or drop us a line at techtankto@gmail.com! 🐟💻\nPodcast 🔗 podcasters.spotify.com/pod/show/techtank6/\nCheck out our active community on Slack for the latest announcements 📢 📣 📢\n#TorontoPodcasts #TechTalks #GuppyTalks #FEFrameworks #SinglePageApps #Neuralink #TechInterviews #PodcastLife #Part1 #TechDiscussions #podcast #toronto #TorontoTech #StartupCommunity #TechInToronto #YTPodcast #TechIndustry #InnovationTalks #TechPodcast #DeveloperLife #TechTank #yyz #techtank #techtanktoronto #techtankto #techtankers",
+    caption:
+      "🎙️ Tune in to the latest episode of Guppy Talks! 🐠🎧\nWe’re diving into our fishbowl with Benjamin Lokash and Chris Taeyoung Kim, joined by guests Evert Pot and Anjalee Benedict, to discuss FE frameworks, SPAs, Neuralink, and mastering interview skills. This is just part 1, so stay tuned for part 2! 🔥\nProduced and edited by Benjamin Lokash with music and content editing by Chris Taeyoung Kim. Big shoutout to our recording directors Rana Selva Soyka and Riaz Virani!\nFor more info, visit techtankto.com or drop us a line at techtankto@gmail.com! 🐟💻\nPodcast 🔗 podcasters.spotify.com/pod/show/techtank6/\nCheck out our active community on Slack for the latest announcements 📢 📣 📢\n#TorontoPodcasts #TechTalks #GuppyTalks #FEFrameworks #SinglePageApps #Neuralink #TechInterviews #PodcastLife #Part1 #TechDiscussions #podcast #toronto #TorontoTech #StartupCommunity #TechInToronto #YTPodcast #TechIndustry #InnovationTalks #TechPodcast #DeveloperLife #TechTank #yyz #techtank #techtanktoronto #techtankto #techtankers",
     date: "2024-09-16",
     shortcode: "C_-1y27uKuL",
     pk: 17920642085966893,
     createdAtRaw: 1726500057,
     media: [
-      { type: "image", path: "/media/instagram/2024-09-16-C1y27uKuL/techtankto_C_-1y27uKuL_3458438155290061707.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-09-16-C1y27uKuL/techtankto_C_-1y27uKuL_3458438155290061707.webp" },
+    ],
   },
   "2024-09-19-DAGbFxFOHtI": {
-    caption: "​Get ready to end summer off with a bang💣!\nJoin our 🔥FYRE FEST 🔥 to celebrate summer before going into hibernation 🐻\n​Here’s the info:\n​​​Location📍: Exact location will be shared upon registration on Luma\n🔗 lu.ma/jkr3i7pz\n​​​When: Saturday, Sept 28th, 4PM\n​​​Dress Code: Casual or sporting attire—there’s a field for games, so come ready to play or chill out! 🏃‍♂️⚽\n​​​BYOB & Food🍻: We’ve got the (halal)marshmallows covered—bring your own beverages and any other snacks you’d like to share! We will have a cooler!!!\n​​​We’re looking forward to a fantastic time with everyone. Let’s make this day unforgettable! ✨\n​Can’t wait to see you there!\n#socialtoronto #devcommunity #techtank #techtanktoronto #techtankto #tech #techevents #byob #fyre #hibernation #sports #social #techtanker #techtankers #yyz #gta #toronto #6ix #iykyk #torontolife #torontolove",
+    caption:
+      "​Get ready to end summer off with a bang💣!\nJoin our 🔥FYRE FEST 🔥 to celebrate summer before going into hibernation 🐻\n​Here’s the info:\n​​​Location📍: Exact location will be shared upon registration on Luma\n🔗 lu.ma/jkr3i7pz\n​​​When: Saturday, Sept 28th, 4PM\n​​​Dress Code: Casual or sporting attire—there’s a field for games, so come ready to play or chill out! 🏃‍♂️⚽\n​​​BYOB & Food🍻: We’ve got the (halal)marshmallows covered—bring your own beverages and any other snacks you’d like to share! We will have a cooler!!!\n​​​We’re looking forward to a fantastic time with everyone. Let’s make this day unforgettable! ✨\n​Can’t wait to see you there!\n#socialtoronto #devcommunity #techtank #techtanktoronto #techtankto #tech #techevents #byob #fyre #hibernation #sports #social #techtanker #techtankers #yyz #gta #toronto #6ix #iykyk #torontolife #torontolove",
     date: "2024-09-19",
     shortcode: "DAGbFxFOHtI",
     pk: 18063441517632959,
     createdAtRaw: 1726752757,
     media: [
-      { type: "image", path: "/media/instagram/2024-09-19-DAGbFxFOHtI/techtankto_DAGbFxFOHtI_3460572507234925384.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-09-19-DAGbFxFOHtI/techtankto_DAGbFxFOHtI_3460572507234925384.webp",
+      },
+    ],
   },
   "2024-09-24-DATiy4XOfvL": {
-    caption: "🎉 React Server Components Event Recap! 🎉\nWe had an incredible night on Wednesday, September 18 at the Plusgrade office (Points HQ)! 🚀\n👨‍💻 Lazar Nikolov wowed us with an insightful talk on React Server Components, breaking down how this cutting-edge tech blends server-side and client-side rendering to supercharge web performance. Attendees were hooked as Lazar walked through the inner workings of RSCs! 🔍\n🍕 With drinks, food, and lively conversation, the night was filled with networking and learning as devs across the community connected and shared ideas.\nMissed it? No worries—more events are on the horizon! Stay tuned for what’s next 👀. For more tutorials and insights, check out Lazar’s YouTube channel: 🔗 @ nikolovlazar 🎥\nLazar Nikolov is a developer advocate at Sentry, living in Toronto but originally from North Macedonia. As a full-stack engineer, he enjoys building interesting pet projects from scratch—though, like any normal developer, he often abandons them. Always curious, Lazar loves learning new things and enjoys live streaming on YouTube and creating courses for\n🔗 egghead.io.\nWant to join our future events? All event registrations are on Meetup, or join TechTank’s active Slack community to stay connected and up-to-date! You can also find all our handles at\n🔗 liw.bio/techtankto\nWe’d love to hear from you! Comment below on what you learned at the event or what you’re excited to explore next! 🙌\nA huge thank you to everyone who volunteered and made this event possible! Your support truly makes a difference.\nBig thanks to Points and Plusgrade for hosting this unforgettable event! Thank you @thanniablanchet for saying a few words and letting us know about opportunities!\nPoints has been a global leader in powering loyalty commerce for more than two decades! Points continues to revolutionize the loyalty and travel industries by creating new opportunities for ancillary revenue.\n🔗www.points.com/about/\n#TechTankTO #ReactServerComponents #TorontoTech #WebDevelopment #TechCommunity #DeveloperLife #TechEvents #FullStackDevelopment #ReactJS #CodingLife #TorontoDev #TechTank #Techtanktoronto #TechTanker #Techtankers #techevents #toronto",
+    caption:
+      "🎉 React Server Components Event Recap! 🎉\nWe had an incredible night on Wednesday, September 18 at the Plusgrade office (Points HQ)! 🚀\n👨‍💻 Lazar Nikolov wowed us with an insightful talk on React Server Components, breaking down how this cutting-edge tech blends server-side and client-side rendering to supercharge web performance. Attendees were hooked as Lazar walked through the inner workings of RSCs! 🔍\n🍕 With drinks, food, and lively conversation, the night was filled with networking and learning as devs across the community connected and shared ideas.\nMissed it? No worries—more events are on the horizon! Stay tuned for what’s next 👀. For more tutorials and insights, check out Lazar’s YouTube channel: 🔗 @ nikolovlazar 🎥\nLazar Nikolov is a developer advocate at Sentry, living in Toronto but originally from North Macedonia. As a full-stack engineer, he enjoys building interesting pet projects from scratch—though, like any normal developer, he often abandons them. Always curious, Lazar loves learning new things and enjoys live streaming on YouTube and creating courses for\n🔗 egghead.io.\nWant to join our future events? All event registrations are on Meetup, or join TechTank’s active Slack community to stay connected and up-to-date! You can also find all our handles at\n🔗 liw.bio/techtankto\nWe’d love to hear from you! Comment below on what you learned at the event or what you’re excited to explore next! 🙌\nA huge thank you to everyone who volunteered and made this event possible! Your support truly makes a difference.\nBig thanks to Points and Plusgrade for hosting this unforgettable event! Thank you @thanniablanchet for saying a few words and letting us know about opportunities!\nPoints has been a global leader in powering loyalty commerce for more than two decades! Points continues to revolutionize the loyalty and travel industries by creating new opportunities for ancillary revenue.\n🔗www.points.com/about/\n#TechTankTO #ReactServerComponents #TorontoTech #WebDevelopment #TechCommunity #DeveloperLife #TechEvents #FullStackDevelopment #ReactJS #CodingLife #TorontoDev #TechTank #Techtanktoronto #TechTanker #Techtankers #techevents #toronto",
     date: "2024-09-24",
     shortcode: "DATiy4XOfvL",
     pk: 18037461965278612,
     createdAtRaw: 1727196620,
     media: [
-      { type: "image", path: "/media/instagram/2024-09-24-DATiy4XOfvL/techtankto_DATiy4XOfvL_3464265568452475851.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-09-24-DATiy4XOfvL/techtankto_DATiy4XOfvL_3464265568452475851.webp",
+      },
+    ],
   },
   "2024-09-27-DAbc737vNNk": {
-    caption: "🚀 Cypress for the Overwhelmed Developer 💻\nEnd-to-end testing ensures your app works seamlessly from a user’s perspective, and Cypress makes it simple! This powerful front-end tool lets developers automate tests by simulating real browser environments, capturing complex user behavior, and ensuring all parts of your system work together. 🛠️\nIn this StudyTank session, hosted by Nonso Otoh and featuring guest teacher Chelsea Roman, you’ll dive into how Cypress works, its time-saving features like real-time reloading and automatic waiting, and why testing your app’s full flow is crucial for a flawless user experience. 💡\n🗓️ Join us on October 1, 2024, at 7 PM EDT for this exciting virtual event. Boost your confidence in your code with Cypress!\n👉 Register now on Meetup\n🔗 www.meetup.com/techtank-to/events/303601353\n#CypressTesting #WebDevTools #StudyTank #EndToEndTesting #WebDevelopment #AutomatedTesting #LearnToCode #testing #code #devcommunity #toronto #online #onlinelearning #techtank #techtankto #techtanktoronto #techtanker #techtankers #torontoevents #remotelearning #cypress #js #javscript #goodpractices",
+    caption:
+      "🚀 Cypress for the Overwhelmed Developer 💻\nEnd-to-end testing ensures your app works seamlessly from a user’s perspective, and Cypress makes it simple! This powerful front-end tool lets developers automate tests by simulating real browser environments, capturing complex user behavior, and ensuring all parts of your system work together. 🛠️\nIn this StudyTank session, hosted by Nonso Otoh and featuring guest teacher Chelsea Roman, you’ll dive into how Cypress works, its time-saving features like real-time reloading and automatic waiting, and why testing your app’s full flow is crucial for a flawless user experience. 💡\n🗓️ Join us on October 1, 2024, at 7 PM EDT for this exciting virtual event. Boost your confidence in your code with Cypress!\n👉 Register now on Meetup\n🔗 www.meetup.com/techtank-to/events/303601353\n#CypressTesting #WebDevTools #StudyTank #EndToEndTesting #WebDevelopment #AutomatedTesting #LearnToCode #testing #code #devcommunity #toronto #online #onlinelearning #techtank #techtankto #techtanktoronto #techtanker #techtankers #torontoevents #remotelearning #cypress #js #javscript #goodpractices",
     date: "2024-09-27",
     shortcode: "DAbc737vNNk",
     pk: 18240629236262972,
     createdAtRaw: 1727458185,
     media: [
-      { type: "image", path: "/media/instagram/2024-09-27-DAbc737vNNk/techtankto_DAbc737vNNk_3466491598001197924.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-09-27-DAbc737vNNk/techtankto_DAbc737vNNk_3466491598001197924.webp",
+      },
+    ],
   },
   "2024-10-01-DAlmPeCNBdb": {
-    caption: "🕵️‍♂️Case Closed: The Mystery of React Server Components Solved!\nLast Wednesday, we cracked the code on React Server Components, thanks to the incredible Lazar Nikolov @nikolovlazardotcom @gooddevhabits ! 🚀\nYour insights into how RSCs are transforming web performance were mind-blowing!\nA huge shoutout to our sponsor, @pointsloyalty Points , a Plusgrade Company! 🙌 Special thanks to Thannia Blanchet @thanniablanchet\nfor keeping this connection strong and providing an amazing venue, delicious food, and drinks. Your support for the tech community in Toronto is inspiring!\nTo everyone who joined us, you are the heartbeat of TechTank! The energy, thought-provoking questions, and engaging discussions made the night unforgettable. 🤝\nMissed the event? No worries! You can...\nWatch the full presentation here:\n🔗 https://www.youtube.com/watch?v=NOlSKs5PLpM\n📸 Check out the event photos here:\n🔗 https://photos.app.goo.gl/rY3cAbhYZPimH6Kx7\nHuge thank you to @nonsootoh for these amazing photos!\nWe’re always looking for new voices! Interested in speaking or partnering with us?\nLet’s connect!\n👉 Become a speaker 👉 Explore sponsorships 📧E-mail us at techtankto@gmail.com\nYour support keeps TechTank thriving! If our events bring you value, consider donating to help us grow:\n🔗 https://techtankto.com/donate 💙\nStay tuned for our next event—exciting details coming soon! ✨\n#ReactJS #ReactServerComponents #WebDevelopment #TechCommunity #TechEvents #PerformanceOptimization #FrontendDevelopment #TorontoTech #DeveloperCommunity #Coding #JavaScript #TechTalks #Innovation #SoftwareEngineering #ReactDeveloper #TechNetworking #CommunityBuilding #WebPerformance #Programming #TechEducation #EventRecap",
+    caption:
+      "🕵️‍♂️Case Closed: The Mystery of React Server Components Solved!\nLast Wednesday, we cracked the code on React Server Components, thanks to the incredible Lazar Nikolov @nikolovlazardotcom @gooddevhabits ! 🚀\nYour insights into how RSCs are transforming web performance were mind-blowing!\nA huge shoutout to our sponsor, @pointsloyalty Points , a Plusgrade Company! 🙌 Special thanks to Thannia Blanchet @thanniablanchet\nfor keeping this connection strong and providing an amazing venue, delicious food, and drinks. Your support for the tech community in Toronto is inspiring!\nTo everyone who joined us, you are the heartbeat of TechTank! The energy, thought-provoking questions, and engaging discussions made the night unforgettable. 🤝\nMissed the event? No worries! You can...\nWatch the full presentation here:\n🔗 https://www.youtube.com/watch?v=NOlSKs5PLpM\n📸 Check out the event photos here:\n🔗 https://photos.app.goo.gl/rY3cAbhYZPimH6Kx7\nHuge thank you to @nonsootoh for these amazing photos!\nWe’re always looking for new voices! Interested in speaking or partnering with us?\nLet’s connect!\n👉 Become a speaker 👉 Explore sponsorships 📧E-mail us at techtankto@gmail.com\nYour support keeps TechTank thriving! If our events bring you value, consider donating to help us grow:\n🔗 https://techtankto.com/donate 💙\nStay tuned for our next event—exciting details coming soon! ✨\n#ReactJS #ReactServerComponents #WebDevelopment #TechCommunity #TechEvents #PerformanceOptimization #FrontendDevelopment #TorontoTech #DeveloperCommunity #Coding #JavaScript #TechTalks #Innovation #SoftwareEngineering #ReactDeveloper #TechNetworking #CommunityBuilding #WebPerformance #Programming #TechEducation #EventRecap",
     date: "2024-10-01",
     shortcode: "DAlmPeCNBdb",
     pk: 17899530414064165,
     createdAtRaw: 1727817399,
     media: [
-      { type: "image", path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347251291647730.webp" },
-      { type: "image", path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347251375470465.webp" },
-      { type: "image", path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347251610367303.webp" },
-      { type: "image", path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347251635508377.webp" },
-      { type: "image", path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347251828330158.webp" },
-      { type: "image", path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347251937482685.webp" },
-      { type: "image", path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347252013071695.webp" },
-      { type: "image", path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347252390475052.webp" },
-      { type: "image", path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347253028008996.webp" },
-      { type: "image", path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347254193920430.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347251291647730.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347251375470465.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347251610367303.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347251635508377.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347251828330158.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347251937482685.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347252013071695.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347252390475052.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347253028008996.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-01-DAlmPeCNBdb/techtankto_DAlmPeCNBdb_3469347254193920430.webp",
+      },
+    ],
   },
   "2024-10-01-DAmHHnlveoh": {
-    caption: "In this episode of Guppy Talks 🐠🎧, we dive into our fishbowl to discuss topics such as: should technology be exciting? are auto-formatters a crutch? Plus, don’t miss our Rapid Fire Question Section, where our guests think fast and answer faster! And then, we go through our GuppyMail where we answer questions from our community listeners. Today’s episode is part two of our discussion with Evert and Anjalee from last episode.\nHosts: Benjamin Lokash and Chris Taeyoung Kim Guests: Evert Pot and Anjalee Benedict Recording Directors: Rana Selva Soyak and Riaz Virani\nThis episode is produced and edited by Benjamin Lokash, and music and content editing by Chris Taeyoung Kim.\nPodcast 🔗 https://podcasters.spotify.com/pod/show/techtank6/\nCheck out our active community on Slack for the latest announcements 📢 📣 📢\nFor more information about our community, visit ⁠techtankto.com⁠, or email us at ⁠techtankto@gmail.com⁠.\n#TorontoPodcasts #TechTalks #GuppyTalks #FEFrameworks #SinglePageApps #Neuralink #TechInterviews #PodcastLife #Part2 #TechDiscussions #podcast #toronto #TorontoTech #StartupCommunity #TechInToronto #YTPodcast #TechIndustry #InnovationTalks #TechPodcast #DeveloperLife #TechTank #yyz #techtank #techtanktoronto #techtankto #techtankers",
+    caption:
+      "In this episode of Guppy Talks 🐠🎧, we dive into our fishbowl to discuss topics such as: should technology be exciting? are auto-formatters a crutch? Plus, don’t miss our Rapid Fire Question Section, where our guests think fast and answer faster! And then, we go through our GuppyMail where we answer questions from our community listeners. Today’s episode is part two of our discussion with Evert and Anjalee from last episode.\nHosts: Benjamin Lokash and Chris Taeyoung Kim Guests: Evert Pot and Anjalee Benedict Recording Directors: Rana Selva Soyak and Riaz Virani\nThis episode is produced and edited by Benjamin Lokash, and music and content editing by Chris Taeyoung Kim.\nPodcast 🔗 https://podcasters.spotify.com/pod/show/techtank6/\nCheck out our active community on Slack for the latest announcements 📢 📣 📢\nFor more information about our community, visit ⁠techtankto.com⁠, or email us at ⁠techtankto@gmail.com⁠.\n#TorontoPodcasts #TechTalks #GuppyTalks #FEFrameworks #SinglePageApps #Neuralink #TechInterviews #PodcastLife #Part2 #TechDiscussions #podcast #toronto #TorontoTech #StartupCommunity #TechInToronto #YTPodcast #TechIndustry #InnovationTalks #TechPodcast #DeveloperLife #TechTank #yyz #techtank #techtanktoronto #techtankto #techtankers",
     date: "2024-10-01",
     shortcode: "DAmHHnlveoh",
     pk: 18073900021507430,
     createdAtRaw: 1727815694,
     media: [
-      { type: "image", path: "/media/instagram/2024-10-01-DAmHHnlveoh/techtankto_DAmHHnlveoh_3469491872806595105.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-01-DAmHHnlveoh/techtankto_DAmHHnlveoh_3469491872806595105.webp",
+      },
+    ],
   },
   "2024-10-03-DAq61RWPvMW": {
-    caption: "🔥#ThrowbackThursday to TechTank’s FYRE FEST 🔥\nWe ended summer with a bang on Sept 28th, complete with games, food, and good vibes all around! 🏃‍♂️⚽\nHuge shoutout to everyone who came out, brought the energy, and made the day unforgettable ✨\nThank you to all the organizers and everyone who helped capture these amazing moments! 🙌\nMissed out? No worries—join our Slack community under the channel # social-toronto so you don’t miss the next one!\nCheck out all the fun in our Google Photos album or swipe through the pics below 📸👇\n🔗 https://photos.app.goo.gl/qztr4apPaox8sBWXA\n#TechTankTO #endofsummer #FyreFest #goodvibesonly #throwback #tbt #tb #techcommunity #torontotech #socialevents #devcommunity #touchsomegrass #techtankevents #YYZTech #yyz #6ix #torontolife #campfire #marshmallows #beforewehibernate #torontislands #islands #photodump",
+    caption:
+      "🔥#ThrowbackThursday to TechTank’s FYRE FEST 🔥\nWe ended summer with a bang on Sept 28th, complete with games, food, and good vibes all around! 🏃‍♂️⚽\nHuge shoutout to everyone who came out, brought the energy, and made the day unforgettable ✨\nThank you to all the organizers and everyone who helped capture these amazing moments! 🙌\nMissed out? No worries—join our Slack community under the channel # social-toronto so you don’t miss the next one!\nCheck out all the fun in our Google Photos album or swipe through the pics below 📸👇\n🔗 https://photos.app.goo.gl/qztr4apPaox8sBWXA\n#TechTankTO #endofsummer #FyreFest #goodvibesonly #throwback #tbt #tb #techcommunity #torontotech #socialevents #devcommunity #touchsomegrass #techtankevents #YYZTech #yyz #6ix #torontolife #campfire #marshmallows #beforewehibernate #torontislands #islands #photodump",
     date: "2024-10-03",
     shortcode: "DAq61RWPvMW",
     pk: 17873806857174776,
     createdAtRaw: 1727977145,
     media: [
-      { type: "image", path: "/media/instagram/2024-10-03-DAq61RWPvMW/techtankto_DAq61RWPvMW_3470845210299134742.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-03-DAq61RWPvMW/techtankto_DAq61RWPvMW_3470845210299134742.webp",
+      },
+    ],
   },
   "2024-10-07-DA1Dl3Kv6k": {
-    caption: "🎓 EdTech at the Crossroads: AI, Accessibility & the Evolving Classroom!\nGet ready for an inspiring panel discussion that will reshape the future of EdTech! 🚀\n📅 Date: Monday, October 28th\n🕕 Time: Doors open at 6 PM\n📍 Location: Rakuten Kobo Office, 150 John St, Toronto\n✨ What’s in store?\n🍕Drinks, food, and great convos with leading experts in EdTech, AI, accessibility, and more! 👥 Plus, an awesome chance to network and connect with the community.\n🗣️ Meet the Panelists:\n🔹Rico Chow (he/him) - Chief Product Officer, SiSi\n🔹Natalie Famula (she/her) - Web Developer II, Prodigy Education\n🔹Alex Cooksey (she/her) - Senior Product Designer, Prodigy Education\n🔹 Patricia Park (she/her) - Educator, Toronto District School Board\nModerator: Chris Taeyoung Kim (she/her), Founder & Community Organizer @techtankto 🐠\n🗓 Schedule:\n6:00 PM - Doors open, grab food & network\n6:45 PM - Announcements & Panel Discussion\n7:45 PM - Q&A & more networking!\n📢 Bonus:\nKobo is hosting a food drive for the Daily Bread Food Bank! 🙌\nPlease bring non-perishable items like canned fish, veggies, or oatmeal to help fight food insecurity in our community. @dailybreadto\nSponsored by Rakuten Kobo – the world’s only dedicated digital bookseller, enabling over 30 million readers to enjoy their favorite books anytime, anywhere. @kobobooks\nRegister here:\n🔗 https://www.meetup.com/techtank-to/events/303655206\nDon’t miss out—let’s redefine the future of education together! 💡\n#tech #techtankto #techtank #techtanker #techtankers #techtanktoronto #torontoevents #techenthusiast #techrecruiters #techentrepreneur #6ix #torontolife #techtoronto #yyz #torontotech #panel #paneldiscussion #torontomeetups #october #octobermeeting #donate #dailybread #communitytoronto #toronto #torontoinsta #education #teachers #ai #webaccessibility #educationtechnology",
+    caption:
+      "🎓 EdTech at the Crossroads: AI, Accessibility & the Evolving Classroom!\nGet ready for an inspiring panel discussion that will reshape the future of EdTech! 🚀\n📅 Date: Monday, October 28th\n🕕 Time: Doors open at 6 PM\n📍 Location: Rakuten Kobo Office, 150 John St, Toronto\n✨ What’s in store?\n🍕Drinks, food, and great convos with leading experts in EdTech, AI, accessibility, and more! 👥 Plus, an awesome chance to network and connect with the community.\n🗣️ Meet the Panelists:\n🔹Rico Chow (he/him) - Chief Product Officer, SiSi\n🔹Natalie Famula (she/her) - Web Developer II, Prodigy Education\n🔹Alex Cooksey (she/her) - Senior Product Designer, Prodigy Education\n🔹 Patricia Park (she/her) - Educator, Toronto District School Board\nModerator: Chris Taeyoung Kim (she/her), Founder & Community Organizer @techtankto 🐠\n🗓 Schedule:\n6:00 PM - Doors open, grab food & network\n6:45 PM - Announcements & Panel Discussion\n7:45 PM - Q&A & more networking!\n📢 Bonus:\nKobo is hosting a food drive for the Daily Bread Food Bank! 🙌\nPlease bring non-perishable items like canned fish, veggies, or oatmeal to help fight food insecurity in our community. @dailybreadto\nSponsored by Rakuten Kobo – the world’s only dedicated digital bookseller, enabling over 30 million readers to enjoy their favorite books anytime, anywhere. @kobobooks\nRegister here:\n🔗 https://www.meetup.com/techtank-to/events/303655206\nDon’t miss out—let’s redefine the future of education together! 💡\n#tech #techtankto #techtank #techtanker #techtankers #techtanktoronto #torontoevents #techenthusiast #techrecruiters #techentrepreneur #6ix #torontolife #techtoronto #yyz #torontotech #panel #paneldiscussion #torontomeetups #october #octobermeeting #donate #dailybread #communitytoronto #toronto #torontoinsta #education #teachers #ai #webaccessibility #educationtechnology",
     date: "2024-10-07",
     shortcode: "DA1Dl3Kv6k_",
     pk: 18155268145323328,
     createdAtRaw: 1728324329,
     media: [
-      { type: "image", path: "/media/instagram/2024-10-07-DA1Dl3Kv6k/techtankto_DA1Dl3Kv6k__3473698483582511423.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-10-07-DA1Dl3Kv6k/techtankto_DA1Dl3Kv6k__3473698483582511423.webp" },
+    ],
   },
   "2024-10-07-DAtx67v2D": {
-    caption: "1️⃣ Click this caption 2️⃣ Go to comments\n#techtankto #techtank #techtanktoronto #toronto #friday #happyfriday #friyay #6ix #yyz #foryou #foryoupage #secret #dashund #dogsofinstagram #dogoftheday #doggo",
+    caption:
+      "1️⃣ Click this caption 2️⃣ Go to comments\n#techtankto #techtank #techtanktoronto #toronto #friday #happyfriday #friyay #6ix #yyz #foryou #foryoupage #secret #dashund #dogsofinstagram #dogoftheday #doggo",
     date: "2024-10-07",
     shortcode: "DAtx6-7v_2D",
     pk: 18028519694346723,
     createdAtRaw: 1728324420,
     media: [
-      { type: "image", path: "/media/instagram/2024-10-07-DAtx67v2D/techtankto_DAtx6-7v_2D_3471650445355646339.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-10-07-DAtx67v2D/techtankto_DAtx6-7v_2D_3471650445355646339.webp" },
+    ],
   },
   "2024-10-11-DAZ7SLvG1T": {
-    caption: "Happy long weekend! 🍁\nTake a break and recharge, but don’t forget to RSVP for our next TechTank social at Waterworks Foodhall on Saturday, October 26th from 6-8 PM! 🕕\nWe’re keeping it chill this month with a fun night exploring restaurants and bars, enjoying tasty food, sipping refreshing drinks, and having great conversations.\nWhether you’re a foodie or just love a good vibe, there’s something for everyone! 🍽️🍹✨\nPlease RSVP to help us with the headcount. Can’t wait to see you there! 🥂🍻\n🔗 RSVP here: lu.ma/fmi3zf6a\n#TechTank #techtankto #techtanktoronto #techtanker #techtankers #TechSocial #TorontoEvents #TorontoTech #WaterworksFoodhall #SocialEvent #TechCommunity #TorontoEats #TorontoFoodie #TorontoDrinks #luma #TechNetworking #SocialEvent #TechIndustry\n#TorontoNightlife #WeekendVibes #TorontoFood #LongWeekend #friends #pheobebuffay #rachelgreen #90s #rossgeller #friendsshow #weekend #cheers",
+    caption:
+      "Happy long weekend! 🍁\nTake a break and recharge, but don’t forget to RSVP for our next TechTank social at Waterworks Foodhall on Saturday, October 26th from 6-8 PM! 🕕\nWe’re keeping it chill this month with a fun night exploring restaurants and bars, enjoying tasty food, sipping refreshing drinks, and having great conversations.\nWhether you’re a foodie or just love a good vibe, there’s something for everyone! 🍽️🍹✨\nPlease RSVP to help us with the headcount. Can’t wait to see you there! 🥂🍻\n🔗 RSVP here: lu.ma/fmi3zf6a\n#TechTank #techtankto #techtanktoronto #techtanker #techtankers #TechSocial #TorontoEvents #TorontoTech #WaterworksFoodhall #SocialEvent #TechCommunity #TorontoEats #TorontoFoodie #TorontoDrinks #luma #TechNetworking #SocialEvent #TechIndustry\n#TorontoNightlife #WeekendVibes #TorontoFood #LongWeekend #friends #pheobebuffay #rachelgreen #90s #rossgeller #friendsshow #weekend #cheers",
     date: "2024-10-11",
     shortcode: "DA_Z7SLvG1T",
     pk: 17850354615312386,
     createdAtRaw: 1728665911,
     media: [
-      { type: "image", path: "/media/instagram/2024-10-11-DAZ7SLvG1T/techtankto_DA_Z7SLvG1T_3476611462489468243.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-10-11-DAZ7SLvG1T/techtankto_DA_Z7SLvG1T_3476611462489468243.webp" },
+    ],
   },
   "2024-10-14-DBHFWyPYBI": {
-    caption: "🐠 “There’s a reason every season to be tankful for you.”\nWishing you all a happy Thanksgiving! Enjoy the long weekend with those closest to you. Have a restful day 🎃🦃🍎\n#HappyThanksgiving #techtank #techtankto #techtanktoronto #techtanker #techtankers #techcommunity#HappyTanksGivingDay #ThanksGivingDay #longweekend",
+    caption:
+      "🐠 “There’s a reason every season to be tankful for you.”\nWishing you all a happy Thanksgiving! Enjoy the long weekend with those closest to you. Have a restful day 🎃🦃🍎\n#HappyThanksgiving #techtank #techtankto #techtanktoronto #techtanker #techtankers #techcommunity#HappyTanksGivingDay #ThanksGivingDay #longweekend",
     date: "2024-10-14",
     shortcode: "DBHFWy-PYBI",
     pk: 17998274993693244,
     createdAtRaw: 1728922126,
     media: [
-      { type: "image", path: "/media/instagram/2024-10-14-DBHFWyPYBI/techtankto_DBHFWy-PYBI_3478772793959350344.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-10-14-DBHFWyPYBI/techtankto_DBHFWy-PYBI_3478772793959350344.webp" },
+    ],
   },
   "2024-10-21-DBZdF5lSjvU": {
-    caption: "Perfection can hold us back, but progress pushes us forward! 🙌 Remember, it's not about waiting for everything to be perfect—it's about getting things DONE and learning along the way. 💪✨\nHow are you pushing through today? Let’s celebrate progress over perfection. 🚀\n--- Motivational Monday is here to power up your week- to spark your creativity and fuel your ambition! In the fast-paced world of tech, it's easy to get caught up in perfectionism and endless to-do lists. Staying inspired is essential. Every Monday, we share motivational quotes, insights, and strategies to help you tackle the week ahead with confidence and focus. Whether you’re coding the next big thing, solving complex problems, or brainstorming new ideas, these posts are designed to keep you energized and moving forward. Let’s kick off each week with the momentum to innovate and grow! 🌱💻\n#DoneIsBetterThanPerfect #ProgressOverPerfection #GetItDone #TechTank #TechTankMotivation #KeepMovingForward #TechInnovation #MindsetMatters #MotivationalMondays",
+    caption:
+      "Perfection can hold us back, but progress pushes us forward! 🙌 Remember, it's not about waiting for everything to be perfect—it's about getting things DONE and learning along the way. 💪✨\nHow are you pushing through today? Let’s celebrate progress over perfection. 🚀\n--- Motivational Monday is here to power up your week- to spark your creativity and fuel your ambition! In the fast-paced world of tech, it's easy to get caught up in perfectionism and endless to-do lists. Staying inspired is essential. Every Monday, we share motivational quotes, insights, and strategies to help you tackle the week ahead with confidence and focus. Whether you’re coding the next big thing, solving complex problems, or brainstorming new ideas, these posts are designed to keep you energized and moving forward. Let’s kick off each week with the momentum to innovate and grow! 🌱💻\n#DoneIsBetterThanPerfect #ProgressOverPerfection #GetItDone #TechTank #TechTankMotivation #KeepMovingForward #TechInnovation #MindsetMatters #MotivationalMondays",
     date: "2024-10-21",
     shortcode: "DBZdF5lSjvU",
     pk: 18052059433745657,
     createdAtRaw: 1729538480,
     media: [
-      { type: "image", path: "/media/instagram/2024-10-21-DBZdF5lSjvU/techtankto_DBZdF5lSjvU_3483943735522900948.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-21-DBZdF5lSjvU/techtankto_DBZdF5lSjvU_3483943735522900948.webp",
+      },
+    ],
   },
   "2024-10-23-DBentgfSU2r": {
-    caption: "🌟 Wonder Wednesdays: Transitioning Into Tech? 🤖\nLooking to make the leap? Here are 3 tips that helped a TechTanker’s journey into the field:\n1️⃣ Practice makes perfect: Dive in and start doing! Define a problem and use tech to solve it. Learn by facing the code head-on. 💻\n2️⃣ Don’t be afraid to ask: Find connections on LinkedIn and reach out for career advice, tech direction, and job opportunities. People are more willing to help than you think! 🤝\n3️⃣ Find your passion: What drives you? Beautiful frontends, structured backends, data, ML? Your goal will fuel your growth! 🚀\n#WonderWednesdays #TechTank #TechTankTo #TechTankToronto #CareerTransition #TechJourney #LearnByDoing #TechCommunity #TorontoTech #DevLife #TechAndTools #TechTanker #TechTankers #TechTips",
+    caption:
+      "🌟 Wonder Wednesdays: Transitioning Into Tech? 🤖\nLooking to make the leap? Here are 3 tips that helped a TechTanker’s journey into the field:\n1️⃣ Practice makes perfect: Dive in and start doing! Define a problem and use tech to solve it. Learn by facing the code head-on. 💻\n2️⃣ Don’t be afraid to ask: Find connections on LinkedIn and reach out for career advice, tech direction, and job opportunities. People are more willing to help than you think! 🤝\n3️⃣ Find your passion: What drives you? Beautiful frontends, structured backends, data, ML? Your goal will fuel your growth! 🚀\n#WonderWednesdays #TechTank #TechTankTo #TechTankToronto #CareerTransition #TechJourney #LearnByDoing #TechCommunity #TorontoTech #DevLife #TechAndTools #TechTanker #TechTankers #TechTips",
     date: "2024-10-23",
     shortcode: "DBentgfSU2r",
     pk: 18029950235120660,
     createdAtRaw: 1729712327,
     media: [
-      { type: "image", path: "/media/instagram/2024-10-23-DBentgfSU2r/techtankto_DBentgfSU2r_3485397812706364843.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-23-DBentgfSU2r/techtankto_DBentgfSU2r_3485397812706364843.webp",
+      },
+    ],
   },
   "2024-10-24-DBgxiIlOOkr": {
-    caption: "🎃 Are you ready for another spook-tacular Halloween? 👻 Throwback to last year’s epic costume party where TechTank showed up in full force! We can’t wait to do it all over again this weekend. Who’s ready for more tricks, treats, and tech this year? 👾💻🧙🏻‍♂️\n#TBT #HalloweenThrowback #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers #techcommunity #dev #tb #thursday #Halloween #Toronto #TechAndTreats #SpookySeason",
+    caption:
+      "🎃 Are you ready for another spook-tacular Halloween? 👻 Throwback to last year’s epic costume party where TechTank showed up in full force! We can’t wait to do it all over again this weekend. Who’s ready for more tricks, treats, and tech this year? 👾💻🧙🏻‍♂️\n#TBT #HalloweenThrowback #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers #techcommunity #dev #tb #thursday #Halloween #Toronto #TechAndTreats #SpookySeason",
     date: "2024-10-24",
     shortcode: "DBgxiIlOOkr",
     pk: 18045624860296637,
     createdAtRaw: 1729786356,
     media: [
-      { type: "image", path: "/media/instagram/2024-10-24-DBgxiIlOOkr/techtankto_DBgxiIlOOkr_3486003942439582712.webp" },
-      { type: "image", path: "/media/instagram/2024-10-24-DBgxiIlOOkr/techtankto_DBgxiIlOOkr_3486003942448066005.webp" },
-      { type: "image", path: "/media/instagram/2024-10-24-DBgxiIlOOkr/techtankto_DBgxiIlOOkr_3486003942448157161.webp" },
-      { type: "image", path: "/media/instagram/2024-10-24-DBgxiIlOOkr/techtankto_DBgxiIlOOkr_3486003942481541681.webp" },
-      { type: "image", path: "/media/instagram/2024-10-24-DBgxiIlOOkr/techtankto_DBgxiIlOOkr_3486003942489854238.webp" },
-      { type: "image", path: "/media/instagram/2024-10-24-DBgxiIlOOkr/techtankto_DBgxiIlOOkr_3486003942523417783.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-24-DBgxiIlOOkr/techtankto_DBgxiIlOOkr_3486003942439582712.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-24-DBgxiIlOOkr/techtankto_DBgxiIlOOkr_3486003942448066005.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-24-DBgxiIlOOkr/techtankto_DBgxiIlOOkr_3486003942448157161.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-24-DBgxiIlOOkr/techtankto_DBgxiIlOOkr_3486003942481541681.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-24-DBgxiIlOOkr/techtankto_DBgxiIlOOkr_3486003942489854238.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-24-DBgxiIlOOkr/techtankto_DBgxiIlOOkr_3486003942523417783.webp",
+      },
+    ],
   },
   "2024-10-28-DBrdDK5ytZm": {
-    caption: "Breaking into tech can feel intimidating—new skills, new networks, and new challenges.\nBut remember, even the best players faced a learning curve. Babe Ruth knew that striking out was part of every home run story. Don’t let the fear of not being “ready” or “perfect” hold you back. 👷\nTech needs diverse perspectives and fresh ideas—your ideas! No one else has the unique combination of skills and experience that you have. Try listing them all down and seeing which niche or industry you can really contribute to!\nWhether you're a career shifter, recent grad, or someone with a dream of creating impact through technology, stay committed, stay curious, and keep learning!\nWe are all for education - come join us at our in person event: Edtech at Crossroads: an inspiring panel discussion that will reshape the future of EdTech! 6 PM at Rakuten Kobo Office, 150 John St, Toronto. 🚀\nOur events are a great way to network so take a swing…. because every swing gets you closer. ⚾\n#TechTank #MotivationalMonday #CareerTransition #TechCareers #DreamBig #NoFear",
+    caption:
+      "Breaking into tech can feel intimidating—new skills, new networks, and new challenges.\nBut remember, even the best players faced a learning curve. Babe Ruth knew that striking out was part of every home run story. Don’t let the fear of not being “ready” or “perfect” hold you back. 👷\nTech needs diverse perspectives and fresh ideas—your ideas! No one else has the unique combination of skills and experience that you have. Try listing them all down and seeing which niche or industry you can really contribute to!\nWhether you're a career shifter, recent grad, or someone with a dream of creating impact through technology, stay committed, stay curious, and keep learning!\nWe are all for education - come join us at our in person event: Edtech at Crossroads: an inspiring panel discussion that will reshape the future of EdTech! 6 PM at Rakuten Kobo Office, 150 John St, Toronto. 🚀\nOur events are a great way to network so take a swing…. because every swing gets you closer. ⚾\n#TechTank #MotivationalMonday #CareerTransition #TechCareers #DreamBig #NoFear",
     date: "2024-10-28",
     shortcode: "DBrdDK5ytZm",
     pk: 18048273715953539,
     createdAtRaw: 1730143285,
     media: [
-      { type: "image", path: "/media/instagram/2024-10-28-DBrdDK5ytZm/techtankto_DBrdDK5ytZm_3489010097542846054.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-28-DBrdDK5ytZm/techtankto_DBrdDK5ytZm_3489010097542846054.webp",
+      },
+    ],
   },
   "2024-10-31-DByybOYuSdw": {
-    caption: "Thought devs feared the outdoors? Think again! 🌱⚾️ From home runs to high-fives, we had an epic season on the softball field. Stay tuned for more sports action, and join our Slack community to get in on the fun ⭐️\nWe’re not just techies, we’re adrenaline chasers 💪🔥\n#DevsOutside #WeTouchGrass #SashimisSoftball #TBT #Softball #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers #techcommunity #dev #tb #thursday #toronto",
+    caption:
+      "Thought devs feared the outdoors? Think again! 🌱⚾️ From home runs to high-fives, we had an epic season on the softball field. Stay tuned for more sports action, and join our Slack community to get in on the fun ⭐️\nWe’re not just techies, we’re adrenaline chasers 💪🔥\n#DevsOutside #WeTouchGrass #SashimisSoftball #TBT #Softball #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers #techcommunity #dev #tb #thursday #toronto",
     date: "2024-10-31",
     shortcode: "DByybOYuSdw",
     pk: 18068227981563337,
     createdAtRaw: 1730389076,
     media: [
-      { type: "image", path: "/media/instagram/2024-10-31-DByybOYuSdw/techtankto_DByybOYuSdw_3491074434364155760.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-10-31-DByybOYuSdw/techtankto_DByybOYuSdw_3491074434364155760.webp",
+      },
+    ],
   },
   "2024-11-01-DB2G8ewvSZr": {
-    caption: "🌟 Earlier this week, we brought together EdTech Professionals for an inspiring panel discussion! 🚀✨\nOur event, “EdTech at the Crossroads: AI, Accessibility, and the Evolving Classroom,” sparked valuable insights about the future of education.\nHuge thanks to our panelists: Rico Chow, Chief Product Officer at SiSi Natalie Famula, Web Developer II at Prodigy Education Alex Cooksey, Senior Product Designer at Prodigy Education Patricia Park, Educator at the Toronto District School Board\nIntroductions by Riaz Virani, TechTank organizer, set the stage for an engaging discussion, moderated by Chris Taeyoung Kim, Founder & Community Organizer at TechTank 🎤📚\nKey topics included:\n	•	Leveraging AI for personalized learning and early intervention 	•	Addressing stigma and treating AI as a supportive tool 	•	Integrating AI into daily practices for lesson planning and student support 	•	Enhancing accessibility for young learners and those with learning difficulties\nWe also enjoyed meeting a cute Samoyed named Cyprus! 🐾💖\nThanks to everyone who contributed to our food drive for @dailybreadto Your generosity helps support those facing food insecurity in our community. 💖\nA big thank you to our sponsor, @kobobooks Kobo, a global leader in eReading, helps over 30 million readers access stories anytime, anywhere.\nTogether, we’re shaping the future of education! 📖🌎\nWant to stay connected?\n Join our Slack community\n🔗 https://techtankto.com/links/slack\n#edtech #futureofeducation #aiineducation #paneldiscussion #techcommunity #networking #dailybreadfoodbank #techtankto #techtank #techtabktoronto #techtankers #techtanker #learning #elearning #learningmanagementsystem\n#artificialintelligence #aiethics #techtools #education #educators",
+    caption:
+      "🌟 Earlier this week, we brought together EdTech Professionals for an inspiring panel discussion! 🚀✨\nOur event, “EdTech at the Crossroads: AI, Accessibility, and the Evolving Classroom,” sparked valuable insights about the future of education.\nHuge thanks to our panelists: Rico Chow, Chief Product Officer at SiSi Natalie Famula, Web Developer II at Prodigy Education Alex Cooksey, Senior Product Designer at Prodigy Education Patricia Park, Educator at the Toronto District School Board\nIntroductions by Riaz Virani, TechTank organizer, set the stage for an engaging discussion, moderated by Chris Taeyoung Kim, Founder & Community Organizer at TechTank 🎤📚\nKey topics included:\n	•	Leveraging AI for personalized learning and early intervention 	•	Addressing stigma and treating AI as a supportive tool 	•	Integrating AI into daily practices for lesson planning and student support 	•	Enhancing accessibility for young learners and those with learning difficulties\nWe also enjoyed meeting a cute Samoyed named Cyprus! 🐾💖\nThanks to everyone who contributed to our food drive for @dailybreadto Your generosity helps support those facing food insecurity in our community. 💖\nA big thank you to our sponsor, @kobobooks Kobo, a global leader in eReading, helps over 30 million readers access stories anytime, anywhere.\nTogether, we’re shaping the future of education! 📖🌎\nWant to stay connected?\n Join our Slack community\n🔗 https://techtankto.com/links/slack\n#edtech #futureofeducation #aiineducation #paneldiscussion #techcommunity #networking #dailybreadfoodbank #techtankto #techtank #techtabktoronto #techtankers #techtanker #learning #elearning #learningmanagementsystem\n#artificialintelligence #aiethics #techtools #education #educators",
     date: "2024-11-01",
     shortcode: "DB2G8ewvSZr",
     pk: 18054018190913837,
     createdAtRaw: 1730501139,
     media: [
-      { type: "image", path: "/media/instagram/2024-11-01-DB2G8ewvSZr/techtankto_DB2G8ewvSZr_3492009105550026347.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-01-DB2G8ewvSZr/techtankto_DB2G8ewvSZr_3492009105550026347.webp",
+      },
+    ],
   },
   "2024-11-05-DB07HJOX6Q": {
-    caption: "✨ GIVEAWAY ALERT ✨\nWe’re so close to hitting 1,000 members in the TechTank Slack community! 🥳\nTo celebrate, we’re giving away an exclusive TechTank Toque 🧢 to our 1000th member who joins. 👀\n🎉 Fun Fact: Did you know that “toque” is a Canadian word for a beanie? 🇨🇦 Keep warm and rep TechTank style with this cozy prize!\nHow to Enter:\nSimply join our Slack and become part of one of Toronto’s most inclusive, diverse, and empowering tech communities!\nYou could be our lucky 1000th member and score the coveted toque. 🚀\n📍 RULES:\n- Must be located in Toronto. - Prize awarded to the 1000th member to join.\n🔗 Join here: https://techtankto.com/links/slack\nor check our linktree 🔗 https://linktr.ee/techtankto\nHuge thanks to everyone who’s made TechTank a welcoming and dynamic space for all tech enthusiasts. 🐠 🐟 🐠\nHelp us reach this milestone—tag a friend who should join the squad! 💙\n#JoinTechTank #ToqueGiveaway #TechCommunityToronto #TechTank #TechTankTo #TechTankToronto #ContestToronto #FreeTouque #TechTanker #TechTankers #Slack #torontofreebies #giveaway #toque #devcommunity #dev\n#toronto #6ix #torontonly #diversetech #inclusive #uxui #projectmanager #socialmedia #marketingdigital #qa #techlead #productdesigner #productmanager",
+    caption:
+      "✨ GIVEAWAY ALERT ✨\nWe’re so close to hitting 1,000 members in the TechTank Slack community! 🥳\nTo celebrate, we’re giving away an exclusive TechTank Toque 🧢 to our 1000th member who joins. 👀\n🎉 Fun Fact: Did you know that “toque” is a Canadian word for a beanie? 🇨🇦 Keep warm and rep TechTank style with this cozy prize!\nHow to Enter:\nSimply join our Slack and become part of one of Toronto’s most inclusive, diverse, and empowering tech communities!\nYou could be our lucky 1000th member and score the coveted toque. 🚀\n📍 RULES:\n- Must be located in Toronto. - Prize awarded to the 1000th member to join.\n🔗 Join here: https://techtankto.com/links/slack\nor check our linktree 🔗 https://linktr.ee/techtankto\nHuge thanks to everyone who’s made TechTank a welcoming and dynamic space for all tech enthusiasts. 🐠 🐟 🐠\nHelp us reach this milestone—tag a friend who should join the squad! 💙\n#JoinTechTank #ToqueGiveaway #TechCommunityToronto #TechTank #TechTankTo #TechTankToronto #ContestToronto #FreeTouque #TechTanker #TechTankers #Slack #torontofreebies #giveaway #toque #devcommunity #dev\n#toronto #6ix #torontonly #diversetech #inclusive #uxui #projectmanager #socialmedia #marketingdigital #qa #techlead #productdesigner #productmanager",
     date: "2024-11-05",
     shortcode: "DB_07HJOX6Q",
     pk: 18021829199300283,
     createdAtRaw: 1730826028,
     media: [
-      { type: "image", path: "/media/instagram/2024-11-05-DB07HJOX6Q/techtankto_DB_07HJOX6Q_3494744596401454736.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-11-05-DB07HJOX6Q/techtankto_DB_07HJOX6Q_3494744596401454736.webp" },
+    ],
   },
   "2024-11-07-DCFhk3OvZVx": {
-    caption: "Throw back to our event from a year ago! 🚀✨ Huge thanks to our sponsor, Rakuten Kobo, for hosting us in their amazing office 2 years in a row! 🖥️💡 Who remembers the insightful talks, the coding tips, and of course, the snacks? 🍕🤓 Here’s to more meetups, more learning, and more memories!\n#TBT #TechTank #RakutenKobo #TechTankTo #TechTankToronto #TechTanker #TechCommunity #TechTankers #dev #tb #thursday #Toronto #meetups #networking",
+    caption:
+      "Throw back to our event from a year ago! 🚀✨ Huge thanks to our sponsor, Rakuten Kobo, for hosting us in their amazing office 2 years in a row! 🖥️💡 Who remembers the insightful talks, the coding tips, and of course, the snacks? 🍕🤓 Here’s to more meetups, more learning, and more memories!\n#TBT #TechTank #RakutenKobo #TechTankTo #TechTankToronto #TechTanker #TechCommunity #TechTankers #dev #tb #thursday #Toronto #meetups #networking",
     date: "2024-11-07",
     shortcode: "DCFhk3OvZVx",
     pk: 18043548824283056,
     createdAtRaw: 1731017226,
     media: [
-      { type: "image", path: "/media/instagram/2024-11-07-DCFhk3OvZVx/techtankto_DCFhk3OvZVx_3496348345503233145.webp" },
-      { type: "image", path: "/media/instagram/2024-11-07-DCFhk3OvZVx/techtankto_DCFhk3OvZVx_3496348345511538947.webp" },
-      { type: "image", path: "/media/instagram/2024-11-07-DCFhk3OvZVx/techtankto_DCFhk3OvZVx_3496348345687656065.webp" },
-      { type: "image", path: "/media/instagram/2024-11-07-DCFhk3OvZVx/techtankto_DCFhk3OvZVx_3496348345738068339.webp" },
-      { type: "image", path: "/media/instagram/2024-11-07-DCFhk3OvZVx/techtankto_DCFhk3OvZVx_3496348345746379858.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-07-DCFhk3OvZVx/techtankto_DCFhk3OvZVx_3496348345503233145.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-07-DCFhk3OvZVx/techtankto_DCFhk3OvZVx_3496348345511538947.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-07-DCFhk3OvZVx/techtankto_DCFhk3OvZVx_3496348345687656065.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-07-DCFhk3OvZVx/techtankto_DCFhk3OvZVx_3496348345738068339.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-07-DCFhk3OvZVx/techtankto_DCFhk3OvZVx_3496348345746379858.webp",
+      },
+    ],
   },
   "2024-11-09-DCHmwcEvQj": {
-    caption: "Wait… someone actually bought *guthib.com* just to call out our spelling fails?! 🤯😂\nThe internet never disappoints! #MindBlown\n#GitHub #Guthib #DeveloperMemes #TechTank #CodingLife #ProgrammingHumor #SurpriseMoment #TechTankTo #DevMemes #TechTankToronto #CodingCommunity #TypoAlert #InternetWins #TechLife #SoftwareDev #DevLife #TechSurprises #CodeHumor #curbyourenthusiasm #oopsmoment #FunnyTech #techtanker #techtankers #funfridays #friday #friyay #friyayvibes #frolic",
+    caption:
+      "Wait… someone actually bought *guthib.com* just to call out our spelling fails?! 🤯😂\nThe internet never disappoints! #MindBlown\n#GitHub #Guthib #DeveloperMemes #TechTank #CodingLife #ProgrammingHumor #SurpriseMoment #TechTankTo #DevMemes #TechTankToronto #CodingCommunity #TypoAlert #InternetWins #TechLife #SoftwareDev #DevLife #TechSurprises #CodeHumor #curbyourenthusiasm #oopsmoment #FunnyTech #techtanker #techtankers #funfridays #friday #friyay #friyayvibes #frolic",
     date: "2024-11-09",
     shortcode: "DCHmwcEvQ_j",
     pk: 18036852710252612,
     createdAtRaw: 1731196249,
     media: [
-      { type: "image", path: "/media/instagram/2024-11-09-DCHmwcEvQj/techtankto_DCHmwcEvQ_j_3496934090123055075.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-11-09-DCHmwcEvQj/techtankto_DCHmwcEvQ_j_3496934090123055075.webp" },
+    ],
   },
   "2024-11-10-DBjhqNBPqns": {
-    caption: "🧟‍♂️ When your search history starts looking like a Halloween horror flick… 🧟‍♀️\n👻 “How to find and kill zombie process in Linux” 🔪 “How to kill child from parent with fork” 🧠 “Fixing memory leaks in Python” 🧵 “Detached head in Git”\nAs a programmer, sometimes it feels like we’re running from real monsters… and memory leaks are scarier than any ghost 👻!\nDestroying zombies in Linux and children in Unity?\nJust another day in the life of a dev-slash-serial (bug) killer! 🖥️💀\n#TechTankToronto #TechTanker #TechTankers #CodeOrDie #TechHorror #HalloweenCode #DevNightmares #DebuggingIsLife #CodeOfTheDead #Git #MemoryLeaks #TechTank #TechTankTO #DevCommunity #ZombieProcess #UnityDev #PythonProblems #LinuxLife #GitGood #ForkIt #KillTheBugs #CodingStruggles #DeveloperLife #CodeSpooky #DevMemes #DevToronto #yyz #toronto",
+    caption:
+      "🧟‍♂️ When your search history starts looking like a Halloween horror flick… 🧟‍♀️\n👻 “How to find and kill zombie process in Linux” 🔪 “How to kill child from parent with fork” 🧠 “Fixing memory leaks in Python” 🧵 “Detached head in Git”\nAs a programmer, sometimes it feels like we’re running from real monsters… and memory leaks are scarier than any ghost 👻!\nDestroying zombies in Linux and children in Unity?\nJust another day in the life of a dev-slash-serial (bug) killer! 🖥️💀\n#TechTankToronto #TechTanker #TechTankers #CodeOrDie #TechHorror #HalloweenCode #DevNightmares #DebuggingIsLife #CodeOfTheDead #Git #MemoryLeaks #TechTank #TechTankTO #DevCommunity #ZombieProcess #UnityDev #PythonProblems #LinuxLife #GitGood #ForkIt #KillTheBugs #CodingStruggles #DeveloperLife #CodeSpooky #DevMemes #DevToronto #yyz #toronto",
     date: "2024-11-10",
     shortcode: "DBjhqNBPqns",
     pk: 18021640388307932,
     createdAtRaw: 1731221663,
     media: [
-      { type: "image", path: "/media/instagram/2024-11-10-DBjhqNBPqns/techtankto_DBjhqNBPqns_3486778572247312876.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-10-DBjhqNBPqns/techtankto_DBjhqNBPqns_3486778572247312876.webp",
+      },
+    ],
   },
   "2024-11-11-DCPpNYhbu": {
-    caption: "🔨 Ready to enter the tech world? Remember: If opportunity doesn’t knock, build a door! 💡\nTech can be a tough industry to break into, but resilience and resourcefulness make all the difference. Whether it’s refining your skills, expanding your network, or launching a passion project, every step you take is a door you’re building toward your next opportunity. 🚀💻 And you don’t have to do it alone...\nWe have a community on Slack supporting each other through their tech journey - join us and be updated on our upcoming events, new job posts in the city, or just be a part of a community that will help you build more doors.\n🔗 https://linktr.ee/techtankto or click the link on our bio.\n#MotivationMonday #BuildYourPath #TechTransitions #CareerGrowth #TechTank",
+    caption:
+      "🔨 Ready to enter the tech world? Remember: If opportunity doesn’t knock, build a door! 💡\nTech can be a tough industry to break into, but resilience and resourcefulness make all the difference. Whether it’s refining your skills, expanding your network, or launching a passion project, every step you take is a door you’re building toward your next opportunity. 🚀💻 And you don’t have to do it alone...\nWe have a community on Slack supporting each other through their tech journey - join us and be updated on our upcoming events, new job posts in the city, or just be a part of a community that will help you build more doors.\n🔗 https://linktr.ee/techtankto or click the link on our bio.\n#MotivationMonday #BuildYourPath #TechTransitions #CareerGrowth #TechTank",
     date: "2024-11-11",
     shortcode: "DCPpNY-hb_u",
     pk: 18467247091001953,
     createdAtRaw: 1731356772,
     media: [
       { type: "image", path: "/media/instagram/2024-11-11-DCPpNYhbu/techtankto_DCPMcRQPHdR_3499070154719655761.webp" },
-      { type: "image", path: "/media/instagram/2024-11-11-DCPpNYhbu/techtankto_DCPpNY-hb_u_3499196675569074158.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-11-11-DCPpNYhbu/techtankto_DCPpNY-hb_u_3499196675569074158.webp" },
+    ],
   },
   "2024-11-14-DCW5HP3xmld": {
-    caption: "Flashback to a year ago, when we shared an unforgettable night of tech talks, meaningful connections, and a vibrant sense of community! 💬✨\nOur event on Large Language Models wasn’t just about AI — it was about bringing brilliant minds together to learn, share, and network.\n🚀 Here’s to more nights of innovation and inspiration! 🌐🤝\nJoin us today for this month’s event! Meetup link in our bio 🔗\n#ThrowbackThursday #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers #TBT #techcommunity #dev #tb #thursday #Networking #Toronto #LLM #AI #LanguageModels",
+    caption:
+      "Flashback to a year ago, when we shared an unforgettable night of tech talks, meaningful connections, and a vibrant sense of community! 💬✨\nOur event on Large Language Models wasn’t just about AI — it was about bringing brilliant minds together to learn, share, and network.\n🚀 Here’s to more nights of innovation and inspiration! 🌐🤝\nJoin us today for this month’s event! Meetup link in our bio 🔗\n#ThrowbackThursday #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers #TBT #techcommunity #dev #tb #thursday #Networking #Toronto #LLM #AI #LanguageModels",
     date: "2024-11-14",
     shortcode: "DCW5HP3xmld",
     pk: 18022648364535931,
     createdAtRaw: 1731599992,
     media: [
-      { type: "image", path: "/media/instagram/2024-11-14-DCW5HP3xmld/techtankto_DCW5HP3xmld_3501236937485090092.webp" },
-      { type: "image", path: "/media/instagram/2024-11-14-DCW5HP3xmld/techtankto_DCW5HP3xmld_3501236937518577314.webp" },
-      { type: "image", path: "/media/instagram/2024-11-14-DCW5HP3xmld/techtankto_DCW5HP3xmld_3501236937518686340.webp" },
-      { type: "image", path: "/media/instagram/2024-11-14-DCW5HP3xmld/techtankto_DCW5HP3xmld_3501236937552131993.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-14-DCW5HP3xmld/techtankto_DCW5HP3xmld_3501236937485090092.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-14-DCW5HP3xmld/techtankto_DCW5HP3xmld_3501236937518577314.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-14-DCW5HP3xmld/techtankto_DCW5HP3xmld_3501236937518686340.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-14-DCW5HP3xmld/techtankto_DCW5HP3xmld_3501236937552131993.webp",
+      },
+    ],
   },
   "2024-11-15-DCZhoCkPPdf": {
-    caption: "The only ‘end’ I want to see is the weekend at this point. 😅\nI just want to rest after the debugging stress. 💻 🧘🧘‍♀️🧘‍♂️\n\n#DevLife #takeabreak #naptime #weekendmood #weekend\n#weekendvibes #friyay #funfridays #techtank #techtankto #techtanktoronto #techtankers #techtanker #frontend #backend #weekend #developers #devlife #drake #oldiebutgoodie",
+    caption:
+      "The only ‘end’ I want to see is the weekend at this point. 😅\nI just want to rest after the debugging stress. 💻 🧘🧘‍♀️🧘‍♂️\n\n#DevLife #takeabreak #naptime #weekendmood #weekend\n#weekendvibes #friyay #funfridays #techtank #techtankto #techtanktoronto #techtankers #techtanker #frontend #backend #weekend #developers #devlife #drake #oldiebutgoodie",
     date: "2024-11-15",
     shortcode: "DCZhoCkPPdf",
     pk: 18016335188341422,
     createdAtRaw: 1731688841,
     media: [
-      { type: "image", path: "/media/instagram/2024-11-15-DCZhoCkPPdf/techtankto_DCZhoCkPPdf_3501978072326666079.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-15-DCZhoCkPPdf/techtankto_DCZhoCkPPdf_3501978072326666079.webp",
+      },
+    ],
   },
   "2024-11-18-DChoRIcBP9R": {
-    caption: "“A good programmer looks both ways before crossing a one-way street.” Why? Because in tech, things aren’t always as they seem! 🚦\nImagine debugging a feature you’re confident only has one source of error, but a surprise dependency pops up from an unexpected place.\nStaying curious, cautious, and adaptable can save the day. As a new developer transitioning into tech, remember: thinking ahead and preparing for the unexpected sets you apart. Keep pushing, keep learning, and keep coding! 💪\n#TechTank #MotivationalMonday #NewDevelopers #StayAhead #AdaptAndThrive",
+    caption:
+      "“A good programmer looks both ways before crossing a one-way street.” Why? Because in tech, things aren’t always as they seem! 🚦\nImagine debugging a feature you’re confident only has one source of error, but a surprise dependency pops up from an unexpected place.\nStaying curious, cautious, and adaptable can save the day. As a new developer transitioning into tech, remember: thinking ahead and preparing for the unexpected sets you apart. Keep pushing, keep learning, and keep coding! 💪\n#TechTank #MotivationalMonday #NewDevelopers #StayAhead #AdaptAndThrive",
     date: "2024-11-18",
     shortcode: "DChoRIcBP9R",
     pk: 17955183749738958,
     createdAtRaw: 1731960259,
     media: [
-      { type: "image", path: "/media/instagram/2024-11-18-DChoRIcBP9R/techtankto_DChoRIcBP9R_3504259084222529361.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-18-DChoRIcBP9R/techtankto_DChoRIcBP9R_3504259084222529361.webp",
+      },
+    ],
   },
   "2024-11-20-DCm66dGvnI": {
-    caption: "Come hang out with Nhi 👋 running this month’s TechTank social, and we’re hitting the pool hall! 🎱✨🚨\nSo far, she’s taken down TWO admins—who’s next? 😏\nBring your A-game, your best smack talk, and come beat her! 🔥💥💪\nChallenge Accepted!\nRegistration 🌐 : https://lu.ma/8qe5mdb7\nWhen 📅 : Saturday, Nov 23rd, 5PM\nWhere 📍: Exact location will drop when you register! 🔥\nAdmission 🎱 : Costs to be split amongst participants\nCome for the competition, stay for the vibes! Let’s make it a night to remember. ✨\nCan’t make it this weekend? That’s OK! Stay tuned on the next social on our slack community for future events. Check the Linktree on our profile to join in!\n#TechTank #TechTankToronto #YYZ #TorontoTech #TorontoLife #SocialToronto #DevCommunity #TechEvents #6ix #toronto #Luma #hangouts #techtankto #techtankers #techtanker",
+    caption:
+      "Come hang out with Nhi 👋 running this month’s TechTank social, and we’re hitting the pool hall! 🎱✨🚨\nSo far, she’s taken down TWO admins—who’s next? 😏\nBring your A-game, your best smack talk, and come beat her! 🔥💥💪\nChallenge Accepted!\nRegistration 🌐 : https://lu.ma/8qe5mdb7\nWhen 📅 : Saturday, Nov 23rd, 5PM\nWhere 📍: Exact location will drop when you register! 🔥\nAdmission 🎱 : Costs to be split amongst participants\nCome for the competition, stay for the vibes! Let’s make it a night to remember. ✨\nCan’t make it this weekend? That’s OK! Stay tuned on the next social on our slack community for future events. Check the Linktree on our profile to join in!\n#TechTank #TechTankToronto #YYZ #TorontoTech #TorontoLife #SocialToronto #DevCommunity #TechEvents #6ix #toronto #Luma #hangouts #techtankto #techtankers #techtanker",
     date: "2024-11-20",
     shortcode: "DCm66dGvnI_",
     pk: 18050761831952622,
     createdAtRaw: 1732138145,
     media: [
-      { type: "image", path: "/media/instagram/2024-11-20-DCm66dGvnI/techtankto_DCm66dGvnI__3505748463633461823.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-11-20-DCm66dGvnI/techtankto_DCm66dGvnI__3505748463633461823.webp" },
+    ],
   },
   "2024-11-21-DCpBLdmvBl1": {
-    caption: "As the days get colder ❄️ reminiscing about our epic Blue Mountain weekend last winter ☃️ snowboarding, hiking, cozy cottage vibes, and a few battle scars to keep it real! 🏂🐾\nJoin the fun 🔗 link in bio to join our Slack\n#WinterAdventure #TBT #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers #techcommunity #dev #thursday #tb #Cottage #Friends",
+    caption:
+      "As the days get colder ❄️ reminiscing about our epic Blue Mountain weekend last winter ☃️ snowboarding, hiking, cozy cottage vibes, and a few battle scars to keep it real! 🏂🐾\nJoin the fun 🔗 link in bio to join our Slack\n#WinterAdventure #TBT #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers #techcommunity #dev #thursday #tb #Cottage #Friends",
     date: "2024-11-21",
     shortcode: "DCpBLdmvBl1",
     pk: 18145153558344730,
     createdAtRaw: 1732208201,
     media: [
-      { type: "image", path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953420465759.webp" },
-      { type: "image", path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953437138357.webp" },
-      { type: "image", path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953437337342.webp" },
-      { type: "image", path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953437356275.webp" },
-      { type: "image", path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953579736550.webp" },
-      { type: "image", path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953579981420.webp" },
-      { type: "image", path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953605020597.webp" },
-      { type: "image", path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953688944594.webp" },
-      { type: "image", path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953688960216.webp" },
-      { type: "image", path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953722397276.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953420465759.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953437138357.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953437337342.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953437356275.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953579736550.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953579981420.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953605020597.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953688944594.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953688960216.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-21-DCpBLdmvBl1/techtankto_DCpBLdmvBl1_3506338953722397276.webp",
+      },
+    ],
   },
   "2024-11-25-DCzpnzENKdU": {
-    caption: "Feeling stuck or doubting your skills? Here’s a reminder: You’re doing better than you think! 💻✨\nSomeone out there is still navigating the web on a widely outdated tool like Internet Explorer (sorry/not sorry if you're an IE user! ✌)\nThis is proof that progress is all about perspective. 🚀\nWhether you’re tackling a new project, learning something new, or just trying to get through the day, you’re already ahead just by showing up and trying. Keep moving forward. You've got this! 💪💡\nJoin our community of tech enthusiasts for support, inspiration, and job posts!\n🔗 Link in our bio.\n#MotivationalMonday #TechTankInspo #KeepGoing #YouGotThis",
+    caption:
+      "Feeling stuck or doubting your skills? Here’s a reminder: You’re doing better than you think! 💻✨\nSomeone out there is still navigating the web on a widely outdated tool like Internet Explorer (sorry/not sorry if you're an IE user! ✌)\nThis is proof that progress is all about perspective. 🚀\nWhether you’re tackling a new project, learning something new, or just trying to get through the day, you’re already ahead just by showing up and trying. Keep moving forward. You've got this! 💪💡\nJoin our community of tech enthusiasts for support, inspiration, and job posts!\n🔗 Link in our bio.\n#MotivationalMonday #TechTankInspo #KeepGoing #YouGotThis",
     date: "2024-11-25",
     shortcode: "DCzpnzENKdU",
     pk: 17993237915725183,
     createdAtRaw: 1732564947,
     media: [
-      { type: "image", path: "/media/instagram/2024-11-25-DCzpnzENKdU/techtankto_DCzpnzENKdU_3509331589449688916.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-25-DCzpnzENKdU/techtankto_DCzpnzENKdU_3509331589449688916.webp",
+      },
+    ],
   },
   "2024-11-28-DC7de7mv4Qc": {
-    caption: "🚀 Fueling Growth- Generative AI & RAG in FP&A— What a ride! 🚀\nLast meetup TechTank teamed up with Vena Solutions to explore how Generative AI and RAG (Retrieval-Augmented Generation) are changing the game in Financial Planning & Analysis (FP&A)! 💡 From chat completions to semantic search, these cutting-edge tools are making data smarter, faster, and more actionable than ever before.\nHuge shoutout to our amazing speakers:\n- Chris Taeyoung Kim for kicking things off and introducing TechTank 🔥\n- Jasper Chow from Vena for sharing how Generative AI and RAG are driving innovation at Vena 💼\n- Kevin Chan for breaking down the technical magic behind RAG and vector databases 💻\n- Shahin Imtiaz for giving us the lowdown on metadata filtering and hybrid search 🔍\n- And of course, Ben Lokash, all the volunteers for making sure everything ran smoothly 🙌\nKey Highlights 👉 How RAG and semantic search are improving FP&A decision-making 📈 👉 Hands-on Jupyter Notebooks and example code in the GitHub repo 📂 👉 Cool tools like JSON schemas and Pydantic for API integration 🔧\nBig thanks to HashTank for capturing all the media moments 📸 and to Vena Solutions for their awesome support! 💪\nCheck out the resources below and let’s keep the conversation going! 💬\n🔗 GitHub Repo: https://github.com/khchan/building-blocks-ai\n✅ Careers at Vena: https://workforcenow.adp.com/mascsr/default/mdf/recruitment/recruitment.html?cid=b8031fb7-5175-4b0a-a6f0-181210d99213&ccId=19000101_000001&lang=en_US\n🌐 Join our TechTank community: https://linktr.ee/techtankto\nHere’s the direct YouTube recording: 🔗https://youtu.be/2UTsy-Lbulk?si=UCxIQxrNef_J-hE3\nAnd a BIG thanks to everyone who braved Toronto traffic during the Taylor Swift Eras Tour to join us! See you at the next event! 🚗💨\n#GenerativeAI #RAG #FP #dataanalytics #TechTank #TechTankTO #TechTanker #TechTankers #VenaSolutions #AI #techtanktoronto #MachineLearning #DataScience #Innovation #TechEvents #ArtificialIntelligence #TechCommunity #FinancialAnalysis #FinancialPlanning #TechTalks #Jupyter #Python #DataAnalysis #CareerOpportunities #TechNetworking #LLM #AIPromting",
+    caption:
+      "🚀 Fueling Growth- Generative AI & RAG in FP&A— What a ride! 🚀\nLast meetup TechTank teamed up with Vena Solutions to explore how Generative AI and RAG (Retrieval-Augmented Generation) are changing the game in Financial Planning & Analysis (FP&A)! 💡 From chat completions to semantic search, these cutting-edge tools are making data smarter, faster, and more actionable than ever before.\nHuge shoutout to our amazing speakers:\n- Chris Taeyoung Kim for kicking things off and introducing TechTank 🔥\n- Jasper Chow from Vena for sharing how Generative AI and RAG are driving innovation at Vena 💼\n- Kevin Chan for breaking down the technical magic behind RAG and vector databases 💻\n- Shahin Imtiaz for giving us the lowdown on metadata filtering and hybrid search 🔍\n- And of course, Ben Lokash, all the volunteers for making sure everything ran smoothly 🙌\nKey Highlights 👉 How RAG and semantic search are improving FP&A decision-making 📈 👉 Hands-on Jupyter Notebooks and example code in the GitHub repo 📂 👉 Cool tools like JSON schemas and Pydantic for API integration 🔧\nBig thanks to HashTank for capturing all the media moments 📸 and to Vena Solutions for their awesome support! 💪\nCheck out the resources below and let’s keep the conversation going! 💬\n🔗 GitHub Repo: https://github.com/khchan/building-blocks-ai\n✅ Careers at Vena: https://workforcenow.adp.com/mascsr/default/mdf/recruitment/recruitment.html?cid=b8031fb7-5175-4b0a-a6f0-181210d99213&ccId=19000101_000001&lang=en_US\n🌐 Join our TechTank community: https://linktr.ee/techtankto\nHere’s the direct YouTube recording: 🔗https://youtu.be/2UTsy-Lbulk?si=UCxIQxrNef_J-hE3\nAnd a BIG thanks to everyone who braved Toronto traffic during the Taylor Swift Eras Tour to join us! See you at the next event! 🚗💨\n#GenerativeAI #RAG #FP #dataanalytics #TechTank #TechTankTO #TechTanker #TechTankers #VenaSolutions #AI #techtanktoronto #MachineLearning #DataScience #Innovation #TechEvents #ArtificialIntelligence #TechCommunity #FinancialAnalysis #FinancialPlanning #TechTalks #Jupyter #Python #DataAnalysis #CareerOpportunities #TechNetworking #LLM #AIPromting",
     date: "2024-11-28",
     shortcode: "DC7de7mv4Qc",
     pk: 18137267959368349,
     createdAtRaw: 1732827262,
     media: [
-      { type: "image", path: "/media/instagram/2024-11-28-DC7de7mv4Qc/techtankto_DC7de7mv4Qc_3511530003399410716.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-28-DC7de7mv4Qc/techtankto_DC7de7mv4Qc_3511530003399410716.webp",
+      },
+    ],
   },
   "2024-11-30-DDAP9IkvaZU": {
-    caption: "🎉💻 Happy Computer Security Day! 💻🎉\nCelebrated every November 30th, was first established in 1988 to raise awareness about protecting your data, devices, and online activities. 🛡️(Mostly in the USA)\n🔑 3 Security Tips to Stay Safe:\n1️⃣ Use a password manager:\nSecurely store unique, strong passwords for every account. Tools like LastPass or Bitwarden make it easy!\n2️⃣ Back up your files:\nPrevent data loss by saving backups on cloud services (like Google Drive) or external drives.\n3️⃣ Enable two-factor authentication (2FA):\nAdd an extra security step to your accounts with codes or biometrics.\n💡 Learn more about Computer Security Day here:\nhttps://www.digicert.com/blog/computer-security-day\n🤖 Join our Slack community for more tech tips, events, and conversations with fellow tech enthusiasts!\nCheck out all our links at linktr.ee/techtankto\n#techtank #techtankto #techtankers #techtanktoronto #techtanker #CyberSecurity #ComputerSecurityDay #DigitalSafety #OnlineProtection #DataBackups #PasswordManager #2FA #StaySecure #TechTips #TechCommunity #digicert",
+    caption:
+      "🎉💻 Happy Computer Security Day! 💻🎉\nCelebrated every November 30th, was first established in 1988 to raise awareness about protecting your data, devices, and online activities. 🛡️(Mostly in the USA)\n🔑 3 Security Tips to Stay Safe:\n1️⃣ Use a password manager:\nSecurely store unique, strong passwords for every account. Tools like LastPass or Bitwarden make it easy!\n2️⃣ Back up your files:\nPrevent data loss by saving backups on cloud services (like Google Drive) or external drives.\n3️⃣ Enable two-factor authentication (2FA):\nAdd an extra security step to your accounts with codes or biometrics.\n💡 Learn more about Computer Security Day here:\nhttps://www.digicert.com/blog/computer-security-day\n🤖 Join our Slack community for more tech tips, events, and conversations with fellow tech enthusiasts!\nCheck out all our links at linktr.ee/techtankto\n#techtank #techtankto #techtankers #techtanktoronto #techtanker #CyberSecurity #ComputerSecurityDay #DigitalSafety #OnlineProtection #DataBackups #PasswordManager #2FA #StaySecure #TechTips #TechCommunity #digicert",
     date: "2024-11-30",
     shortcode: "DDAP9IkvaZU",
     pk: 18028029848206182,
     createdAtRaw: 1732996011,
     media: [
-      { type: "image", path: "/media/instagram/2024-11-30-DDAP9IkvaZU/techtankto_DDAP9IkvaZU_3512877881141077588.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-11-30-DDAP9IkvaZU/techtankto_DDAP9IkvaZU_3512877881141077588.webp",
+      },
+    ],
   },
   "2024-12-02-DDFWKMavIG": {
-    caption: "Progress in tech—and in life—isn’t about perfection; it’s about iteration. 💡 That messy first draft? It’s the foundation for greatness.\nPush it to the repo of life, let feedback guide you, and watch yourself grow.\nProgress is built step by step, commit by commit. Keep iterating—you’re on your way to something amazing! 💻✨\nJoin our Slack community to network and get feedback!\n🔗Link in bio\n#MotivationalMonday #TechTankInspo #KeepIterating #ProgressNotPerfection #TechTank #TechTankTo #TechTankToronto #TechTankers #TechTanker #LifeLongLearning",
+    caption:
+      "Progress in tech—and in life—isn’t about perfection; it’s about iteration. 💡 That messy first draft? It’s the foundation for greatness.\nPush it to the repo of life, let feedback guide you, and watch yourself grow.\nProgress is built step by step, commit by commit. Keep iterating—you’re on your way to something amazing! 💻✨\nJoin our Slack community to network and get feedback!\n🔗Link in bio\n#MotivationalMonday #TechTankInspo #KeepIterating #ProgressNotPerfection #TechTank #TechTankTo #TechTankToronto #TechTankers #TechTanker #LifeLongLearning",
     date: "2024-12-02",
     shortcode: "DDFWKMavI_G",
     pk: 18335066851145190,
     createdAtRaw: 1733158724,
     media: [
-      { type: "image", path: "/media/instagram/2024-12-02-DDFWKMavIG/techtankto_DDFWKMavI_G_3514312541784018886.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-12-02-DDFWKMavIG/techtankto_DDFWKMavI_G_3514312541784018886.webp" },
+    ],
   },
   "2024-12-03-DDHtcovAURw": {
-    caption: "Feeling like an imposter in tech? You're not alone! 💻💭\nAt our recent Code Diversity meetup, we dove deep into Imposter Syndrome—a challenge that impacts both new and seasoned developers.\nHere are 6 actionable tips to help you tackle self-doubt and celebrate your growth:\n1️⃣ Acknowledge the imposter – Recognize self-doubt and reframe negative thoughts. 2️⃣ Celebrate your wins – Keep a “brag folder” and share your accomplishments with peers! 3️⃣ Foster community – Build connections to normalize and navigate these feelings. 4️⃣ Focus on growth, not perfection – Mistakes are part of learning. Take small, actionable steps. 5️⃣ Challenge comparisons – Reflect on your unique journey and milestones. 6️⃣ Practice self-compassion – Be kind to yourself and take breaks when needed.\nWe’re all on this journey together—learning, growing, and thriving. Share one of your wins in the comments! Let’s celebrate 🎉\nMeetups happen once a month in small, intimate groups. 💬 Want to join the conversation and keep it going? Register on Meetup for the next event, and hop into our Slack channel, # Code Diversity, to connect with others in the community. Link in bio!\n#CodeDiversity\n#ImposterSyndrome #WomenInTech #NonBinaryInTech #TechCommunity #GrowthMindset #DeveloperLife #CelebrateWins #CodeNewbie #WomenWhoCode #TechTips #MentalHealthInTech #SelfCompassion #CareerGrowth #TechCareers #LearnToCode #TechJourney #InclusiveTech #WomenInSTEM #BreakTheBias #SupportSystem",
+    caption:
+      "Feeling like an imposter in tech? You're not alone! 💻💭\nAt our recent Code Diversity meetup, we dove deep into Imposter Syndrome—a challenge that impacts both new and seasoned developers.\nHere are 6 actionable tips to help you tackle self-doubt and celebrate your growth:\n1️⃣ Acknowledge the imposter – Recognize self-doubt and reframe negative thoughts. 2️⃣ Celebrate your wins – Keep a “brag folder” and share your accomplishments with peers! 3️⃣ Foster community – Build connections to normalize and navigate these feelings. 4️⃣ Focus on growth, not perfection – Mistakes are part of learning. Take small, actionable steps. 5️⃣ Challenge comparisons – Reflect on your unique journey and milestones. 6️⃣ Practice self-compassion – Be kind to yourself and take breaks when needed.\nWe’re all on this journey together—learning, growing, and thriving. Share one of your wins in the comments! Let’s celebrate 🎉\nMeetups happen once a month in small, intimate groups. 💬 Want to join the conversation and keep it going? Register on Meetup for the next event, and hop into our Slack channel, # Code Diversity, to connect with others in the community. Link in bio!\n#CodeDiversity\n#ImposterSyndrome #WomenInTech #NonBinaryInTech #TechCommunity #GrowthMindset #DeveloperLife #CelebrateWins #CodeNewbie #WomenWhoCode #TechTips #MentalHealthInTech #SelfCompassion #CareerGrowth #TechCareers #LearnToCode #TechJourney #InclusiveTech #WomenInSTEM #BreakTheBias #SupportSystem",
     date: "2024-12-03",
     shortcode: "DDHtcovAURw",
     pk: 18073974565623772,
     createdAtRaw: 1733238042,
     media: [
-      { type: "image", path: "/media/instagram/2024-12-03-DDHtcovAURw/techtankto_DDHtcovAURw_3514977895976222728.webp" },
-      { type: "image", path: "/media/instagram/2024-12-03-DDHtcovAURw/techtankto_DDHtcovAURw_3514977895992915567.webp" },
-      { type: "image", path: "/media/instagram/2024-12-03-DDHtcovAURw/techtankto_DDHtcovAURw_3514977896303294095.webp" },
-      { type: "image", path: "/media/instagram/2024-12-03-DDHtcovAURw/techtankto_DDHtcovAURw_3514977896311670364.webp" },
-      { type: "image", path: "/media/instagram/2024-12-03-DDHtcovAURw/techtankto_DDHtcovAURw_3514977896454187404.webp" },
-      { type: "image", path: "/media/instagram/2024-12-03-DDHtcovAURw/techtankto_DDHtcovAURw_3514977896697634616.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-03-DDHtcovAURw/techtankto_DDHtcovAURw_3514977895976222728.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-03-DDHtcovAURw/techtankto_DDHtcovAURw_3514977895992915567.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-03-DDHtcovAURw/techtankto_DDHtcovAURw_3514977896303294095.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-03-DDHtcovAURw/techtankto_DDHtcovAURw_3514977896311670364.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-03-DDHtcovAURw/techtankto_DDHtcovAURw_3514977896454187404.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-03-DDHtcovAURw/techtankto_DDHtcovAURw_3514977896697634616.webp",
+      },
+    ],
   },
   "2024-12-04-DDKp0Kbv259": {
-    caption: "🎉 A Shoutout to Our Amazing Community!\nThank you, Marms W, for sharing your first impression of our #CodeDiversity community! 💬\nTechTank\ncoffee meetup called Code Diversity brought together an inspiring group of developers to talk about various topics, celebrating achievements, and learning from one another.\nYour story reminds us why these meetups matter so much: creating a space where Women & Gender-Diverse Folks in Tech can connect, grow, and feel supported. 🌟\n📅 Want to join the next one? Spots are limited—check the link in bio and join our slack to learn about the next coffee hangout!\n💻 Keep the convo going in our Slack channel # code-diversity!\nLet’s keep building this amazing community together—see you at the next meetup on Dec 14th! 🙌\n#TechCommunity #WomenInTech #NonBinaryInTech #TechTankTO #TechTank #TechTankToronto #TechTankers #TechTanker #DevCommunity #ThankYou #DevCommunity #Dev #Developers #SWE",
+    caption:
+      "🎉 A Shoutout to Our Amazing Community!\nThank you, Marms W, for sharing your first impression of our #CodeDiversity community! 💬\nTechTank\ncoffee meetup called Code Diversity brought together an inspiring group of developers to talk about various topics, celebrating achievements, and learning from one another.\nYour story reminds us why these meetups matter so much: creating a space where Women & Gender-Diverse Folks in Tech can connect, grow, and feel supported. 🌟\n📅 Want to join the next one? Spots are limited—check the link in bio and join our slack to learn about the next coffee hangout!\n💻 Keep the convo going in our Slack channel # code-diversity!\nLet’s keep building this amazing community together—see you at the next meetup on Dec 14th! 🙌\n#TechCommunity #WomenInTech #NonBinaryInTech #TechTankTO #TechTank #TechTankToronto #TechTankers #TechTanker #DevCommunity #ThankYou #DevCommunity #Dev #Developers #SWE",
     date: "2024-12-04",
     shortcode: "DDKp0Kbv259",
     pk: 18061026415845250,
     createdAtRaw: 1733336801,
     media: [
-      { type: "image", path: "/media/instagram/2024-12-04-DDKp0Kbv259/techtankto_DDKp0Kbv259_3515806363638787709.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-04-DDKp0Kbv259/techtankto_DDKp0Kbv259_3515806363638787709.webp",
+      },
+    ],
   },
   "2024-12-05-DDL8DILxGRz": {
-    caption: "🎄✨ Throwback Thursday! ✨🎄\nLooking back at last year’s holiday party has us feeling all the festive vibes! From laughs to epic memories, it was truly a night to remember. 🥂🎉\nMark your calendars because this year’s celebration will be even bigger and better with Bits, Bytes & Bowties 🎩 – a black-tie evening featuring mulled wine, exciting raffles, and plenty of holiday spirit. Join us on December 20th, 2024 for a night to remember!\n✨ Don’t miss out – register today! 🥳 luma link in our bio 🔗\n#TechTankTo #HolidayParty #ThrowbackThursday #TBT #TechTank #TechTankToronto #TechTanker #TechTankers #techcommunity #thursday #tb #Holiday #Blacktie",
+    caption:
+      "🎄✨ Throwback Thursday! ✨🎄\nLooking back at last year’s holiday party has us feeling all the festive vibes! From laughs to epic memories, it was truly a night to remember. 🥂🎉\nMark your calendars because this year’s celebration will be even bigger and better with Bits, Bytes & Bowties 🎩 – a black-tie evening featuring mulled wine, exciting raffles, and plenty of holiday spirit. Join us on December 20th, 2024 for a night to remember!\n✨ Don’t miss out – register today! 🥳 luma link in our bio 🔗\n#TechTankTo #HolidayParty #ThrowbackThursday #TBT #TechTank #TechTankToronto #TechTanker #TechTankers #techcommunity #thursday #tb #Holiday #Blacktie",
     date: "2024-12-05",
     shortcode: "DDL8DILxGRz",
     pk: 17873157963233015,
     createdAtRaw: 1733379915,
     media: [
-      { type: "image", path: "/media/instagram/2024-12-05-DDL8DILxGRz/techtankto_DDL8DILxGRz_3516168022929150406.webp" },
-      { type: "image", path: "/media/instagram/2024-12-05-DDL8DILxGRz/techtankto_DDL8DILxGRz_3516168022937476125.webp" },
-      { type: "image", path: "/media/instagram/2024-12-05-DDL8DILxGRz/techtankto_DDL8DILxGRz_3516168022945849761.webp" },
-      { type: "image", path: "/media/instagram/2024-12-05-DDL8DILxGRz/techtankto_DDL8DILxGRz_3516168022945856804.webp" },
-      { type: "image", path: "/media/instagram/2024-12-05-DDL8DILxGRz/techtankto_DDL8DILxGRz_3516168022954310723.webp" },
-      { type: "image", path: "/media/instagram/2024-12-05-DDL8DILxGRz/techtankto_DDL8DILxGRz_3516168022971083458.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-05-DDL8DILxGRz/techtankto_DDL8DILxGRz_3516168022929150406.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-05-DDL8DILxGRz/techtankto_DDL8DILxGRz_3516168022937476125.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-05-DDL8DILxGRz/techtankto_DDL8DILxGRz_3516168022945849761.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-05-DDL8DILxGRz/techtankto_DDL8DILxGRz_3516168022945856804.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-05-DDL8DILxGRz/techtankto_DDL8DILxGRz_3516168022954310723.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-05-DDL8DILxGRz/techtankto_DDL8DILxGRz_3516168022971083458.webp",
+      },
+    ],
   },
   "2024-12-13-DDhUiARIj9": {
-    caption: "Get ready to celebrate the holiday season in style next week!! ✨🎄\nTechTank Toronto is throwing a festive soirée where tech meets elegance. 🎀\nAll is welcome to join us for an unforgettable evening filled with mingling, games, and holiday cheer! 🌟 with Special Guest @dj.see.a 🎶\n\n🎩 Theme:\nBlack Tie + Tech Twist\nPut on your best bowtie or most elegant evening dress and add a dash of tech-inspired flair!\n📍 Location:\nToronto (Exact spot shared upon registration)\n🗓️ Date & Time:\nFriday, December 20, 2024\n7:00 PM – 11:00 PM\n💰 Admission:\n$25 per person – includes food, drinks, venue, auction fun, and all the party magic! 🪄\nRegister from the link: lu.ma/eqp4ccn5 or check the link in bio.\nE-transfer your fee to techtankto@gmail.com within a week of registering to secure your spot.\n🍴 Food & Drinks:\n- Mulled wine and prepared bites (we’ve got you covered – let us know any dietary restrictions!) - BYOB welcome!\n🎲 Fun & Games:\n- Silent Auction: Bid on epic community-donated items. - Raffle Tickets: Win unique prizes (or quirky surprises!). - Ice Breaker Games\n🚗 Parking Options:\n- Near Chapters Indigo: $5 (6 PM–6 AM) - Precise Park Link: $8 (12 hours)\nNeed help covering the fee? No worries – DM us and we’ll sort it out.\nLet’s celebrate a year of tech, growth, and community together! Can’t wait to see you there! 🚀💃\n#HolidayWithTech #TechTankToronto #TechMeetsElegance #TorontoEvents #TechTank #TechTankers #TechTankTo #TechTanker #toronto #holiday #holidays #holidayseason\n#DressToImpress #HolidayParty #TorontoEvents",
+    caption:
+      "Get ready to celebrate the holiday season in style next week!! ✨🎄\nTechTank Toronto is throwing a festive soirée where tech meets elegance. 🎀\nAll is welcome to join us for an unforgettable evening filled with mingling, games, and holiday cheer! 🌟 with Special Guest @dj.see.a 🎶\n\n🎩 Theme:\nBlack Tie + Tech Twist\nPut on your best bowtie or most elegant evening dress and add a dash of tech-inspired flair!\n📍 Location:\nToronto (Exact spot shared upon registration)\n🗓️ Date & Time:\nFriday, December 20, 2024\n7:00 PM – 11:00 PM\n💰 Admission:\n$25 per person – includes food, drinks, venue, auction fun, and all the party magic! 🪄\nRegister from the link: lu.ma/eqp4ccn5 or check the link in bio.\nE-transfer your fee to techtankto@gmail.com within a week of registering to secure your spot.\n🍴 Food & Drinks:\n- Mulled wine and prepared bites (we’ve got you covered – let us know any dietary restrictions!) - BYOB welcome!\n🎲 Fun & Games:\n- Silent Auction: Bid on epic community-donated items. - Raffle Tickets: Win unique prizes (or quirky surprises!). - Ice Breaker Games\n🚗 Parking Options:\n- Near Chapters Indigo: $5 (6 PM–6 AM) - Precise Park Link: $8 (12 hours)\nNeed help covering the fee? No worries – DM us and we’ll sort it out.\nLet’s celebrate a year of tech, growth, and community together! Can’t wait to see you there! 🚀💃\n#HolidayWithTech #TechTankToronto #TechMeetsElegance #TorontoEvents #TechTank #TechTankers #TechTankTo #TechTanker #toronto #holiday #holidays #holidayseason\n#DressToImpress #HolidayParty #TorontoEvents",
     date: "2024-12-13",
     shortcode: "DDhU_iARIj9",
     pk: 17918568185917213,
     createdAtRaw: 1734097926,
     media: [
-      { type: "image", path: "/media/instagram/2024-12-13-DDhUiARIj9/techtankto_DDhU_iARIj9_3522188710349408509.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-12-13-DDhUiARIj9/techtankto_DDhU_iARIj9_3522188710349408509.webp" },
+    ],
   },
   "2024-12-17-DDrzcGXudd": {
-    caption: "🏆 Season 1 Complete! 🎉\nWe’re thrilled to celebrate our 2nd place finish! 🥈 The real win was the incredible progress we made as a team. Week after week, we grew stronger, and it’s been amazing to see how far we’ve come.\nNow, we’re keeping the momentum going for Season 2! 🚀\nIf you’re ready to join the team and level up with us, check out the slack channel # volleyball-sashimis to reserve your spot!\nSeason 2 Details:\n📅 Duration: 12 weeks\n📍 Location: Glenview Sr. PS\n🗓️ Start Date: January 14, 2025\n🏁 End Date: April 8, 2025\n⏰ Game Times: Tuesdays at 6:45 PM, 7:45 PM, and 8:45 PM\n💲 Cost per game: $11.20–$16.79 (depending on team size: 6–9 players)\nLet’s make Season 2 even better! 💪\nWho’s in? 🙌\n#TeamGoals #Season2 #JoinTheTeam #KeepImproving #CommunitySports #Sashimis #Volleyball #JoinSeason2 #SportsTeam #IndoorGames #Toronto #TechTank #TechTankTO #TechTankers #TechTankToronto #TechTanker #VolleyballSashimis #SocialSports #6ix",
+    caption:
+      "🏆 Season 1 Complete! 🎉\nWe’re thrilled to celebrate our 2nd place finish! 🥈 The real win was the incredible progress we made as a team. Week after week, we grew stronger, and it’s been amazing to see how far we’ve come.\nNow, we’re keeping the momentum going for Season 2! 🚀\nIf you’re ready to join the team and level up with us, check out the slack channel # volleyball-sashimis to reserve your spot!\nSeason 2 Details:\n📅 Duration: 12 weeks\n📍 Location: Glenview Sr. PS\n🗓️ Start Date: January 14, 2025\n🏁 End Date: April 8, 2025\n⏰ Game Times: Tuesdays at 6:45 PM, 7:45 PM, and 8:45 PM\n💲 Cost per game: $11.20–$16.79 (depending on team size: 6–9 players)\nLet’s make Season 2 even better! 💪\nWho’s in? 🙌\n#TeamGoals #Season2 #JoinTheTeam #KeepImproving #CommunitySports #Sashimis #Volleyball #JoinSeason2 #SportsTeam #IndoorGames #Toronto #TechTank #TechTankTO #TechTankers #TechTankToronto #TechTanker #VolleyballSashimis #SocialSports #6ix",
     date: "2024-12-17",
     shortcode: "DDrzcGXud-d",
     pk: 18080407411572544,
     createdAtRaw: 1734449143,
     media: [
-      { type: "image", path: "/media/instagram/2024-12-17-DDrzcGXudd/techtankto_DDrzcGXud-d_3525137364705468317.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-12-17-DDrzcGXudd/techtankto_DDrzcGXud-d_3525137364705468317.webp" },
+    ],
   },
   "2024-12-23-DB9wVRshHUn": {
-    caption: "Embrace the Disruption! 🚀\nIn today’s tech landscape, progress is all about reimagining the possible. At TechTank, we’re here to empower tech enthusiasts to push boundaries, challenge the norms, and drive their own innovation. ⚙️\nWhether you're building, coding, designing or leading, remember—don’t wait for change to happen. Be the disruptor in your journey. Join our slack (link in bio) to be disruptors together💥\nOur Linktree: https://linktr.ee/techtankto\n#TechTank #FutureOfTech #InnovationJourney #DisruptToThrive #MotivationalMondays #Innovate #StayCurious #CreateYourOwn",
+    caption:
+      "Embrace the Disruption! 🚀\nIn today’s tech landscape, progress is all about reimagining the possible. At TechTank, we’re here to empower tech enthusiasts to push boundaries, challenge the norms, and drive their own innovation. ⚙️\nWhether you're building, coding, designing or leading, remember—don’t wait for change to happen. Be the disruptor in your journey. Join our slack (link in bio) to be disruptors together💥\nOur Linktree: https://linktr.ee/techtankto\n#TechTank #FutureOfTech #InnovationJourney #DisruptToThrive #MotivationalMondays #Innovate #StayCurious #CreateYourOwn",
     date: "2024-12-23",
     shortcode: "DB9wVRshHUn",
     pk: 18068465776743324,
     createdAtRaw: 1734993755,
     media: [
-      { type: "image", path: "/media/instagram/2024-12-23-DB9wVRshHUn/techtankto_DB9wVRshHUn_3494161454251406631.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2024-12-23-DB9wVRshHUn/techtankto_DB9wVRshHUn_3494161454251406631.webp",
+      },
+    ],
   },
   "2024-12-26-DEDf3AaPGe": {
     caption: "Thank you for an amazing 2024, TechTank! 💙\n#2024highlights #2024memories #recap #TechTankTo #thankyou",
@@ -957,11 +1344,12 @@ const instagramPosts: Record<string, InstagramPost> = {
     pk: 17887632048173141,
     createdAtRaw: 1735244584,
     media: [
-      { type: "image", path: "/media/instagram/2024-12-26-DEDf3AaPGe/techtankto_DEDf3AaPGe__3531806652241831871.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2024-12-26-DEDf3AaPGe/techtankto_DEDf3AaPGe__3531806652241831871.webp" },
+    ],
   },
   "2025-01-07-DENIAWK8UN": {
-    caption: "🎉 TechTank To 2024 Wrapped 🎉\n🚀 Did you know?\nThis year, 1,659 #introductions were shared on our Slack, alongside 1,507 job postings—highlighting how TechTank thrives as a hub for connection and collaboration!\n🎙️ GuppyTalks Podcast\nWe launched 5 episodes in 2024, diving into developer journeys and expert insights. Got a topic in mind for 2025? Let us know—we’d love to amplify your voice!\n🏐 Sashimis Sports Teams\nTech meets play! Our volleyball team clinched 2nd place this fall. Here’s to teamwork, both on and off the court!\n📊 Behind the Numbers\n- 992 Slack Members - 2,619 Meetup Members\nBut the magic is in the connections we made: 🪄\n✅ Introductions → Collaborations ✅ Events → New ideas ✅ Messages → Lifelong friendships\n✨ What’s Next for 2025?\nExpect more workshops, fresh podcast episodes, and plenty of exciting surprises (maybe even another trophy for Sashimis?).\nSwipe through to reflect on this year’s highlights and share your journey with us.\n👉 Don’t forget to tag @TechTankTO and use #TechTankTO for a chance to be featured in our stories!\nLet’s keep growing together in 2025. 🌱",
+    caption:
+      "🎉 TechTank To 2024 Wrapped 🎉\n🚀 Did you know?\nThis year, 1,659 #introductions were shared on our Slack, alongside 1,507 job postings—highlighting how TechTank thrives as a hub for connection and collaboration!\n🎙️ GuppyTalks Podcast\nWe launched 5 episodes in 2024, diving into developer journeys and expert insights. Got a topic in mind for 2025? Let us know—we’d love to amplify your voice!\n🏐 Sashimis Sports Teams\nTech meets play! Our volleyball team clinched 2nd place this fall. Here’s to teamwork, both on and off the court!\n📊 Behind the Numbers\n- 992 Slack Members - 2,619 Meetup Members\nBut the magic is in the connections we made: 🪄\n✅ Introductions → Collaborations ✅ Events → New ideas ✅ Messages → Lifelong friendships\n✨ What’s Next for 2025?\nExpect more workshops, fresh podcast episodes, and plenty of exciting surprises (maybe even another trophy for Sashimis?).\nSwipe through to reflect on this year’s highlights and share your journey with us.\n👉 Don’t forget to tag @TechTankTO and use #TechTankTO for a chance to be featured in our stories!\nLet’s keep growing together in 2025. 🌱",
     date: "2025-01-07",
     shortcode: "DENIAW-K8UN",
     pk: 18481010545036535,
@@ -975,144 +1363,203 @@ const instagramPosts: Record<string, InstagramPost> = {
       { type: "image", path: "/media/instagram/2025-01-07-DENIAWK8UN/techtankto_DENIAW-K8UN_3534516453240450445.webp" },
       { type: "image", path: "/media/instagram/2025-01-07-DENIAWK8UN/techtankto_DENIAW-K8UN_3534516453458326852.webp" },
       { type: "image", path: "/media/instagram/2025-01-07-DENIAWK8UN/techtankto_DENIAW-K8UN_3534516454230119498.webp" },
-      { type: "image", path: "/media/instagram/2025-01-07-DENIAWK8UN/techtankto_DENIAW-K8UN_3534516454683071781.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2025-01-07-DENIAWK8UN/techtankto_DENIAW-K8UN_3534516454683071781.webp" },
+    ],
   },
   "2025-01-18-DE8BI1uv0kd": {
-    caption: "And… we’re back! 🎉\nHAPPY NEW YEAR (1st post in 2025!)\nReady for new tech insights? 💪\nKick off 2025 with Tony Ko, Senior Software Engineer, as he shares lessons on:\n💡 “Building Cross-Browser Extensions: Challenges and Best Practices”\nTony has over 7 years of experience delivering secure, high-performing solutions for top brands like Aeroplan, Air Miles, and Toyota. Don’t miss this chance to learn strategies for handling browser compatibility and network with Toronto’s tech community!\nLearn more about Tony: 🔗 Portfolio: https://tko.dev/ 🔗 LinkedIn: https://www.linkedin.com/in/tkodev/\nEvent Details: 🗓️ Date: Tuesday, January 28th ⏰ Time: 6:00 PM - 8:30 PM EST 📍 Location: Cohere (171 John St, Toronto, 3rd Floor)\nSchedule: 6:00 PM - Arrive, enjoy food, and socialize 6:45 PM - Announcements and presentation 7:45 PM - Networking and Q&A\nThank you to our sponsor, Cohere, for providing the space, food, and beverages! Cohere is a global enterprise AI company co-headquartered in Toronto and San Francisco. They specialize in building secure, multilingual AI models designed to solve real-world business challenges with the highest levels of security and privacy.\nLearn more about Cohere here: 🔗 https://cohere.com/\nRSVP now on Meetup: 🔗 https://www.meetup.com/techtank-to/events/305400630/\n#SWE #Coding #Browsers #browserextensions #CodingPractices #TechTankTo #DevCommunity #Tech #webdevelopment #techtanktoronto #techtank #techtanker #techtankers #dev #techtalk",
+    caption:
+      "And… we’re back! 🎉\nHAPPY NEW YEAR (1st post in 2025!)\nReady for new tech insights? 💪\nKick off 2025 with Tony Ko, Senior Software Engineer, as he shares lessons on:\n💡 “Building Cross-Browser Extensions: Challenges and Best Practices”\nTony has over 7 years of experience delivering secure, high-performing solutions for top brands like Aeroplan, Air Miles, and Toyota. Don’t miss this chance to learn strategies for handling browser compatibility and network with Toronto’s tech community!\nLearn more about Tony: 🔗 Portfolio: https://tko.dev/ 🔗 LinkedIn: https://www.linkedin.com/in/tkodev/\nEvent Details: 🗓️ Date: Tuesday, January 28th ⏰ Time: 6:00 PM - 8:30 PM EST 📍 Location: Cohere (171 John St, Toronto, 3rd Floor)\nSchedule: 6:00 PM - Arrive, enjoy food, and socialize 6:45 PM - Announcements and presentation 7:45 PM - Networking and Q&A\nThank you to our sponsor, Cohere, for providing the space, food, and beverages! Cohere is a global enterprise AI company co-headquartered in Toronto and San Francisco. They specialize in building secure, multilingual AI models designed to solve real-world business challenges with the highest levels of security and privacy.\nLearn more about Cohere here: 🔗 https://cohere.com/\nRSVP now on Meetup: 🔗 https://www.meetup.com/techtank-to/events/305400630/\n#SWE #Coding #Browsers #browserextensions #CodingPractices #TechTankTo #DevCommunity #Tech #webdevelopment #techtanktoronto #techtank #techtanker #techtankers #dev #techtalk",
     date: "2025-01-18",
     shortcode: "DE8BI1uv0kd",
     pk: 18049147364275153,
     createdAtRaw: 1737185500,
     media: [
-      { type: "image", path: "/media/instagram/2025-01-18-DE8BI1uv0kd/techtankto_DE8BI1uv0kd_3547715611956037917.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-01-18-DE8BI1uv0kd/techtankto_DE8BI1uv0kd_3547715611956037917.webp",
+      },
+    ],
   },
   "2025-01-20-DFD0RpYPyQX": {
-    caption: "🎉 Thank You, All 1,000 of You! 🎉\nTechTank has officially hit 1K members! This milestone means the world to us, and we couldn’t have done it without YOU. 💖\nYou’ve believed in our vision, supported our journey, and helped us grow this incredible community. Together, we’ve created something truly special—a space where people connect, collaborate, and inspire one another.\nFrom the bottom of our hearts, THANK YOU for being part of this adventure. We’re so grateful to have every single one of you with us as we continue to grow and make an impact. Let’s keep building, learning, and thriving together! 🐠\nWant to join TechTank? Join us on Slack! Link in our bio 🔗\n| ABOUT | TechTank is all about bringing people together. It is a lively and inclusive tech community where we wholeheartedly embrace tech enthusiasts from all walks of life. Whether you’re a newbie just starting out or a seasoned professional, TechTank wants to provide an inclusive environment where you can connect with like-minded individuals and foster meaningful relationships.\n#TechTank #TechTankTo #TechTankers #TechCommunity #Toronto #1KMilestone",
+    caption:
+      "🎉 Thank You, All 1,000 of You! 🎉\nTechTank has officially hit 1K members! This milestone means the world to us, and we couldn’t have done it without YOU. 💖\nYou’ve believed in our vision, supported our journey, and helped us grow this incredible community. Together, we’ve created something truly special—a space where people connect, collaborate, and inspire one another.\nFrom the bottom of our hearts, THANK YOU for being part of this adventure. We’re so grateful to have every single one of you with us as we continue to grow and make an impact. Let’s keep building, learning, and thriving together! 🐠\nWant to join TechTank? Join us on Slack! Link in our bio 🔗\n| ABOUT | TechTank is all about bringing people together. It is a lively and inclusive tech community where we wholeheartedly embrace tech enthusiasts from all walks of life. Whether you’re a newbie just starting out or a seasoned professional, TechTank wants to provide an inclusive environment where you can connect with like-minded individuals and foster meaningful relationships.\n#TechTank #TechTankTo #TechTankers #TechCommunity #Toronto #1KMilestone",
     date: "2025-01-20",
     shortcode: "DFD0RpYPyQX",
     pk: 17995310519753688,
     createdAtRaw: 1737402586,
     media: [
-      { type: "image", path: "/media/instagram/2025-01-20-DFD0RpYPyQX/techtankto_DFD0RpYPyQX_3549910842377970711.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-01-20-DFD0RpYPyQX/techtankto_DFD0RpYPyQX_3549910842377970711.webp",
+      },
+    ],
   },
   "2025-02-25-DGdU8GHOON": {
-    caption: "We kicked off our first meetup of the year with a session on building robust extensions that work seamlessly across platforms! Big thanks to Tony Ko @tkodev for sharing his expert insights on DOM management and deployment strategies🙏\nCheck out Tony’s LinkedIn:\n🔗 https://www.linkedin.com/in/tkodev\nSpecial shoutout to our sponsor Cohere for providing the perfect space to learn and network ✨ \nCheck out Cohere’s latest product, North\n🔗 https://cohere.com/north\nTo everyone who braved the snow to join us—thank you for your energy and amazing questions!\n✨ Missed it? No worries!\nCatch up on all the highlights:\nPhotos 📷\n🔗 https://photos.app.goo.gl/JdCB2QUhzxXPwUTg9\nRecording 📽️\n🔗 https://youtu.be/f8ONw6O_rco?si=N5OaEdIcFOM3vZVu\nTony’s Slides 💻\n🔗 https://www.figma.com/deck/Pp9WuKLFwDnXimapCLwnb2/TechTalk—Cross-Browser-Extensions?node-id=1-1788&t=h0Rn8vbGsHPTRxUa-1\n✨ Want to join TechTank’s journey?\nSpeak at a future event 🎤\n🔗 https://www.techtankto.com/speak\nPartner with us - Reach out via email: 📧 techtankto@gmail.com\n✨ Stay connected with us:\nSee our Linktree in our bio for more ways to get involved\nConsider donating so we can continue our mission:\n🔗 https://www.techtankto.com/donate\nLooking forward to seeing you in Spring 2025! 💙\n#techtankto #techtank #techtanktoronto #techtanker #techtankers #devcommunity #browserextension #torontonetworking #networking #developer #swe #software #dom #speaker #techtips #techtalk #cohere #coherenorth",
+    caption:
+      "We kicked off our first meetup of the year with a session on building robust extensions that work seamlessly across platforms! Big thanks to Tony Ko @tkodev for sharing his expert insights on DOM management and deployment strategies🙏\nCheck out Tony’s LinkedIn:\n🔗 https://www.linkedin.com/in/tkodev\nSpecial shoutout to our sponsor Cohere for providing the perfect space to learn and network ✨ \nCheck out Cohere’s latest product, North\n🔗 https://cohere.com/north\nTo everyone who braved the snow to join us—thank you for your energy and amazing questions!\n✨ Missed it? No worries!\nCatch up on all the highlights:\nPhotos 📷\n🔗 https://photos.app.goo.gl/JdCB2QUhzxXPwUTg9\nRecording 📽️\n🔗 https://youtu.be/f8ONw6O_rco?si=N5OaEdIcFOM3vZVu\nTony’s Slides 💻\n🔗 https://www.figma.com/deck/Pp9WuKLFwDnXimapCLwnb2/TechTalk—Cross-Browser-Extensions?node-id=1-1788&t=h0Rn8vbGsHPTRxUa-1\n✨ Want to join TechTank’s journey?\nSpeak at a future event 🎤\n🔗 https://www.techtankto.com/speak\nPartner with us - Reach out via email: 📧 techtankto@gmail.com\n✨ Stay connected with us:\nSee our Linktree in our bio for more ways to get involved\nConsider donating so we can continue our mission:\n🔗 https://www.techtankto.com/donate\nLooking forward to seeing you in Spring 2025! 💙\n#techtankto #techtank #techtanktoronto #techtanker #techtankers #devcommunity #browserextension #torontonetworking #networking #developer #swe #software #dom #speaker #techtips #techtalk #cohere #coherenorth",
     date: "2025-02-25",
     shortcode: "DGdU8GHOON_",
     pk: 17945902205958214,
     createdAtRaw: 1740513755,
     media: [
-      { type: "image", path: "/media/instagram/2025-02-25-DGdU8GHOON/techtankto_DGdU8GHOON__3575105769864487807.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2025-02-25-DGdU8GHOON/techtankto_DGdU8GHOON__3575105769864487807.webp" },
+    ],
   },
   "2025-02-26-DGjOLKRNswM": {
-    caption: "🎲 TechTank's last Toronto Social at Snakes & Lattes was a blast!🍻✨\nFrom epic board game battles to great convos, we had it all. Thank you Nhi for being a great host!\nSwipe through and guess the board game in photo #️⃣3️⃣—drop your answer in the comments! 👇🔥\nMissed this one?\nDon’t worry—more socials coming soon!\nJoin our community on Slack and join the channel # social-toronto & stay tuned. 🚀\n#TechTankTO #BoardGameNight #TorontoTech #TechCommunity #TechTank #TechTankToronto #TechTanker #TechTankers #Social",
+    caption:
+      "🎲 TechTank's last Toronto Social at Snakes & Lattes was a blast!🍻✨\nFrom epic board game battles to great convos, we had it all. Thank you Nhi for being a great host!\nSwipe through and guess the board game in photo #️⃣3️⃣—drop your answer in the comments! 👇🔥\nMissed this one?\nDon’t worry—more socials coming soon!\nJoin our community on Slack and join the channel # social-toronto & stay tuned. 🚀\n#TechTankTO #BoardGameNight #TorontoTech #TechCommunity #TechTank #TechTankToronto #TechTanker #TechTankers #Social",
     date: "2025-02-26",
     shortcode: "DGjOLKRNswM",
     pk: 18304750219224352,
     createdAtRaw: 1740610320,
     featured: true,
     media: [
-      { type: "image", path: "/media/instagram/2025-02-26-DGjOLKRNswM/techtankto_DGjOLKRNswM_3576764798978118741.webp" },
+      {
+        type: "image",
+        path: "/media/instagram/2025-02-26-DGjOLKRNswM/techtankto_DGjOLKRNswM_3576764798978118741.webp",
+      },
       { type: "video", path: "/media/instagram/2025-02-26-DGjOLKRNswM/techtankto_DGjOLKRNswM_3576764799414295229.mp4" },
-      { type: "image", path: "/media/instagram/2025-02-26-DGjOLKRNswM/techtankto_DGjOLKRNswM_3576764799640753678.webp" },
-      { type: "image", path: "/media/instagram/2025-02-26-DGjOLKRNswM/techtankto_DGjOLKRNswM_3576764799993081935.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-02-26-DGjOLKRNswM/techtankto_DGjOLKRNswM_3576764799640753678.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2025-02-26-DGjOLKRNswM/techtankto_DGjOLKRNswM_3576764799993081935.webp",
+      },
+    ],
   },
   "2025-03-04-DGyMGxmtIPs": {
-    caption: "🔥 New Hobby Channels in TechTank Slack! 🔥\nTech isn’t just about coding—we’re building a space for everything you love! 🎉\nJoin our brand-new hobby channels and connect with fellow techies over shared interests:\n🎮 # game-tank – Talk strategy, new releases, or gaming nostalgia 📚 # readers-cove – Share book recs & reading goals 🎵 # sound-waves – Drop your favorite tracks & concert experiences 🐾 # aquarium – Show off your pets (furry, scaly, or feathery!) 🐶🐱🐟 🍜 # gta-foodies – Find the best eats in Toronto & GTA\nThese channels are brand new & experimental—your engagement shapes them!\nDive in, share your interests, and make Slack even more fun. 🌊\n#TechTank #Community #new #jointhefun #TechTankTo #devcommunity #TechTankers #TechTanker #JoinUs #Slack #techtanktoronto #hobby #games #music #books #reading #food #foodie #toronto #gta #pets #welovepets #JoinTheConversation",
+    caption:
+      "🔥 New Hobby Channels in TechTank Slack! 🔥\nTech isn’t just about coding—we’re building a space for everything you love! 🎉\nJoin our brand-new hobby channels and connect with fellow techies over shared interests:\n🎮 # game-tank – Talk strategy, new releases, or gaming nostalgia 📚 # readers-cove – Share book recs & reading goals 🎵 # sound-waves – Drop your favorite tracks & concert experiences 🐾 # aquarium – Show off your pets (furry, scaly, or feathery!) 🐶🐱🐟 🍜 # gta-foodies – Find the best eats in Toronto & GTA\nThese channels are brand new & experimental—your engagement shapes them!\nDive in, share your interests, and make Slack even more fun. 🌊\n#TechTank #Community #new #jointhefun #TechTankTo #devcommunity #TechTankers #TechTanker #JoinUs #Slack #techtanktoronto #hobby #games #music #books #reading #food #foodie #toronto #gta #pets #welovepets #JoinTheConversation",
     date: "2025-03-04",
     shortcode: "DGyMGxmtIPs",
     pk: 17879445951167023,
     createdAtRaw: 1741105804,
     media: [
-      { type: "image", path: "/media/instagram/2025-03-04-DGyMGxmtIPs/techtankto_DGyMGxmtIPs_3580977895850673132.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-03-04-DGyMGxmtIPs/techtankto_DGyMGxmtIPs_3580977895850673132.webp",
+      },
+    ],
   },
   "2025-03-08-DG8Yis9u3z9": {
-    caption: "🌟 Celebrating an unforgettable International Women’s Day event from last year! 💜✨\nWe had the privilege of hearing from incredible #WomenInTech, who shared their wisdom, experiences, and insights. Huge thanks to our panelists, moderator, volunteers, and our generous sponsors at Cohere for making this event possible! 🙌\nLet’s continue to uplift, amplify, and empower women in tech—today and every day 💪🚀\n#TechTankTo #WomenInTech #IWD #TechTankers #Inspiration #DiversityInTech #TechCommunity",
+    caption:
+      "🌟 Celebrating an unforgettable International Women’s Day event from last year! 💜✨\nWe had the privilege of hearing from incredible #WomenInTech, who shared their wisdom, experiences, and insights. Huge thanks to our panelists, moderator, volunteers, and our generous sponsors at Cohere for making this event possible! 🙌\nLet’s continue to uplift, amplify, and empower women in tech—today and every day 💪🚀\n#TechTankTo #WomenInTech #IWD #TechTankers #Inspiration #DiversityInTech #TechCommunity",
     date: "2025-03-08",
     shortcode: "DG8Yis9u3z9",
     pk: 18079707307639243,
     createdAtRaw: 1741448146,
     media: [
-      { type: "image", path: "/media/instagram/2025-03-08-DG8Yis9u3z9/techtankto_DG8Yis9u3z9_3583847341338885373.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-03-08-DG8Yis9u3z9/techtankto_DG8Yis9u3z9_3583847341338885373.webp",
+      },
+    ],
   },
   "2025-03-17-DHTZOe2BpUC": {
-    caption: "🍀 Happy St. Patrick’s Day! Lá Fhéile Pádraig (pronounced: Law-Feh-leh Paw-drig) 🍀\nToday, we’re celebrating Irish contributions to the tech world!\nFrom pioneering programmers to innovators transforming industries, the Irish have shaped the way we use technology.\nHonouring these remarkable individuals who’ve helped build the digital world we live in today.\n👩‍💻 Kay McNulty (Kathleen Rita Antonelli) – Trailblazer in programming\n💳 Patrick & John Collison – Founders of Stripe\n📚 Tim O'Reilly – Tech visionary, writer and educator\nIn Gaelic, “Sláinte mhath” means “Good Health,” and is a traditional way to say \"Cheers!\" to celebrate success and good fortune. 🍻  Sláinte mhath! Here's to the legacy of innovation and the power of tech to connect us all.   #StPatricksDay #IrishTech #TechInnovators #WomenInTech #Entrepreneurship #OReillyMedia #Stripe #TechPioneers #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers  -------- Meta: date(YYYY-MM-DD): 2025-03-17 shortcode: DHTZOe2BpUC pk: 18002597894740092 created_at_raw: 1742220028 ",
+    caption:
+      "🍀 Happy St. Patrick’s Day! Lá Fhéile Pádraig (pronounced: Law-Feh-leh Paw-drig) 🍀\nToday, we’re celebrating Irish contributions to the tech world!\nFrom pioneering programmers to innovators transforming industries, the Irish have shaped the way we use technology.\nHonouring these remarkable individuals who’ve helped build the digital world we live in today.\n👩‍💻 Kay McNulty (Kathleen Rita Antonelli) – Trailblazer in programming\n💳 Patrick & John Collison – Founders of Stripe\n📚 Tim O'Reilly – Tech visionary, writer and educator\nIn Gaelic, “Sláinte mhath” means “Good Health,” and is a traditional way to say \"Cheers!\" to celebrate success and good fortune. 🍻  Sláinte mhath! Here's to the legacy of innovation and the power of tech to connect us all.   #StPatricksDay #IrishTech #TechInnovators #WomenInTech #Entrepreneurship #OReillyMedia #Stripe #TechPioneers #TechTank #TechTankTo #TechTankToronto #TechTanker #TechTankers  -------- Meta: date(YYYY-MM-DD): 2025-03-17 shortcode: DHTZOe2BpUC pk: 18002597894740092 created_at_raw: 1742220028 ",
     media: [
-      { type: "image", path: "/media/instagram/2025-03-17-DHTZOe2BpUC/techtankto_DHTZOe2BpUC_3590324259987485450.webp" },
-      { type: "image", path: "/media/instagram/2025-03-17-DHTZOe2BpUC/techtankto_DHTZOe2BpUC_3590324260381870175.webp" },
-      { type: "image", path: "/media/instagram/2025-03-17-DHTZOe2BpUC/techtankto_DHTZOe2BpUC_3590324260465752644.webp" },
-      { type: "image", path: "/media/instagram/2025-03-17-DHTZOe2BpUC/techtankto_DHTZOe2BpUC_3590324260666949343.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-03-17-DHTZOe2BpUC/techtankto_DHTZOe2BpUC_3590324259987485450.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2025-03-17-DHTZOe2BpUC/techtankto_DHTZOe2BpUC_3590324260381870175.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2025-03-17-DHTZOe2BpUC/techtankto_DHTZOe2BpUC_3590324260465752644.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2025-03-17-DHTZOe2BpUC/techtankto_DHTZOe2BpUC_3590324260666949343.webp",
+      },
+    ],
   },
   "2025-03-28-DHtTcVTvIo6": {
-    caption: "✨ Thank you for attending! ✨\nOur latest CodeDiversity Meetup was our biggest one yet—thank you for being part of it! ☕💜\nIt’s always inspiring to see this community grow, connect, and support each other.\nA huge shoutout to Niki and Thannia for hosting this space every month with so much care and dedication! 💖\nYour warmth and effort make these meetups truly special.\n🚀 We’ll be back soon! Our next meetup will likely be in late April—stay tuned for updates.\n🔗 Stay connected: Join our Slack community and find the # code-diversity channel to keep the conversation going! Connect with us here 👉 https://linktr.ee/techtankto\nLet’s keep building an inclusive and supportive tech community—see you soon! 🧑🏽‍💻👩🏻‍💻👨🏾‍💻👩🏿‍💻👨🏼‍💻👩‍💻🌟\n#CodeDiversity #WomenInTech #NonBinaryInTech #TechCommunity #Networking #TechTankTo #TechTank\n#TechTankToronto #2slgbtqia #code",
+    caption:
+      "✨ Thank you for attending! ✨\nOur latest CodeDiversity Meetup was our biggest one yet—thank you for being part of it! ☕💜\nIt’s always inspiring to see this community grow, connect, and support each other.\nA huge shoutout to Niki and Thannia for hosting this space every month with so much care and dedication! 💖\nYour warmth and effort make these meetups truly special.\n🚀 We’ll be back soon! Our next meetup will likely be in late April—stay tuned for updates.\n🔗 Stay connected: Join our Slack community and find the # code-diversity channel to keep the conversation going! Connect with us here 👉 https://linktr.ee/techtankto\nLet’s keep building an inclusive and supportive tech community—see you soon! 🧑🏽‍💻👩🏻‍💻👨🏾‍💻👩🏿‍💻👨🏼‍💻👩‍💻🌟\n#CodeDiversity #WomenInTech #NonBinaryInTech #TechCommunity #Networking #TechTankTo #TechTank\n#TechTankToronto #2slgbtqia #code",
     date: "2025-03-28",
     shortcode: "DHtTcVTvIo6",
     pk: 18085231534720582,
     createdAtRaw: 1743160498,
     media: [
-      { type: "image", path: "/media/instagram/2025-03-28-DHtTcVTvIo6/techtankto_DHtTcVTvIo6_3597617187247655482.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-03-28-DHtTcVTvIo6/techtankto_DHtTcVTvIo6_3597617187247655482.webp",
+      },
+    ],
   },
   "2025-03-31-DH3khozuwa5": {
-    caption: "💪 Gear up, friends! TechTank is turning TWO, and we’re celebrating with an epic CycleParty! 🚴‍♀️✨\nJoin us for 404: Fatigue Not Found, a high-energy, techno-pumping spin session that’ll have you smiling, sweating, and feeling like Angela Basset walking away from that burning car in Waiting to Exhale. 🔥💅\nSaturday April 12th for an afternoon adventure 🚴🚴‍♀️🚴‍♂️\nEvent Schedule:\n🔹 2:30 PM – Arrive at the studio ready to ride\n🔹 3:00-4:00 PM – Ride time! 60 minutes of pure energy and celebration\n🔹 4:00-5:00 PM – Cool down, shower, change\n🔹 5:00-7:00 PM – Post-ride celebration at Prema Coffee for drinks, snacks, and anniversary vibes ✨\nThis anniversary ride is all about good vibes, great music, and celebrating two fantastic years together. Bring your energy, your friends, and your best dance moves on the bike. Come dressed for a sweaty ride in your fave gym gear, and don’t forget your water bottle.\nSpaces are limited, so grab your spot and let’s ride into year three together! Can’t wait to celebrate with you! 🥳\nTickets are $35 – send an e-transfer to [techtankto@gmail.com](mailto:techtankto@gmail.com) to reserve your spot.\nPayment deadline: April 9 (we need to send the attendee list to the studio).\nOnce signed up, create your SPINCO account if you don’t have one yet.\nAt the studio, shoes and towels are provided. They also have essentials like hair ties, earplugs, deodorant spray, and showers.\nPrema Coffee: Please support the café by purchasing a drink or snack while attending.\nRegister now: https://lu.ma/ekdq0p25\nBy signing up, you agree to TechTank’s Sport Waiver. See you on the bikes—time to channel that Angela Basset energy. 🔥\n#TechTankToTurnsTwo #AnniversaryRide #CelebrationMode #TorontoCommunity #SquadGoals #SpinSquad #NoFatigueFound #FeelLikeABoss #angelabasset #TechTankTO #CycleParty #TechTankToronto #TechTank #TechTankers",
+    caption:
+      "💪 Gear up, friends! TechTank is turning TWO, and we’re celebrating with an epic CycleParty! 🚴‍♀️✨\nJoin us for 404: Fatigue Not Found, a high-energy, techno-pumping spin session that’ll have you smiling, sweating, and feeling like Angela Basset walking away from that burning car in Waiting to Exhale. 🔥💅\nSaturday April 12th for an afternoon adventure 🚴🚴‍♀️🚴‍♂️\nEvent Schedule:\n🔹 2:30 PM – Arrive at the studio ready to ride\n🔹 3:00-4:00 PM – Ride time! 60 minutes of pure energy and celebration\n🔹 4:00-5:00 PM – Cool down, shower, change\n🔹 5:00-7:00 PM – Post-ride celebration at Prema Coffee for drinks, snacks, and anniversary vibes ✨\nThis anniversary ride is all about good vibes, great music, and celebrating two fantastic years together. Bring your energy, your friends, and your best dance moves on the bike. Come dressed for a sweaty ride in your fave gym gear, and don’t forget your water bottle.\nSpaces are limited, so grab your spot and let’s ride into year three together! Can’t wait to celebrate with you! 🥳\nTickets are $35 – send an e-transfer to [techtankto@gmail.com](mailto:techtankto@gmail.com) to reserve your spot.\nPayment deadline: April 9 (we need to send the attendee list to the studio).\nOnce signed up, create your SPINCO account if you don’t have one yet.\nAt the studio, shoes and towels are provided. They also have essentials like hair ties, earplugs, deodorant spray, and showers.\nPrema Coffee: Please support the café by purchasing a drink or snack while attending.\nRegister now: https://lu.ma/ekdq0p25\nBy signing up, you agree to TechTank’s Sport Waiver. See you on the bikes—time to channel that Angela Basset energy. 🔥\n#TechTankToTurnsTwo #AnniversaryRide #CelebrationMode #TorontoCommunity #SquadGoals #SpinSquad #NoFatigueFound #FeelLikeABoss #angelabasset #TechTankTO #CycleParty #TechTankToronto #TechTank #TechTankers",
     date: "2025-03-31",
     shortcode: "DH3khozuwa5",
     pk: 18085714615528530,
     createdAtRaw: 1743433942,
     media: [
-      { type: "image", path: "/media/instagram/2025-03-31-DH3khozuwa5/techtankto_DH3khozuwa5_3600507068340700857.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-03-31-DH3khozuwa5/techtankto_DH3khozuwa5_3600507068340700857.webp",
+      },
+    ],
   },
   "2025-04-03-DHURGPAs": {
-    caption: "🚀 TechTank’s first-ever Lightning Talk is here! ⚡\nJoin us on Thursday, April 10th @ 6PM at Vena Solutions (The Cube, 2nd Floor – 2 Fraser Ave, Suite 200, Toronto, ON M6K 1Y6) for an exciting evening on Migrating a SaaS Product Across Cloud Providers.\n🎤 Hear from:\n🔹 Saiid Douaihy (Senior Software Manager, Vena Solutions) – Experienced in backend and database development, leading teams responsible for managing the OLAP cube and ETL framework.\n🔹 Pawan Keer (Senior Software Development Manager, Vena Solutions) – Focuses on enhancing Developer Productivity and Experience, leading The Tooling team to improve engineering efficiency.\n🔹 Lucas Tran (Senior Software Developer, Vena Solutions) – Passionate about creating developer tools and improving Vena’s codebase to ensure efficiency and competitiveness.\n💡 Whether you’re tackling a migration or just curious about multi-cloud strategies, this is your chance to learn, network, and enjoy food & drinks with fellow tech enthusiasts.\n📅 Schedule:\n🕕 6:00 PM – Arrive, grab food & socialize\n🎙️ 6:45 PM – Announcements + Lightning Talks/Q&A\n🤝 7:45 PM – More networking (and optional post-event hangout at a nearby bar!)\n🔗 Register here: 👉 www.meetup.com/techtank-to/events/306752010/\n🏆 Sponsored by Vena Solutions – revolutionizing FP&A with AI-powered tools.\nLearn more: 👉 www.venasolutions.com\n#TechTankTO #TechTankToronto #TorontoNetworking #LightningTalks #CloudMigration #SaaS #TorontoTech #SoftwareDevelopment #DevCommunity",
+    caption:
+      "🚀 TechTank’s first-ever Lightning Talk is here! ⚡\nJoin us on Thursday, April 10th @ 6PM at Vena Solutions (The Cube, 2nd Floor – 2 Fraser Ave, Suite 200, Toronto, ON M6K 1Y6) for an exciting evening on Migrating a SaaS Product Across Cloud Providers.\n🎤 Hear from:\n🔹 Saiid Douaihy (Senior Software Manager, Vena Solutions) – Experienced in backend and database development, leading teams responsible for managing the OLAP cube and ETL framework.\n🔹 Pawan Keer (Senior Software Development Manager, Vena Solutions) – Focuses on enhancing Developer Productivity and Experience, leading The Tooling team to improve engineering efficiency.\n🔹 Lucas Tran (Senior Software Developer, Vena Solutions) – Passionate about creating developer tools and improving Vena’s codebase to ensure efficiency and competitiveness.\n💡 Whether you’re tackling a migration or just curious about multi-cloud strategies, this is your chance to learn, network, and enjoy food & drinks with fellow tech enthusiasts.\n📅 Schedule:\n🕕 6:00 PM – Arrive, grab food & socialize\n🎙️ 6:45 PM – Announcements + Lightning Talks/Q&A\n🤝 7:45 PM – More networking (and optional post-event hangout at a nearby bar!)\n🔗 Register here: 👉 www.meetup.com/techtank-to/events/306752010/\n🏆 Sponsored by Vena Solutions – revolutionizing FP&A with AI-powered tools.\nLearn more: 👉 www.venasolutions.com\n#TechTankTO #TechTankToronto #TorontoNetworking #LightningTalks #CloudMigration #SaaS #TorontoTech #SoftwareDevelopment #DevCommunity",
     date: "2025-04-03",
     shortcode: "DH_U_RGPAs-",
     pk: 18068943919733727,
     createdAtRaw: 1743694207,
     media: [
-      { type: "image", path: "/media/instagram/2025-04-03-DHURGPAs/techtankto_DH_U_RGPAs-_3602690535535151934.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2025-04-03-DHURGPAs/techtankto_DH_U_RGPAs-_3602690535535151934.webp" },
+    ],
   },
   "2025-04-07-DIJXS15O4OQ": {
-    caption: "🚨 48 HOURS LEFT 🚨 Why you hesitatin’? 🫣 This Saturday, April 12, we’re throwing down for our 🎉 TWO-YEAR ANNIVERSARY 🎉 and you’re invited.\n⏳ Sign-ups close soon — don’t miss out!\n👉 Register here: https://lu.ma/ekdq0p25\n#TechTankTO #AnniversaryEvent #TorontoEvents #TechCommunity #TwoYears #TechTank",
+    caption:
+      "🚨 48 HOURS LEFT 🚨 Why you hesitatin’? 🫣 This Saturday, April 12, we’re throwing down for our 🎉 TWO-YEAR ANNIVERSARY 🎉 and you’re invited.\n⏳ Sign-ups close soon — don’t miss out!\n👉 Register here: https://lu.ma/ekdq0p25\n#TechTankTO #AnniversaryEvent #TorontoEvents #TechCommunity #TwoYears #TechTank",
     date: "2025-04-07",
     shortcode: "DIJXS15O4OQ",
     pk: 17927211408024185,
     createdAtRaw: 1744031204,
     media: [
-      { type: "image", path: "/media/instagram/2025-04-07-DIJXS15O4OQ/techtankto_DIJXS15O4OQ_3605515426575647632.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-04-07-DIJXS15O4OQ/techtankto_DIJXS15O4OQ_3605515426575647632.webp",
+      },
+    ],
   },
   "2025-04-12-DIVH5KgtCqS": {
-    caption: "🎉 TECHTANK TURNS TWO! 🎉 From our early days as The Dev Wears Prada to the thriving community we are now—we’ve come a long way 🐟💻 Every meetup, convo, and collab has helped build this amazing tech fam 💖\nThank YOU for swimming with us these past two years—your support, knowledge, and friendship mean the world 🌍💫\n✨ CELEBRATION REMINDER ✨ 🚲 404: Fatigue Not Found is TOMORROW! Spin class is full, but you can still catch us at the after-party: 🕔 5–7PM 📍 Prema Coffee (35 McCaul St # 110) 🥤 Drinks, snacks & bday vibes No reg needed—just show up & celebrate! (And grab a lil something from the café to support 💕)\nHere’s to more growth, laughs, and techy adventures ahead 🚀\n#HappyBirthdayTechTank 🥂 #TechTank #TechTankTo #TechTankToronto #TechTankers #devcommunity #TechTankTurnsTwo",
+    caption:
+      "🎉 TECHTANK TURNS TWO! 🎉 From our early days as The Dev Wears Prada to the thriving community we are now—we’ve come a long way 🐟💻 Every meetup, convo, and collab has helped build this amazing tech fam 💖\nThank YOU for swimming with us these past two years—your support, knowledge, and friendship mean the world 🌍💫\n✨ CELEBRATION REMINDER ✨ 🚲 404: Fatigue Not Found is TOMORROW! Spin class is full, but you can still catch us at the after-party: 🕔 5–7PM 📍 Prema Coffee (35 McCaul St # 110) 🥤 Drinks, snacks & bday vibes No reg needed—just show up & celebrate! (And grab a lil something from the café to support 💕)\nHere’s to more growth, laughs, and techy adventures ahead 🚀\n#HappyBirthdayTechTank 🥂 #TechTank #TechTankTo #TechTankToronto #TechTankers #devcommunity #TechTankTurnsTwo",
     date: "2025-04-12",
     shortcode: "DIVH5KgtCqS",
     pk: 18090105820586520,
     createdAtRaw: 1744425834,
     media: [
-      { type: "image", path: "/media/instagram/2025-04-12-DIVH5KgtCqS/techtankto_DIVH5KgtCqS_3608825391029168786.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-04-12-DIVH5KgtCqS/techtankto_DIVH5KgtCqS_3608825391029168786.webp",
+      },
+    ],
   },
   "2025-04-23-DIy88Ogx6": {
-    caption: "SPINNING into our second year with tankers! 🚴‍♀️💙\n“404: Fatigue Not Found” spin class was sweaty, silly, and so much fun thanks to everyone who came out to celebrate TechTank’s 2nd anniversary!\nHere’s to strong legs, stronger community, and many more years of laughs and learning together!\n#TechTankTO #HappyBirthdayTechTank 🍾 #TechTankers #TorontoEvents #TechCommunity",
+    caption:
+      "SPINNING into our second year with tankers! 🚴‍♀️💙\n“404: Fatigue Not Found” spin class was sweaty, silly, and so much fun thanks to everyone who came out to celebrate TechTank’s 2nd anniversary!\nHere’s to strong legs, stronger community, and many more years of laughs and learning together!\n#TechTankTO #HappyBirthdayTechTank 🍾 #TechTankers #TorontoEvents #TechCommunity",
     date: "2025-04-23",
     shortcode: "DIy88_-Ogx6",
     pk: 17973027536842059,
     createdAtRaw: 1745426565,
     media: [
-      { type: "image", path: "/media/instagram/2025-04-23-DIy88Ogx6/techtankto_DIy88_-Ogx6_3617221525380926586.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2025-04-23-DIy88Ogx6/techtankto_DIy88_-Ogx6_3617221525380926586.webp" },
+    ],
   },
   "2025-04-24-DI1cmTyu5kg": {
-    caption: "Congratulations 🎉\nMeet FINN — our adorable, floofy, and totally irresistible TechTank Pet of the Month!\nAlso known as: Phineas Gage, Finny, Finnoo, Finnoodle, Noodle, Finnonny, Nonny, Puppy Boy, Puppy Bear, Nafiniel, and *Floof*.\n🤍 With a face for every mood and a heart-melting stare that’s stolen the whole team’s hearts, Finn’s the snuggliest, fluffiest star lighting up our month. Congrats, Finn — you’re pawsitively iconic! 🐾",
+    caption:
+      "Congratulations 🎉\nMeet FINN — our adorable, floofy, and totally irresistible TechTank Pet of the Month!\nAlso known as: Phineas Gage, Finny, Finnoo, Finnoodle, Noodle, Finnonny, Nonny, Puppy Boy, Puppy Bear, Nafiniel, and *Floof*.\n🤍 With a face for every mood and a heart-melting stare that’s stolen the whole team’s hearts, Finn’s the snuggliest, fluffiest star lighting up our month. Congrats, Finn — you’re pawsitively iconic! 🐾",
     date: "2025-04-24",
     shortcode: "DI1cmTyu5kg",
     pk: 18099395080535304,
@@ -1120,32 +1567,47 @@ const instagramPosts: Record<string, InstagramPost> = {
     featured: true,
     media: [
       { type: "video", path: "/media/instagram/2025-04-24-DI1cmTyu5kg/techtankto_3617221525380926586.mp4" },
-      { type: "image", path: "/media/instagram/2025-04-24-DI1cmTyu5kg/techtankto_DI1cmTyu5kg_3617923646778680573.webp" },
-      { type: "image", path: "/media/instagram/2025-04-24-DI1cmTyu5kg/techtankto_DI1cmTyu5kg_3617923646795404540.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-04-24-DI1cmTyu5kg/techtankto_DI1cmTyu5kg_3617923646778680573.webp",
+      },
+      {
+        type: "image",
+        path: "/media/instagram/2025-04-24-DI1cmTyu5kg/techtankto_DI1cmTyu5kg_3617923646795404540.webp",
+      },
+    ],
   },
   "2025-06-02-DKaPVrgPuE0": {
-    caption: "🎉 We’re part of Toronto Tech Week 2025!\n✨ CodeDiversity is back — centering women & gender-diverse folks in tech with lightning talks, workshops & real connection\n🗓️ June 25 👉RSVP now on Luma in our bio\n💜 Sponsored by @7shifts\n#CodeDiversity #TorontoTechWeek #WomenInTech #NonBinaryInTech #TechTankTo",
+    caption:
+      "🎉 We’re part of Toronto Tech Week 2025!\n✨ CodeDiversity is back — centering women & gender-diverse folks in tech with lightning talks, workshops & real connection\n🗓️ June 25 👉RSVP now on Luma in our bio\n💜 Sponsored by @7shifts\n#CodeDiversity #TorontoTechWeek #WomenInTech #NonBinaryInTech #TechTankTo",
     date: "2025-06-02",
     shortcode: "DKaPVrgPuE0",
     pk: 17942434472881101,
     createdAtRaw: 1748892436,
     media: [
-      { type: "image", path: "/media/instagram/2025-06-02-DKaPVrgPuE0/techtankto_DKaPVrgPuE0_3646294308828406068.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-06-02-DKaPVrgPuE0/techtankto_DKaPVrgPuE0_3646294308828406068.webp",
+      },
+    ],
   },
   "2025-06-10-DKuVT7DuHIx": {
-    caption: "🚨 GIVEAWAY ALERT! 🚨\nWin a ticket to see @techroastshow LIVE in Toronto 🎤🔥\nWe’ve teamed up with MRG Live to give away ticket to the TechRoast at The Queen Elizabeth Theatre on June 26th! Expect an unforgettable night of comedians roasting the tech world!\nHow to Enter:\nWinner will be chosen on June 25th, 2025 from attendees at ✨CodeDiversity✨\nFollow for more giveaways & event updates:\n👉 @techtankto\n👉 @mrgliveofficial",
+    caption:
+      "🚨 GIVEAWAY ALERT! 🚨\nWin a ticket to see @techroastshow LIVE in Toronto 🎤🔥\nWe’ve teamed up with MRG Live to give away ticket to the TechRoast at The Queen Elizabeth Theatre on June 26th! Expect an unforgettable night of comedians roasting the tech world!\nHow to Enter:\nWinner will be chosen on June 25th, 2025 from attendees at ✨CodeDiversity✨\nFollow for more giveaways & event updates:\n👉 @techtankto\n👉 @mrgliveofficial",
     date: "2025-06-10",
     shortcode: "DKuVT7DuHIx",
     pk: 17879665506225189,
     createdAtRaw: 1749566397,
     media: [
-      { type: "image", path: "/media/instagram/2025-06-10-DKuVT7DuHIx/techtankto_DKuVT7DuHIx_3651950075904029233.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-06-10-DKuVT7DuHIx/techtankto_DKuVT7DuHIx_3651950075904029233.webp",
+      },
+    ],
   },
   "2025-07-07-DLz4I7KOww6": {
-    caption: "🔥 BBQ SEASON🔥\nJoin us for Buns & Fun(d)s, a summer cookout for a cause! 🍔☀️ $25 gets you food, soft drinks & good vibes to support TechTank 💪\n🎟️ Check out our bio to RSVP on Luma\n🗓 Saturday, Aug 2 | 1:30PM\n🍻 BYOB\n#TechTankTO #BBQForACause #TorontoTech #SummerVibes #Tankers",
+    caption:
+      "🔥 BBQ SEASON🔥\nJoin us for Buns & Fun(d)s, a summer cookout for a cause! 🍔☀️ $25 gets you food, soft drinks & good vibes to support TechTank 💪\n🎟️ Check out our bio to RSVP on Luma\n🗓 Saturday, Aug 2 | 1:30PM\n🍻 BYOB\n#TechTankTO #BBQForACause #TorontoTech #SummerVibes #Tankers",
     date: "2025-07-07",
     shortcode: "DLz4I7KOww6",
     pk: 18071767186979833,
@@ -1153,11 +1615,15 @@ const instagramPosts: Record<string, InstagramPost> = {
     featured: true,
     media: [
       { type: "video", path: "/media/instagram/2025-07-07-DLz4I7KOww6/techtankto_3671525025119931450.mp4" },
-      { type: "image", path: "/media/instagram/2025-07-07-DLz4I7KOww6/techtankto_DLz4I7KOww6_3671525025119931450.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-07-07-DLz4I7KOww6/techtankto_DLz4I7KOww6_3671525025119931450.webp",
+      },
+    ],
   },
   "2025-08-12-DNRVwWtPwky": {
-    caption: "YouTube 📹 LINK IN BIO EDM Party Mix Summer 2025 @techtankto\n#dj #edmdj #housedj #technodj #edm #housemusic #technomusic #canadiandj #koreandj #femaledj #nightlife #edmmix #hardstyle #hardstylemusic #ravemusic #technomix #clubmusic #partymusic",
+    caption:
+      "YouTube 📹 LINK IN BIO EDM Party Mix Summer 2025 @techtankto\n#dj #edmdj #housedj #technodj #edm #housemusic #technomusic #canadiandj #koreandj #femaledj #nightlife #edmmix #hardstyle #hardstylemusic #ravemusic #technomix #clubmusic #partymusic",
     date: "2025-08-12",
     shortcode: "DNRVwWtPwky",
     pk: 18337280413163939,
@@ -1165,11 +1631,15 @@ const instagramPosts: Record<string, InstagramPost> = {
     featured: true,
     media: [
       { type: "video", path: "/media/instagram/2025-08-12-DNRVwWtPwky/dj.see.a_3697832450940930354.mp4" },
-      { type: "image", path: "/media/instagram/2025-08-12-DNRVwWtPwky/techtankto_DNRVwWtPwky_3697832450940930354.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-08-12-DNRVwWtPwky/techtankto_DNRVwWtPwky_3697832450940930354.webp",
+      },
+    ],
   },
   "2025-08-20-DNmHtVwNshY": {
-    caption: "We’re excited to announce our first-ever ✨Mentorship Meetup✨ a new TechTank initiative designed to connect early-career folks in tech (1–5 years in) with mentors across multiple disciplines.\nRegister 👉 Link in bio (Luma)\nMeet the Mentors\n✅ Front-End Development: Natalie Famula\n✅ Full Stack Development: Florence Shelley Cobarrubia\n✅ Game Development: Winnie W. Kwan\n✅ UX & UI Design: Mark Frias\n✅ QA (Manual): Alejandra Villarreal\n✅ Data & Analytics: Queenie So\nThis is a pilot program initiated by Charlotte, a member of our community 🙏 Join and help us shape the future of mentorship at TechTank. We can’t wait to see you there!\n#TechTank #Mentorship #Tankers #Community #TorontoTech",
+    caption:
+      "We’re excited to announce our first-ever ✨Mentorship Meetup✨ a new TechTank initiative designed to connect early-career folks in tech (1–5 years in) with mentors across multiple disciplines.\nRegister 👉 Link in bio (Luma)\nMeet the Mentors\n✅ Front-End Development: Natalie Famula\n✅ Full Stack Development: Florence Shelley Cobarrubia\n✅ Game Development: Winnie W. Kwan\n✅ UX & UI Design: Mark Frias\n✅ QA (Manual): Alejandra Villarreal\n✅ Data & Analytics: Queenie So\nThis is a pilot program initiated by Charlotte, a member of our community 🙏 Join and help us shape the future of mentorship at TechTank. We can’t wait to see you there!\n#TechTank #Mentorship #Tankers #Community #TorontoTech",
     date: "2025-08-20",
     shortcode: "DNmHtVwNshY",
     pk: 18078892546765610,
@@ -1177,21 +1647,29 @@ const instagramPosts: Record<string, InstagramPost> = {
     featured: true,
     media: [
       { type: "video", path: "/media/instagram/2025-08-20-DNmHtVwNshY/techtankto_3703681645618317400.mp4" },
-      { type: "image", path: "/media/instagram/2025-08-20-DNmHtVwNshY/techtankto_DNmHtVwNshY_3703681645618317400.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2025-08-20-DNmHtVwNshY/techtankto_DNmHtVwNshY_3703681645618317400.webp",
+      },
+    ],
   },
   "2026-02-05-DUY9ewPgSol": {
-    caption: "✨ CodeDiversity × TigerBaby ✨ Clay & Connection — International Women’s Day\nJoin us for a cozy pottery + coffee social for women & gender-diverse folks in tech 🤍\n🧱 What’s included • Guided pottery workshop • All materials + firing\n🗓️ Saturday, March 14 11:00AM–2:00PM\nIf you’re craving connection, creativity, and a softer way to mark IWD come join us ✨ 🔗 RSVP on luma in our bio\n#CodeDiversity #TechTank #InternationalWomensDay #WomenInTech #NonBinaryInTech",
+    caption:
+      "✨ CodeDiversity × TigerBaby ✨ Clay & Connection — International Women’s Day\nJoin us for a cozy pottery + coffee social for women & gender-diverse folks in tech 🤍\n🧱 What’s included • Guided pottery workshop • All materials + firing\n🗓️ Saturday, March 14 11:00AM–2:00PM\nIf you’re craving connection, creativity, and a softer way to mark IWD come join us ✨ 🔗 RSVP on luma in our bio\n#CodeDiversity #TechTank #InternationalWomensDay #WomenInTech #NonBinaryInTech",
     date: "2026-02-05",
     shortcode: "DUY9ewPgSol",
     pk: 17936958942175039,
     createdAtRaw: 1770324232,
     media: [
-      { type: "image", path: "/media/instagram/2026-02-05-DUY9ewPgSol/techtankto_DUY9ewPgSol_3826078277672446501.webp" }
-    ]
+      {
+        type: "image",
+        path: "/media/instagram/2026-02-05-DUY9ewPgSol/techtankto_DUY9ewPgSol_3826078277672446501.webp",
+      },
+    ],
   },
   "2026-04-10-DW9vcgiPHx": {
-    caption: "we're just out here trying to make tech feel a little more human 🤝\nsocials, coffee chats, workshops, panels... it's all part of it\ncome hang with us this month: 📅 Code Diversity - Apr 11 (tomorrow!) 📅 CI Optimization @ BrainStation - Apr 13 🎉 3 year anniversary social - Apr 16 🌸 Supercollider Spring Fling - Apr 27\nopen to anyone in tech and tech-adjacent roles. all are welcome!\nthank you @prismatic_verse for putting this together 🙏\n#techtank #toronto #torontotech #torontotechcommunity #techinTO #womenintech #techcommunity #builders #techbuilders #torontoevents #yyztech",
+    caption:
+      "we're just out here trying to make tech feel a little more human 🤝\nsocials, coffee chats, workshops, panels... it's all part of it\ncome hang with us this month: 📅 Code Diversity - Apr 11 (tomorrow!) 📅 CI Optimization @ BrainStation - Apr 13 🎉 3 year anniversary social - Apr 16 🌸 Supercollider Spring Fling - Apr 27\nopen to anyone in tech and tech-adjacent roles. all are welcome!\nthank you @prismatic_verse for putting this together 🙏\n#techtank #toronto #torontotech #torontotechcommunity #techinTO #womenintech #techcommunity #builders #techbuilders #torontoevents #yyztech",
     date: "2026-04-10",
     shortcode: "DW9-vcgiPHx",
     pk: 18107726435506054,
@@ -1199,8 +1677,8 @@ const instagramPosts: Record<string, InstagramPost> = {
     featured: true,
     media: [
       { type: "video", path: "/media/instagram/2026-04-10-DW9vcgiPHx/techtankto_3872527193918206449.mp4" },
-      { type: "image", path: "/media/instagram/2026-04-10-DW9vcgiPHx/techtankto_DW9-vcgiPHx_3872527193918206449.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2026-04-10-DW9vcgiPHx/techtankto_DW9-vcgiPHx_3872527193918206449.webp" },
+    ],
   },
   "2026-06-09-DZWPNciI8eO": {
     caption: "TechTank latest video",
@@ -1208,8 +1686,8 @@ const instagramPosts: Record<string, InstagramPost> = {
     shortcode: "DZWPNciI8eO",
     media: [
       { type: "video", path: "/media/instagram/2026-06-09-DZWPNciI8eO/techtankto_DZWPNciI8eO.mp4" },
-      { type: "image", path: "/media/instagram/2026-06-09-DZWPNciI8eO/techtankto_DZWPNciI8eO.webp" }
-    ]
+      { type: "image", path: "/media/instagram/2026-06-09-DZWPNciI8eO/techtankto_DZWPNciI8eO.webp" },
+    ],
   },
 };
 

--- a/constants/team.ts
+++ b/constants/team.ts
@@ -27,7 +27,6 @@ Danny focuses on organizing tech talks and panel discussions. Although he doesn'
 He's careful about picking topics that are relatable to the audience. The best talks, in his view, are about problems people have actually run into, or ideas that are just genuinely interesting. Self-promotion or corporate pitches dressed up as talks, not so much.
 As an introverted self-taught developer, Danny understands how it can feel discouraging to show up to a tech event for the first time. What keeps him invested is watching people grow, whether they're just starting out or further along in their careers. He believes seeing and hearing how someone else thinks is where a lot of insight lives, and he doesn't want anyone to miss out on that.
 By day, Danny is a software engineer on the frontend team at Ideogram, an AI image generation company, where he gets to work across the stack and ship features end to end. Outside of TechTank and his day job, software is still what he spends his time on.`,
-
       },
       {
         name: "Niki Fereidooni",
@@ -59,7 +58,7 @@ She found TechTank through a LinkedIn message from the founder and decided to ch
 As she became more involved, Sophia naturally stepped into a bigger role. She started TechTank’s Instagram account to share moments from events and help grow the community. From there, she took on social media, event planning, and later finances, creating experiences people genuinely enjoy, remember, and keep coming back for.
 To Sophia, TechTank is about real connection, growth, and opportunity. She hopes people leave TechTank events feeling inspired, supported, and more confident in their journey, whether that means making new friends, finding career opportunities, or simply feeling like they belong in tech, just as she once did.
 Outside of tech, she enjoys hosting events, muay thai, travelling, and creating unforgettable experiences.
-`
+`,
       },
     ],
   },
@@ -140,9 +139,19 @@ When she's not here, she's somewhere in the world or somewhere in Toronto chasin
     members: [
       { name: "Charu Idnani", pronouns: "she/her", role: "CodeDiversity", avatar: "/images/team/charu-idnani.webp" },
       { name: "Garv Gupta", pronouns: "she/her", role: "General", avatar: "/images/team/garv-gupta.webp" },
-      { name: "Nhi Nguyen", pronouns: "she/her", role: "General, CodeDiversity", avatar: "/images/team/nhi-nguyen.webp" },
+      {
+        name: "Nhi Nguyen",
+        pronouns: "she/her",
+        role: "General, CodeDiversity",
+        avatar: "/images/team/nhi-nguyen.webp",
+      },
       { name: "Rana Soyak", pronouns: "she/her", role: "General", avatar: "/images/team/rana-soyak.webp" },
-      { name: "John Malapit", pronouns: "he/him", role: "General, Sashimis (Sports)", avatar: "/images/team/john-malapit.webp" },
+      {
+        name: "John Malapit",
+        pronouns: "he/him",
+        role: "General, Sashimis (Sports)",
+        avatar: "/images/team/john-malapit.webp",
+      },
       { name: "Rohan Villoth", pronouns: "he/him", role: "General", avatar: "/images/team/rohan-villoth.webp" },
       { name: "Danyal Imran", pronouns: "he/him", role: "General", avatar: "/images/team/danyal-imran.webp" },
       { name: "Justin Bento", pronouns: "he/him", role: "General", avatar: "/images/team/justin-bento.webp" },

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "tags": [
-    "-lintignore"
-  ]
+  "tags": ["-lintignore"]
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   experimental: {
-    optimizePackageImports: ['lucide-react'],
+    optimizePackageImports: ["lucide-react"],
   },
   images: {
     formats: ["image/avif", "image/webp"],
@@ -36,8 +36,8 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       {
-        source: '/links/slack',
-        destination: 'https://join.slack.com/t/thetechtank/shared_invite/zt-3zhdtiavp-afxTnTcQdXEdfx~0mjXGtA',
+        source: "/links/slack",
+        destination: "https://join.slack.com/t/thetechtank/shared_invite/zt-3zhdtiavp-afxTnTcQdXEdfx~0mjXGtA",
         permanent: false,
       },
     ];

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "knip": "knip --fix --format --include-entry-exports --allow-remove-files",
     "analyze": "next experimental-analyze",
-    "typecheck": "pnpm exec tsc --noEmit",
+    "type:check": "pnpm exec tsc --noEmit",
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "oxfmt .",
+    "format:check": "oxfmt --check ."
   },
   "keywords": [],
   "author": "",
@@ -43,6 +45,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "knip": "^6.22.0",
+    "oxfmt": "^0.57.0",
     "postcss": "^8.5.10",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.3"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "techtank-to",
   "version": "1.0.0",
-  "description": "TechTank TO - Toronto's tech community website",
-  "type": "module",
   "private": true,
+  "description": "TechTank TO - Toronto's tech community website",
+  "keywords": [],
+  "license": "ISC",
+  "author": "",
+  "type": "module",
   "sideEffects": false,
   "scripts": {
     "knip": "knip --fix --format --include-entry-exports --allow-remove-files",
@@ -15,13 +18,6 @@
     "lint": "next lint",
     "format": "oxfmt .",
     "format:check": "oxfmt --check ."
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "packageManager": "pnpm@10.33.0",
-  "engines": {
-    "pnpm": ">=10"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",
@@ -49,5 +45,9 @@
     "postcss": "^8.5.10",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.3"
-  }
+  },
+  "engines": {
+    "pnpm": ">=10"
+  },
+  "packageManager": "pnpm@10.33.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       knip:
         specifier: ^6.22.0
         version: 6.22.0
+      oxfmt:
+        specifier: ^0.57.0
+        version: 0.57.0
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
@@ -565,6 +568,128 @@ packages:
 
   '@oxc-resolver/binding-win32-x64-msvc@11.21.3':
     resolution: {integrity: sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxfmt/binding-android-arm-eabi@0.57.0':
+    resolution: {integrity: sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.57.0':
+    resolution: {integrity: sha512-mp6PibWbao3aizijcheOeHQaYEhcUAt8pwLniYbtLfHxL/psFF0BykAwCj+s3c6qIpa8yN8keZICWrqtZ70w8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.57.0':
+    resolution: {integrity: sha512-T+0stuCBqmUVY+aMIvrgXhzGhHO3sD5tNiiEcYqgSdPsnukskQqn2u5qOVD0sv1l7RLdFS5Z/f5Wi9Ktyjr3Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.57.0':
+    resolution: {integrity: sha512-O+3JbqWs/mCI2oi4xfhRO2IVPFJNDDEBV8Odo+ZpmsUOeKJfjXoNH7nDmBEQcDgK7NfjDIyE7kRgYSZcTLDO0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.57.0':
+    resolution: {integrity: sha512-pxwhxVC+JkLX9twOQ/8C/vbuOQcMZyKIDmiRDZfO7yITuVcIdZCiLRqqf4QOxb2+8FWrRXzQpm+1DBKcMpHSSQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.57.0':
+    resolution: {integrity: sha512-pxBU4zH2imB/MDBfth2rOMeVxXUMjRQLCazagwLARIFH3hVlxZJBlM4nSnHXaIHJK4/qezoFCIORN6AY8Mra4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.57.0':
+    resolution: {integrity: sha512-JAprOzt8tycYou36ZgEw14DlRHTiN8qdtKANdV3VZIRIvTI/lh/cX13c9pJ/EnDk2GT3FASH7KvCgQ2AufAifQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.57.0':
+    resolution: {integrity: sha512-ajtjaxSaj9xl4BW7REt+Cef/ttzbAq00Bq4z7JUDZEfgFXdwSjH8K9bF+IcIJzZB9lKqMfQ4eHuSFOvvlvtqOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.57.0':
+    resolution: {integrity: sha512-p4Y/+RYk9Bk5WO+zHSUXAClRmZ2fbJCejMuCAsU2HhyME4jqf6Ftt/mJYEwIah1wGCBDYOB7wEGV1x5bCEZ6hA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.57.0':
+    resolution: {integrity: sha512-By6tRALAZsno0F4zedmtG+wdMvJiJmJoXM4d3+A9zHE4HRXLqXITwRH8mgrlcXc5yJM2g2W3riRPwTYdgemZLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.57.0':
+    resolution: {integrity: sha512-skYeG+RgvyzspqVEBsEprL90OYYZfoVNqB3HcCNR6QDJyXKOzfDRT3zncnHmUaFluIlBHuY23mU1b5WGgR98hA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.57.0':
+    resolution: {integrity: sha512-FFgACrZOXAXUh5KQh2mt1CDOVOZmn+QzHP71wM9QobNwyQvoFfyAeefVUltW83g3sm7LTiH3yfFqLLVUpA5ZFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.57.0':
+    resolution: {integrity: sha512-Nm/BAOfQeFiiKd502mZn/GAVKJwtd0RdCg17G3Wz/WSOIQmDi3+7/SZH4BHn1Ye5KvTVH3ua8WvfwLLycNIuvA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.57.0':
+    resolution: {integrity: sha512-BiSy5Ku3mQqyxS6YIqAJgd403wEUWvI7kerfzPxc2l/txZVmZM0pSj7oDM+4bGBExowxOi7o73jEam1W0EDTZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.57.0':
+    resolution: {integrity: sha512-BCRkJiotz5s9afLYD2LuMvzAoDYx9H17E/YbDyu4xK7l4zHDPeny9ErSXL//i/nJyaOwRk08x4b8cgJC00+JDg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.57.0':
+    resolution: {integrity: sha512-4Oaxe1qrGgXfpCJ1C/ERJ2iCtV2rN1R79ga9fsfyVHfSQRu/hVW780u2KDqZWFZ/iGTHODJji0JemxqFZ63eIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.57.0':
+    resolution: {integrity: sha512-MYLAsDnhdNsSGheLYhWgbk0vfIrlS84iQYun/y21fX6u0jj8iBtYtbpZMdiqYeuf8U12eVPUjVY2xE2NrCfJ0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.57.0':
+    resolution: {integrity: sha512-PBwdzZALJY/jcCx2E6is0yu+cuVXeySTDmwuseD+9j0mHqlRNxwlKgsyRTBed/woPeqfVfuXfWjoq4Cx2Zt3Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.57.0':
+    resolution: {integrity: sha512-bQJdH9i4RRfw55jm7+8/xS7GzHLLTbHx4huhrrDxQJaJtbSDbsyOnODvP1ftT7EG0KFKAYO2S+q6AcioXODx8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
@@ -1067,6 +1192,19 @@ packages:
   oxc-resolver@11.21.3:
     resolution: {integrity: sha512-2Mx3fKQz7+xgrBONjsxOgCGtMHOn38/HxMzW1I5efwXB5a4lRN0Vp40gYUJFBWJslcrvwoofTrqoTnLbwTd3pA==}
 
+  oxfmt@0.57.0:
+    resolution: {integrity: sha512-ZB7Bi+rGDSqmVIo9jwcLyFgjxXvQhDdU+jx+ZrVy6VRiVXK2+CHc4hO3J4dUQjHe7V0ymHB+MDuv5z+NhK07HA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1140,6 +1278,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1503,6 +1645,63 @@ snapshots:
     optional: true
 
   '@oxc-resolver/binding-win32-x64-msvc@11.21.3':
+    optional: true
+
+  '@oxfmt/binding-android-arm-eabi@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.57.0':
     optional: true
 
   '@radix-ui/primitive@1.1.3': {}
@@ -1925,6 +2124,30 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.21.3
       '@oxc-resolver/binding-win32-x64-msvc': 11.21.3
 
+  oxfmt@0.57.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.57.0
+      '@oxfmt/binding-android-arm64': 0.57.0
+      '@oxfmt/binding-darwin-arm64': 0.57.0
+      '@oxfmt/binding-darwin-x64': 0.57.0
+      '@oxfmt/binding-freebsd-x64': 0.57.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.57.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.57.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.57.0
+      '@oxfmt/binding-linux-arm64-musl': 0.57.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.57.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.57.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.57.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.57.0
+      '@oxfmt/binding-linux-x64-gnu': 0.57.0
+      '@oxfmt/binding-linux-x64-musl': 0.57.0
+      '@oxfmt/binding-openharmony-arm64': 0.57.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.57.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.57.0
+      '@oxfmt/binding-win32-x64-msvc': 0.57.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -2002,6 +2225,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@2.1.0: {}
 
   tslib@2.8.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,6 @@ allowBuilds:
   sharp: false
 trustPolicy: no-downgrade
 overrides:
-  next@>=16.0.0 <16.2.5: '>=16.2.5'
-  next@>=16.0.0 <16.2.6: '>=16.2.6'
-  postcss@<8.5.10: '>=8.5.10'
+  next@>=16.0.0 <16.2.5: ">=16.2.5"
+  next@>=16.0.0 <16.2.6: ">=16.2.6"
+  postcss@<8.5.10: ">=8.5.10"

--- a/prd/PRD.md
+++ b/prd/PRD.md
@@ -73,6 +73,7 @@ community serves the Greater Toronto Area tech ecosystem and operates
 under Ontario/Canadian jurisdiction.
 
 **Current sponsors and hosts:**
+
 - 7shifts (Canadian HQ)
 - Rakuten Canada
 - Cohere (Canadian-founded)
@@ -116,22 +117,22 @@ under Ontario/Canadian jurisdiction.
 
 ### 2.1 Route map
 
-| Path | Title | Purpose |
-|---|---|---|
-| `/` | Home | Social-proof-driven overview and primary CTAs |
-| `/about` | About | Values & community manifesto (the four pillars) |
-| `/get-involved` | Get Involved | Onboarding hub; routes visitors to a role |
-| `/get-involved/speak-or-facilitate` | Speak or Facilitate | Speaker logistics + intake action (email us) |
-| `/get-involved/host` | Host | Venue logistics (40–120 cap, 6–8:30pm) + intake action (email us) |
-| `/get-involved/sponsor` | Sponsor | Corporate partner pitch + intake action (email us) |
-| `/get-involved/organizer` | Organizer Team | Crew onboarding + intake action (email us) |
-| `/events` | Events | Upcoming events via Luma calendar |
-| `/resources/media-kit` | Media Kit | Brand assets, logos, and fast facts for press and partners |
-| `/resources/design-system` | Design System | Brand guidelines — colours, typography, and component reference |
-| `/about/faq` | FAQ | Frequently asked questions about membership, events, sponsorship, and policies |
-| `/legal/terms-of-service` | Terms of Service | — |
-| `/legal/privacy-policy` | Privacy Policy | — |
-| `/legal/code-of-conduct` | Code of Conduct | — |
+| Path                                | Title               | Purpose                                                                        |
+| ----------------------------------- | ------------------- | ------------------------------------------------------------------------------ |
+| `/`                                 | Home                | Social-proof-driven overview and primary CTAs                                  |
+| `/about`                            | About               | Values & community manifesto (the four pillars)                                |
+| `/get-involved`                     | Get Involved        | Onboarding hub; routes visitors to a role                                      |
+| `/get-involved/speak-or-facilitate` | Speak or Facilitate | Speaker logistics + intake action (email us)                                   |
+| `/get-involved/host`                | Host                | Venue logistics (40–120 cap, 6–8:30pm) + intake action (email us)              |
+| `/get-involved/sponsor`             | Sponsor             | Corporate partner pitch + intake action (email us)                             |
+| `/get-involved/organizer`           | Organizer Team      | Crew onboarding + intake action (email us)                                     |
+| `/events`                           | Events              | Upcoming events via Luma calendar                                              |
+| `/resources/media-kit`              | Media Kit           | Brand assets, logos, and fast facts for press and partners                     |
+| `/resources/design-system`          | Design System       | Brand guidelines — colours, typography, and component reference                |
+| `/about/faq`                        | FAQ                 | Frequently asked questions about membership, events, sponsorship, and policies |
+| `/legal/terms-of-service`           | Terms of Service    | —                                                                              |
+| `/legal/privacy-policy`             | Privacy Policy      | —                                                                              |
+| `/legal/code-of-conduct`            | Code of Conduct     | —                                                                              |
 
 ### 2.2 Shared layouts (Next.js)
 
@@ -270,15 +271,16 @@ carries:
   so visitors can scroll the full history as additional social proof.
 
 For v1, a "recap" is a linked bundle (Google Photos URL + YouTube URL
-+ host/sponsor thanks surfaced inline). A dedicated `/events/<slug>`
-detail route is a v2 option only if organizers want editorial recaps
-and is explicitly out of scope for the initial launch.
+
+- host/sponsor thanks surfaced inline). A dedicated `/events/<slug>`
+  detail route is a v2 option only if organizers want editorial recaps
+  and is explicitly out of scope for the initial launch.
 
 ### 5.7 Recurring UI patterns
 
 - **Overline kicker.** Every major section opens with a short,
   all-caps kicker (e.g. `WAYS TO GET INVOLVED`, `NEXT UP`, `RECENT
-  EVENTS`, `LATEST HIGHLIGHTS`, `GET IN TOUCH`) above the headline.
+EVENTS`, `LATEST HIGHLIGHTS`, `GET IN TOUCH`) above the headline.
   Establishes a clear scanning rhythm.
 - **Role cards with checkmarks.** The four `/get-involved` role
   teasers share one shape on `/` and `/get-involved`: icon → overline
@@ -384,7 +386,7 @@ and is explicitly out of scope for the initial launch.
     corners (`1.25rem+`), and soft shadows. Used for cards and overlays.
   - **Photo-forward:** event poster images are hero content; design
     prioritizes real photography over empty white space.
-  - Do *not* introduce hot pink, true blue, or colours outside this
+  - Do _not_ introduce hot pink, true blue, or colours outside this
     family without explicit organizer sign-off.
 - **Imagery:** real event photography first; diverse, candid, well-lit.
 

--- a/prd/pages/about.md
+++ b/prd/pages/about.md
@@ -2,8 +2,8 @@
 
 **URL:** https://www.techtankto.com/about
 **Page title:** About — TechTank TO
-**Role:** Values and community manifesto. Establishes *why* TechTank
-exists and *what* it stands for, through the four core pillars.
+**Role:** Values and community manifesto. Establishes _why_ TechTank
+exists and _what_ it stands for, through the four core pillars.
 
 ---
 

--- a/prd/pages/resources/faq.md
+++ b/prd/pages/resources/faq.md
@@ -30,12 +30,12 @@ about membership, events, sponsorship, volunteering, and policies.
 
 ### FAQ groups (accordion per group)
 
-| Group | Questions |
-|---|---|
-| General | Is TechTank free? / Where are you based? / Who are these events for? / How do I find out about events? / Do I need to be a member to attend? |
-| Sponsorship & Hosting | Can my company sponsor or host? / Where does donation and sponsorship money go? / What does sponsoring include? / Is TechTank a nonprofit? |
-| Getting Involved | I have an idea for an event — can I bring it? / Can I volunteer? |
-| Events & Policies | RSVP and cancellation policy / Photos and video at events / What to do if something made me uncomfortable |
+| Group                 | Questions                                                                                                                                    |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| General               | Is TechTank free? / Where are you based? / Who are these events for? / How do I find out about events? / Do I need to be a member to attend? |
+| Sponsorship & Hosting | Can my company sponsor or host? / Where does donation and sponsorship money go? / What does sponsoring include? / Is TechTank a nonprofit?   |
+| Getting Involved      | I have an idea for an event — can I bring it? / Can I volunteer?                                                                             |
+| Events & Policies     | RSVP and cancellation policy / Photos and video at events / What to do if something made me uncomfortable                                    |
 
 ### Closing CTA
 

--- a/scripts/compress-media.md
+++ b/scripts/compress-media.md
@@ -5,6 +5,7 @@ This directory contains scripts for batch compressing and optimizing video asset
 ## Purpose
 
 The `compress-media` scripts processes all `.mp4` files found in the `public/media/instagram` directory. For each video, it:
+
 1. Downscales the resolution (max 480px width) to drastically reduce file size without impacting the UI.
 2. Generates a highly optimized **WebM (VP9)** version for modern browsers.
 3. Re-encodes the original video into a heavily compressed **MP4 (H.264)** version to serve as a reliable fallback for iOS and older devices.
@@ -23,7 +24,7 @@ You can easily install FFmpeg using the Windows Package Manager (`winget`):
 winget install --exact --id Gyan.FFmpeg --accept-package-agreements
 ```
 
-*Note: After installing, you may need to restart your terminal for the `ffmpeg` command to be recognized in your PATH.*
+_Note: After installing, you may need to restart your terminal for the `ffmpeg` command to be recognized in your PATH._
 
 ### Installation (macOS)
 

--- a/stores/app-state.ts
+++ b/stores/app-state.ts
@@ -9,6 +9,5 @@ interface AppState {
 export const useAppStore = create<AppState>((set) => ({
   mobileMenuOpen: false,
   setMobileMenuOpen: (open) => set({ mobileMenuOpen: open }),
-  toggleMobileMenu: () =>
-    set((state) => ({ mobileMenuOpen: !state.mobileMenuOpen })),
+  toggleMobileMenu: () => set((state) => ({ mobileMenuOpen: !state.mobileMenuOpen })),
 }));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -25,19 +21,9 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Adds oxfmt as the project's formatter, reformats the codebase, and wires up CI for typecheck and format-check.

## Key files to review

- [`.oxfmtrc.json`](.oxfmtrc.json) — formatter config (`printWidth: 120`, defaults otherwise)
- [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — new CI workflow, parallel `typecheck` + `format` jobs
- [`AGENTS.md`](AGENTS.md) — adds rule that agents run `pnpm typecheck` and `pnpm format` after code changes
- [`CONTRIBUTING.md`](CONTRIBUTING.md) — short "Editor setup" section for VS Code + Oxc extension
- [`README.md`](README.md) — documents new `pnpm format` / `pnpm format:check` scripts

The bulk of the diff is in `style: format codebase with oxfmt` (commit \`246b23c\`) — pure whitespace, wrap points, and \`package.json\` key reorder from oxfmt's \`sortPackageJson\` default. No behavioural changes.

## Test plan

- [x] \`pnpm format:check\` clean locally
- [x] \`pnpm typecheck\` clean locally
- [ ] CI green on this PR