### PR TITLE
refactor(ci): combine lint, typecheck and format jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 
+permissions: read-all
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,7 @@ on:
   pull_request:
 
 jobs:
-  type-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm type:check
-
-  format:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,3 +17,5 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm format:check
+      - run: pnpm lint
+      - run: pnpm type:check


### PR DESCRIPTION
# Summary

- combine linting, formatting and type checking jobs into one ci job
- restrict actions to readonly operations to avoid unintended changes in the branch
- no real benefit of having jobs run in parallel at this scale as we do not have long-running ci checks
- only real bottleneck is package installation with `pnpm install --frozen-lockfile` so better to just have it run once

## Checklist

- [x] Close the issue on merge
- [x] No new TypeScript errors (`pnpm build` and `pnpm lint:fix` passes)
- [x] No placeholder content (`#`, `TODO`, Lorem Ipsum) left in production paths
